### PR TITLE
Replace manual deep-copy with copystructure

### DIFF
--- a/ui/config.go
+++ b/ui/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // Config holds the full application configuration, persisted to JSON.
@@ -209,76 +211,11 @@ func (cs *configStore) saveLocked() error {
 func (cs *configStore) Get() Config {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	cfg := *cs.config
-	cfg.Instances = make([]Instance, len(cs.config.Instances))
-	copy(cfg.Instances, cs.config.Instances)
-	cfg.SyncHistory = make([]SyncHistoryEntry, len(cs.config.SyncHistory))
-	for i, sh := range cs.config.SyncHistory {
-		cfg.SyncHistory[i] = sh
-		cfg.SyncHistory[i].SyncedCFs = make([]string, len(sh.SyncedCFs))
-		copy(cfg.SyncHistory[i].SyncedCFs, sh.SyncedCFs)
-		if len(sh.SelectedCFs) > 0 {
-			cfg.SyncHistory[i].SelectedCFs = make(map[string]bool, len(sh.SelectedCFs))
-			for k, v := range sh.SelectedCFs {
-				cfg.SyncHistory[i].SelectedCFs[k] = v
-			}
-		}
-		if sh.Overrides != nil {
-			o := *sh.Overrides
-			cfg.SyncHistory[i].Overrides = &o
-		}
-		if sh.Behavior != nil {
-			b := *sh.Behavior
-			cfg.SyncHistory[i].Behavior = &b
-		}
+	copied, err := copystructure.Copy(cs.config)
+	if err != nil {
+		log.Fatalf("BUG: config deep-copy failed: %v", err)
 	}
-	// Deep-copy QualitySizeOverrides (nested map)
-	if cs.config.QualitySizeOverrides != nil {
-		cfg.QualitySizeOverrides = make(map[string]map[string]QSOverride, len(cs.config.QualitySizeOverrides))
-		for k, v := range cs.config.QualitySizeOverrides {
-			inner := make(map[string]QSOverride, len(v))
-			for ik, iv := range v {
-				inner[ik] = iv
-			}
-			cfg.QualitySizeOverrides[k] = inner
-		}
-	}
-	// Deep-copy QualitySizeAutoSync
-	if cs.config.QualitySizeAutoSync != nil {
-		cfg.QualitySizeAutoSync = make(map[string]QSAutoSync, len(cs.config.QualitySizeAutoSync))
-		for k, v := range cs.config.QualitySizeAutoSync {
-			cfg.QualitySizeAutoSync[k] = v
-		}
-	}
-	// Deep-copy CleanupKeep
-	if cs.config.CleanupKeep != nil {
-		cfg.CleanupKeep = make(map[string][]string, len(cs.config.CleanupKeep))
-		for k, v := range cs.config.CleanupKeep {
-			cp := make([]string, len(v))
-			copy(cp, v)
-			cfg.CleanupKeep[k] = cp
-		}
-	}
-	// Deep-copy AutoSync rules
-	if len(cs.config.AutoSync.Rules) > 0 {
-		cfg.AutoSync.Rules = make([]AutoSyncRule, len(cs.config.AutoSync.Rules))
-		for i, r := range cs.config.AutoSync.Rules {
-			cfg.AutoSync.Rules[i] = r
-			if len(r.SelectedCFs) > 0 {
-				cfg.AutoSync.Rules[i].SelectedCFs = make([]string, len(r.SelectedCFs))
-				copy(cfg.AutoSync.Rules[i].SelectedCFs, r.SelectedCFs)
-			}
-			if r.Behavior != nil {
-				b := *r.Behavior
-				cfg.AutoSync.Rules[i].Behavior = &b
-			}
-			if r.Overrides != nil {
-				o := *r.Overrides
-				cfg.AutoSync.Rules[i].Overrides = &o
-			}
-		}
-	}
-	return cfg
+	return *copied.(*Config)
 }
 
 // Set replaces the config and saves to disk.

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -2,4 +2,8 @@ module clonarr
 
 go 1.24
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -1,3 +1,7 @@
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ui/trash.go
+++ b/ui/trash.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // --- TRaSH Data Types ---
@@ -979,30 +981,11 @@ func SnapshotAppData(snap *TrashData, app string) *AppData {
 	default:
 		return nil
 	}
-	cp := *src
-	if src.CustomFormats != nil {
-		cp.CustomFormats = make(map[string]*TrashCF, len(src.CustomFormats))
-		for k, v := range src.CustomFormats {
-			cp.CustomFormats[k] = v
-		}
+	copied, err := copystructure.Copy(src)
+	if err != nil {
+		log.Fatalf("BUG: AppData deep-copy failed: %v", err)
 	}
-	if src.CFGroups != nil {
-		cp.CFGroups = make([]*TrashCFGroup, len(src.CFGroups))
-		copy(cp.CFGroups, src.CFGroups)
-	}
-	if src.Profiles != nil {
-		cp.Profiles = make([]*TrashQualityProfile, len(src.Profiles))
-		copy(cp.Profiles, src.Profiles)
-	}
-	if src.ProfileGroups != nil {
-		cp.ProfileGroups = make([]*ProfileGroup, len(src.ProfileGroups))
-		copy(cp.ProfileGroups, src.ProfileGroups)
-	}
-	if src.QualitySizes != nil {
-		cp.QualitySizes = make([]*TrashQualitySize, len(src.QualitySizes))
-		copy(cp.QualitySizes, src.QualitySizes)
-	}
-	return &cp
+	return copied.(*AppData)
 }
 
 // ResolvedCF is a single CF with resolved score.


### PR DESCRIPTION
## Why
The current deep-copy logic in `configStore.Get()` and `SnapshotAppData()` manually copies every field one by one — over 60 lines of brittle code that silently breaks whenever a new field is added to `Config` or `AppData`. This has already caused bugs where newly added fields were missing from copies, leading to stale data in the UI or lost settings on save. By switching to `mitchellh/copystructure`, any struct change is automatically handled, making the codebase safer to evolve.

## Summary
- Replace manual field-by-field deep-copy in `configStore.Get()` with `copystructure.Copy`
- Replace manual `SnapshotAppData()` deep-copy with `copystructure.Copy`
- Remove 60+ lines of error-prone copy code
- Add `mitchellh/copystructure v1.2.0` dependency (well-maintained, zero transitive deps beyond `reflectwalk`)

## Changed files
- `ui/config.go` — `Get()` uses `copystructure.Copy`
- `ui/trash.go` — `SnapshotAppData()` uses `copystructure.Copy`
- `ui/go.mod` / `ui/go.sum` — added dependency

## Test plan
- [ ] `cd ui && go build ./...`
- [ ] Change settings, reload — verify persistence
- [ ] Open profile, modify sync plan, go back — verify original data unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)