### PR TITLE
Add sync behavior controls and advanced scoring backend

### DIFF
--- a/ui/autosync.go
+++ b/ui/autosync.go
@@ -88,6 +88,7 @@ func (app *App) runAutoSyncRule(rule AutoSyncRule, currentCommit string) {
 		SelectedCFs:    rule.SelectedCFs,
 		Behavior:       rule.Behavior,
 		Overrides:      rule.Overrides,
+		ScoreOverrides: rule.ScoreOverrides,
 	}
 	if rule.ProfileSource == "imported" {
 		req.ImportedProfileID = rule.ImportedProfileID

--- a/ui/config.go
+++ b/ui/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // Config holds the full application configuration, persisted to JSON.
@@ -209,76 +211,11 @@ func (cs *configStore) saveLocked() error {
 func (cs *configStore) Get() Config {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	cfg := *cs.config
-	cfg.Instances = make([]Instance, len(cs.config.Instances))
-	copy(cfg.Instances, cs.config.Instances)
-	cfg.SyncHistory = make([]SyncHistoryEntry, len(cs.config.SyncHistory))
-	for i, sh := range cs.config.SyncHistory {
-		cfg.SyncHistory[i] = sh
-		cfg.SyncHistory[i].SyncedCFs = make([]string, len(sh.SyncedCFs))
-		copy(cfg.SyncHistory[i].SyncedCFs, sh.SyncedCFs)
-		if len(sh.SelectedCFs) > 0 {
-			cfg.SyncHistory[i].SelectedCFs = make(map[string]bool, len(sh.SelectedCFs))
-			for k, v := range sh.SelectedCFs {
-				cfg.SyncHistory[i].SelectedCFs[k] = v
-			}
-		}
-		if sh.Overrides != nil {
-			o := *sh.Overrides
-			cfg.SyncHistory[i].Overrides = &o
-		}
-		if sh.Behavior != nil {
-			b := *sh.Behavior
-			cfg.SyncHistory[i].Behavior = &b
-		}
+	copied, err := copystructure.Copy(cs.config)
+	if err != nil {
+		log.Fatalf("BUG: config deep-copy failed: %v", err)
 	}
-	// Deep-copy QualitySizeOverrides (nested map)
-	if cs.config.QualitySizeOverrides != nil {
-		cfg.QualitySizeOverrides = make(map[string]map[string]QSOverride, len(cs.config.QualitySizeOverrides))
-		for k, v := range cs.config.QualitySizeOverrides {
-			inner := make(map[string]QSOverride, len(v))
-			for ik, iv := range v {
-				inner[ik] = iv
-			}
-			cfg.QualitySizeOverrides[k] = inner
-		}
-	}
-	// Deep-copy QualitySizeAutoSync
-	if cs.config.QualitySizeAutoSync != nil {
-		cfg.QualitySizeAutoSync = make(map[string]QSAutoSync, len(cs.config.QualitySizeAutoSync))
-		for k, v := range cs.config.QualitySizeAutoSync {
-			cfg.QualitySizeAutoSync[k] = v
-		}
-	}
-	// Deep-copy CleanupKeep
-	if cs.config.CleanupKeep != nil {
-		cfg.CleanupKeep = make(map[string][]string, len(cs.config.CleanupKeep))
-		for k, v := range cs.config.CleanupKeep {
-			cp := make([]string, len(v))
-			copy(cp, v)
-			cfg.CleanupKeep[k] = cp
-		}
-	}
-	// Deep-copy AutoSync rules
-	if len(cs.config.AutoSync.Rules) > 0 {
-		cfg.AutoSync.Rules = make([]AutoSyncRule, len(cs.config.AutoSync.Rules))
-		for i, r := range cs.config.AutoSync.Rules {
-			cfg.AutoSync.Rules[i] = r
-			if len(r.SelectedCFs) > 0 {
-				cfg.AutoSync.Rules[i].SelectedCFs = make([]string, len(r.SelectedCFs))
-				copy(cfg.AutoSync.Rules[i].SelectedCFs, r.SelectedCFs)
-			}
-			if r.Behavior != nil {
-				b := *r.Behavior
-				cfg.AutoSync.Rules[i].Behavior = &b
-			}
-			if r.Overrides != nil {
-				o := *r.Overrides
-				cfg.AutoSync.Rules[i].Overrides = &o
-			}
-		}
-	}
-	return cfg
+	return *copied.(*Config)
 }
 
 // Set replaces the config and saves to disk.

--- a/ui/config.go
+++ b/ui/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	TrashRepo            TrashRepo                        `json:"trashRepo"`
 	PullInterval         string                           `json:"pullInterval"` // Go duration (e.g. "24h", "1h", "0" to disable)
 	DevMode              bool                             `json:"devMode"`      // Enable TRaSH developer tools (TRaSH JSON export)
+	AdvancedScoring      bool                             `json:"advancedScoring"` // Allow per-CF score overrides on TRaSH profiles
 	DebugLogging         bool                             `json:"debugLogging"` // Write detailed operations to /config/debug.log
 	QualitySizeOverrides map[string]map[string]QSOverride `json:"qualitySizeOverrides,omitempty"` // instanceID → quality name → override
 	QualitySizeAutoSync  map[string]QSAutoSync             `json:"qualitySizeAutoSync,omitempty"`  // instanceID → auto-sync settings
@@ -56,6 +57,7 @@ type AutoSyncRule struct {
 	SelectedCFs       []string       `json:"selectedCFs,omitempty"`       // user's optional CF selections
 	Behavior          *SyncBehavior  `json:"behavior,omitempty"`          // sync behavior rules (nil = defaults)
 	Overrides         *SyncOverrides `json:"overrides,omitempty"`         // user overrides (min score, language, cutoff, etc.)
+	ScoreOverrides    map[string]int `json:"scoreOverrides,omitempty"`    // per-CF score overrides (trash_id → score)
 	LastSyncCommit    string         `json:"lastSyncCommit,omitempty"`
 	LastSyncTime      string         `json:"lastSyncTime,omitempty"`
 	LastSyncError     string         `json:"lastSyncError,omitempty"`
@@ -119,6 +121,7 @@ type SyncHistoryEntry struct {
 	SelectedCFs    map[string]bool   `json:"selectedCFs,omitempty"`
 	Overrides      *SyncOverrides    `json:"overrides,omitempty"`
 	Behavior       *SyncBehavior     `json:"behavior,omitempty"`
+	ScoreOverrides map[string]int    `json:"scoreOverrides,omitempty"`
 	CFsCreated     int               `json:"cfsCreated"`
 	CFsUpdated     int               `json:"cfsUpdated"`
 	ScoresUpdated  int               `json:"scoresUpdated"`

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -2,4 +2,8 @@ module clonarr
 
 go 1.24
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -1,3 +1,7 @@
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ui/handlers.go
+++ b/ui/handlers.go
@@ -58,9 +58,10 @@ func (app *App) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TrashRepo    *TrashRepo      `json:"trashRepo,omitempty"`
 		PullInterval *string         `json:"pullInterval,omitempty"`
-		DevMode      *bool           `json:"devMode,omitempty"`
-		DebugLogging *bool           `json:"debugLogging"`
-		Prowlarr     *ProwlarrConfig `json:"prowlarr,omitempty"`
+		DevMode         *bool           `json:"devMode,omitempty"`
+		AdvancedScoring *bool           `json:"advancedScoring,omitempty"`
+		DebugLogging    *bool           `json:"debugLogging"`
+		Prowlarr        *ProwlarrConfig `json:"prowlarr,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, 400, "Invalid JSON")
@@ -83,6 +84,9 @@ func (app *App) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.DevMode != nil {
 			cfg.DevMode = *req.DevMode
+		}
+		if req.AdvancedScoring != nil {
+			cfg.AdvancedScoring = *req.AdvancedScoring
 		}
 		if req.DebugLogging != nil {
 			cfg.DebugLogging = *req.DebugLogging
@@ -2439,6 +2443,7 @@ func (app *App) handleApply(w http.ResponseWriter, r *http.Request) {
 		SelectedCFs:    selectedCFMap,
 		Overrides:      req.Overrides,
 		Behavior:       req.Behavior,
+		ScoreOverrides: req.ScoreOverrides,
 		CFsCreated:     result.CFsCreated,
 		CFsUpdated:     result.CFsUpdated,
 		ScoresUpdated:  result.ScoresUpdated,
@@ -2492,6 +2497,7 @@ func (app *App) handleApply(w http.ResponseWriter, r *http.Request) {
 			SelectedCFs:       req.SelectedCFs,
 			Behavior:          req.Behavior,
 			Overrides:         req.Overrides,
+			ScoreOverrides:    req.ScoreOverrides,
 		})
 	})
 

--- a/ui/sync.go
+++ b/ui/sync.go
@@ -72,6 +72,8 @@ type SyncRequest struct {
 	Overrides *SyncOverrides `json:"overrides,omitempty"`
 	// Sync behavior rules (nil = defaults: add_missing, remove_custom, reset_to_zero)
 	Behavior *SyncBehavior `json:"behavior,omitempty"`
+	// Per-CF score overrides (trash_id → score)
+	ScoreOverrides map[string]int `json:"scoreOverrides,omitempty"`
 }
 
 // SyncOverrides allows users to override specific profile settings from TRaSH defaults.
@@ -160,6 +162,16 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 
 	if scoreCtx == "" {
 		scoreCtx = "default"
+	}
+
+	// Merge user score overrides into cfScoreOverrides
+	if len(req.ScoreOverrides) > 0 {
+		if cfScoreOverrides == nil {
+			cfScoreOverrides = make(map[string]int, len(req.ScoreOverrides))
+		}
+		for tid, score := range req.ScoreOverrides {
+			cfScoreOverrides[tid] = score
+		}
 	}
 
 	// Resolve sync behavior rules
@@ -530,6 +542,16 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 
 	if scoreCtx == "" {
 		scoreCtx = "default"
+	}
+
+	// Merge user score overrides into cfScoreOverrides
+	if len(req.ScoreOverrides) > 0 {
+		if cfScoreOverrides == nil {
+			cfScoreOverrides = make(map[string]int, len(req.ScoreOverrides))
+		}
+		for tid, score := range req.ScoreOverrides {
+			cfScoreOverrides[tid] = score
+		}
 	}
 
 	client := NewArrClient(instance.URL, instance.APIKey)

--- a/ui/trash.go
+++ b/ui/trash.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // --- TRaSH Data Types ---
@@ -979,30 +981,11 @@ func SnapshotAppData(snap *TrashData, app string) *AppData {
 	default:
 		return nil
 	}
-	cp := *src
-	if src.CustomFormats != nil {
-		cp.CustomFormats = make(map[string]*TrashCF, len(src.CustomFormats))
-		for k, v := range src.CustomFormats {
-			cp.CustomFormats[k] = v
-		}
+	copied, err := copystructure.Copy(src)
+	if err != nil {
+		log.Fatalf("BUG: AppData deep-copy failed: %v", err)
 	}
-	if src.CFGroups != nil {
-		cp.CFGroups = make([]*TrashCFGroup, len(src.CFGroups))
-		copy(cp.CFGroups, src.CFGroups)
-	}
-	if src.Profiles != nil {
-		cp.Profiles = make([]*TrashQualityProfile, len(src.Profiles))
-		copy(cp.Profiles, src.Profiles)
-	}
-	if src.ProfileGroups != nil {
-		cp.ProfileGroups = make([]*ProfileGroup, len(src.ProfileGroups))
-		copy(cp.ProfileGroups, src.ProfileGroups)
-	}
-	if src.QualitySizes != nil {
-		cp.QualitySizes = make([]*TrashQualitySize, len(src.QualitySizes))
-		copy(cp.QualitySizes, src.QualitySizes)
-	}
-	return &cp
+	return copied.(*AppData)
 }
 
 // ResolvedCF is a single CF with resolved score.


### PR DESCRIPTION
> **Depends on:** #1 — merge that first, then this PR's diff will show only the new changes.

## Summary
- Add `SyncBehavior` struct (AddMode, RemoveMode, ResetMode) to control how sync handles CF additions, score overrides, and removals
- Add `ScoreOverrides` (per-CF score override map) to SyncRequest, SyncHistoryEntry, and AutoSyncRule
- Add `AdvancedScoring` toggle to Config for enabling per-CF score customization
- Wire score overrides through BuildSyncPlan and ExecuteSyncPlan to the existing `resolveScore` function
- Propagate score overrides in auto-sync rule execution

## Changed files
- `ui/config.go` — SyncBehavior, SyncOverrides types, AdvancedScoring config field
- `ui/sync.go` — ScoreOverrides in SyncRequest, merge logic in plan/execute
- `ui/handlers.go` — AdvancedScoring in config update, score overrides in sync history and auto-sync rules
- `ui/autosync.go` — Pass ScoreOverrides from rule to SyncRequest

## Test plan
- [ ] Create a sync rule and verify AddMode/RemoveMode/ResetMode dropdowns work
- [ ] Enable Advanced Scoring in Settings, override a CF score, sync, and verify the custom score is applied
- [ ] Create an auto-sync rule with score overrides, trigger auto-sync, verify overrides persist
- [ ] Verify default sync behavior (add_missing, remove_custom, reset_to_zero) when no behavior is specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)