### PR TITLE
UI: sync controls, scoring, edit/sync buttons, custom CFs, toasts

### DIFF
--- a/ui/autosync.go
+++ b/ui/autosync.go
@@ -88,6 +88,7 @@ func (app *App) runAutoSyncRule(rule AutoSyncRule, currentCommit string) {
 		SelectedCFs:    rule.SelectedCFs,
 		Behavior:       rule.Behavior,
 		Overrides:      rule.Overrides,
+		ScoreOverrides: rule.ScoreOverrides,
 	}
 	if rule.ProfileSource == "imported" {
 		req.ImportedProfileID = rule.ImportedProfileID

--- a/ui/config.go
+++ b/ui/config.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // Config holds the full application configuration, persisted to JSON.
@@ -16,6 +18,7 @@ type Config struct {
 	TrashRepo            TrashRepo                        `json:"trashRepo"`
 	PullInterval         string                           `json:"pullInterval"` // Go duration (e.g. "24h", "1h", "0" to disable)
 	DevMode              bool                             `json:"devMode"`      // Enable TRaSH developer tools (TRaSH JSON export)
+	AdvancedScoring      bool                             `json:"advancedScoring"` // Allow per-CF score overrides on TRaSH profiles
 	DebugLogging         bool                             `json:"debugLogging"` // Write detailed operations to /config/debug.log
 	QualitySizeOverrides map[string]map[string]QSOverride `json:"qualitySizeOverrides,omitempty"` // instanceID → quality name → override
 	QualitySizeAutoSync  map[string]QSAutoSync             `json:"qualitySizeAutoSync,omitempty"`  // instanceID → auto-sync settings
@@ -54,6 +57,7 @@ type AutoSyncRule struct {
 	SelectedCFs       []string       `json:"selectedCFs,omitempty"`       // user's optional CF selections
 	Behavior          *SyncBehavior  `json:"behavior,omitempty"`          // sync behavior rules (nil = defaults)
 	Overrides         *SyncOverrides `json:"overrides,omitempty"`         // user overrides (min score, language, cutoff, etc.)
+	ScoreOverrides    map[string]int `json:"scoreOverrides,omitempty"`    // per-CF score overrides (trash_id → score)
 	LastSyncCommit    string         `json:"lastSyncCommit,omitempty"`
 	LastSyncTime      string         `json:"lastSyncTime,omitempty"`
 	LastSyncError     string         `json:"lastSyncError,omitempty"`
@@ -117,6 +121,7 @@ type SyncHistoryEntry struct {
 	SelectedCFs    map[string]bool   `json:"selectedCFs,omitempty"`
 	Overrides      *SyncOverrides    `json:"overrides,omitempty"`
 	Behavior       *SyncBehavior     `json:"behavior,omitempty"`
+	ScoreOverrides map[string]int    `json:"scoreOverrides,omitempty"`
 	CFsCreated     int               `json:"cfsCreated"`
 	CFsUpdated     int               `json:"cfsUpdated"`
 	ScoresUpdated  int               `json:"scoresUpdated"`
@@ -209,76 +214,11 @@ func (cs *configStore) saveLocked() error {
 func (cs *configStore) Get() Config {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	cfg := *cs.config
-	cfg.Instances = make([]Instance, len(cs.config.Instances))
-	copy(cfg.Instances, cs.config.Instances)
-	cfg.SyncHistory = make([]SyncHistoryEntry, len(cs.config.SyncHistory))
-	for i, sh := range cs.config.SyncHistory {
-		cfg.SyncHistory[i] = sh
-		cfg.SyncHistory[i].SyncedCFs = make([]string, len(sh.SyncedCFs))
-		copy(cfg.SyncHistory[i].SyncedCFs, sh.SyncedCFs)
-		if len(sh.SelectedCFs) > 0 {
-			cfg.SyncHistory[i].SelectedCFs = make(map[string]bool, len(sh.SelectedCFs))
-			for k, v := range sh.SelectedCFs {
-				cfg.SyncHistory[i].SelectedCFs[k] = v
-			}
-		}
-		if sh.Overrides != nil {
-			o := *sh.Overrides
-			cfg.SyncHistory[i].Overrides = &o
-		}
-		if sh.Behavior != nil {
-			b := *sh.Behavior
-			cfg.SyncHistory[i].Behavior = &b
-		}
+	copied, err := copystructure.Copy(cs.config)
+	if err != nil {
+		log.Fatalf("BUG: config deep-copy failed: %v", err)
 	}
-	// Deep-copy QualitySizeOverrides (nested map)
-	if cs.config.QualitySizeOverrides != nil {
-		cfg.QualitySizeOverrides = make(map[string]map[string]QSOverride, len(cs.config.QualitySizeOverrides))
-		for k, v := range cs.config.QualitySizeOverrides {
-			inner := make(map[string]QSOverride, len(v))
-			for ik, iv := range v {
-				inner[ik] = iv
-			}
-			cfg.QualitySizeOverrides[k] = inner
-		}
-	}
-	// Deep-copy QualitySizeAutoSync
-	if cs.config.QualitySizeAutoSync != nil {
-		cfg.QualitySizeAutoSync = make(map[string]QSAutoSync, len(cs.config.QualitySizeAutoSync))
-		for k, v := range cs.config.QualitySizeAutoSync {
-			cfg.QualitySizeAutoSync[k] = v
-		}
-	}
-	// Deep-copy CleanupKeep
-	if cs.config.CleanupKeep != nil {
-		cfg.CleanupKeep = make(map[string][]string, len(cs.config.CleanupKeep))
-		for k, v := range cs.config.CleanupKeep {
-			cp := make([]string, len(v))
-			copy(cp, v)
-			cfg.CleanupKeep[k] = cp
-		}
-	}
-	// Deep-copy AutoSync rules
-	if len(cs.config.AutoSync.Rules) > 0 {
-		cfg.AutoSync.Rules = make([]AutoSyncRule, len(cs.config.AutoSync.Rules))
-		for i, r := range cs.config.AutoSync.Rules {
-			cfg.AutoSync.Rules[i] = r
-			if len(r.SelectedCFs) > 0 {
-				cfg.AutoSync.Rules[i].SelectedCFs = make([]string, len(r.SelectedCFs))
-				copy(cfg.AutoSync.Rules[i].SelectedCFs, r.SelectedCFs)
-			}
-			if r.Behavior != nil {
-				b := *r.Behavior
-				cfg.AutoSync.Rules[i].Behavior = &b
-			}
-			if r.Overrides != nil {
-				o := *r.Overrides
-				cfg.AutoSync.Rules[i].Overrides = &o
-			}
-		}
-	}
-	return cfg
+	return *copied.(*Config)
 }
 
 // Set replaces the config and saves to disk.

--- a/ui/config_test.go
+++ b/ui/config_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+func TestResolveSyncBehavior_Nil(t *testing.T) {
+	got := ResolveSyncBehavior(nil)
+	want := DefaultSyncBehavior()
+	if got != want {
+		t.Fatalf("nil → %+v, want %+v", got, want)
+	}
+}
+
+func TestResolveSyncBehavior_FullyPopulated(t *testing.T) {
+	b := &SyncBehavior{AddMode: "do_not_add", RemoveMode: "allow_custom", ResetMode: "do_not_adjust"}
+	got := ResolveSyncBehavior(b)
+	if got != *b {
+		t.Fatalf("got %+v, want %+v", got, *b)
+	}
+}
+
+func TestResolveSyncBehavior_PartialFillsDefaults(t *testing.T) {
+	b := &SyncBehavior{AddMode: "add_new"}
+	got := ResolveSyncBehavior(b)
+	if got.AddMode != "add_new" {
+		t.Fatalf("AddMode = %q, want add_new", got.AddMode)
+	}
+	if got.RemoveMode != "remove_custom" {
+		t.Fatalf("RemoveMode = %q, want remove_custom (default)", got.RemoveMode)
+	}
+	if got.ResetMode != "reset_to_zero" {
+		t.Fatalf("ResetMode = %q, want reset_to_zero (default)", got.ResetMode)
+	}
+}
+
+func TestResolveSyncBehavior_EmptyStruct(t *testing.T) {
+	b := &SyncBehavior{}
+	got := ResolveSyncBehavior(b)
+	want := DefaultSyncBehavior()
+	if got != want {
+		t.Fatalf("empty → %+v, want %+v", got, want)
+	}
+}

--- a/ui/go.mod
+++ b/ui/go.mod
@@ -2,4 +2,8 @@ module clonarr
 
 go 1.24
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/ui/go.sum
+++ b/ui/go.sum
@@ -1,3 +1,7 @@
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ui/handlers.go
+++ b/ui/handlers.go
@@ -58,9 +58,10 @@ func (app *App) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TrashRepo    *TrashRepo      `json:"trashRepo,omitempty"`
 		PullInterval *string         `json:"pullInterval,omitempty"`
-		DevMode      *bool           `json:"devMode,omitempty"`
-		DebugLogging *bool           `json:"debugLogging"`
-		Prowlarr     *ProwlarrConfig `json:"prowlarr,omitempty"`
+		DevMode         *bool           `json:"devMode,omitempty"`
+		AdvancedScoring *bool           `json:"advancedScoring,omitempty"`
+		DebugLogging    *bool           `json:"debugLogging"`
+		Prowlarr        *ProwlarrConfig `json:"prowlarr,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, 400, "Invalid JSON")
@@ -83,6 +84,9 @@ func (app *App) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		}
 		if req.DevMode != nil {
 			cfg.DevMode = *req.DevMode
+		}
+		if req.AdvancedScoring != nil {
+			cfg.AdvancedScoring = *req.AdvancedScoring
 		}
 		if req.DebugLogging != nil {
 			cfg.DebugLogging = *req.DebugLogging
@@ -2439,6 +2443,7 @@ func (app *App) handleApply(w http.ResponseWriter, r *http.Request) {
 		SelectedCFs:    selectedCFMap,
 		Overrides:      req.Overrides,
 		Behavior:       req.Behavior,
+		ScoreOverrides: req.ScoreOverrides,
 		CFsCreated:     result.CFsCreated,
 		CFsUpdated:     result.CFsUpdated,
 		ScoresUpdated:  result.ScoresUpdated,
@@ -2492,6 +2497,7 @@ func (app *App) handleApply(w http.ResponseWriter, r *http.Request) {
 			SelectedCFs:       req.SelectedCFs,
 			Behavior:          req.Behavior,
 			Overrides:         req.Overrides,
+			ScoreOverrides:    req.ScoreOverrides,
 		})
 	})
 

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -242,6 +242,11 @@
   /* Loading */
   .spinner { display: inline-block; width: 14px; height: 14px; border: 2px solid #30363d; border-top-color: #58a6ff; border-radius: 50%; animation: spin 0.6s linear infinite; }
   @keyframes spin { to { transform: rotate(360deg); } }
+  @keyframes toastSlideIn { from { transform: translateY(-100%); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+  @keyframes toastSlideOut { from { transform: translateY(0); opacity: 1; } to { transform: translateY(-100%); opacity: 0; } }
+  @keyframes toastProgress { from { width: 100%; } to { width: 0%; } }
+  .toast-enter { animation: toastSlideIn 0.3s ease-out forwards; }
+  .toast-exit { animation: toastSlideOut 0.3s ease-in forwards; }
 
   /* Empty state */
   .empty-state { text-align: center; padding: 48px 20px; color: #8b949e; }
@@ -506,7 +511,8 @@
               <div style="display:flex;align-items:center;padding:12px 16px;cursor:pointer;gap:8px;border-left:3px solid #e1e4e8" @click="syncRulesExpanded = { ...syncRulesExpanded, [tab.type]: !syncRulesExpanded[tab.type] }">
                 <span class="profile-group-chevron" :class="{ open: syncRulesExpanded[tab.type] }">&#9654;</span>
                 <span style="font-size:13px;font-weight:500">Sync Rules & History</span>
-                <span style="font-size:11px;color:#8b949e;margin-left:auto"
+                <button class="btn btn-sm" style="margin-left:auto;font-size:10px;padding:2px 8px" @click.stop="syncAllProfiles(tab.type)" title="Sync all profiles for this app type">Sync All</button>
+                <span style="font-size:11px;color:#8b949e"
                       x-text="(() => { let count = 0; for (const inst of instancesOfType(tab.type)) count += (syncHistory[inst.id]?.length || 0); return count > 0 ? count + ' synced profile' + (count !== 1 ? 's' : '') : 'No syncs yet'; })()"></span>
               </div>
               <div x-show="syncRulesExpanded[tab.type]" style="border-top:1px solid #21262d">
@@ -516,7 +522,7 @@
                       <div style="padding:8px 16px;font-size:11px;color:#8b949e;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;background:#0d1117;border-bottom:1px solid #21262d" x-text="inst.name"></div>
                       <template x-for="sh in syncHistory[inst.id]" :key="sh.arrProfileId">
                         <div style="display:flex;align-items:center;padding:8px 16px;border-bottom:1px solid #161b22;gap:8px;font-size:12px">
-                          <span style="color:#58a6ff;font-weight:500" x-text="sh.profileName"></span>
+                          <a class="profile-name-link" style="color:#58a6ff;font-weight:500;cursor:pointer" @click.stop="editSyncedProfile(inst, sh)" x-text="sh.profileName"></a>
                           <div style="display:flex;align-items:center;gap:4px;flex-shrink:0">
                               <label class="toggle toggle-sm" @click.stop title="Toggle auto-sync for this profile">
                                 <input type="checkbox"
@@ -536,7 +542,8 @@
                           </template>
                           <span style="color:#8b949e;margin-left:auto" x-text="(sh.syncedCFs?.length || 0) + ' CFs'"></span>
                           <span style="color:#8b949e" x-text="timeAgo(sh.lastSync)"></span>
-                          <button class="btn btn-sm" @click.stop="resyncProfile(inst, sh)">Re-sync</button>
+                          <button class="btn btn-sm" @click.stop="editSyncedProfile(inst, sh)">Edit</button>
+                          <button class="btn btn-sm" @click.stop="quickSyncProfile(inst, sh)">Sync</button>
                           <button class="btn btn-sm" style="color:#f85149;border-color:#f85149" @click.stop="removeSyncHistory(inst.id, sh.arrProfileId)">Remove</button>
                         </div>
                       </template>
@@ -2638,6 +2645,13 @@
               <span style="font-size:11px;color:#d29922">Override Mode — edit values to customize sync settings. Yellow indicates values that differ from TRaSH defaults.</span>
             </template>
             <div style="flex:1"></div>
+            <template x-if="config.advancedScoring && !profileDetail?.detail?.imported">
+              <label style="display:flex;align-items:center;gap:4px;font-size:11px;color:#8b949e;cursor:pointer;user-select:none" title="Enable per-CF score overrides">
+                <input type="checkbox" x-model="advancedScoringEnabled" @change="if (!advancedScoringEnabled) syncScoreOverrides = {}" style="accent-color:#d29922">
+                <span>Advanced Scoring</span>
+                <span x-show="Object.keys(syncScoreOverrides).length > 0" style="background:#d29922;color:#0d1117;font-size:9px;padding:0 4px;border-radius:3px;font-weight:600" x-text="Object.keys(syncScoreOverrides).length"></span>
+              </label>
+            </template>
             <template x-if="!pdOverrideActive">
               <button class="btn" style="font-size:11px;padding:3px 10px;border-color:#d29922;color:#d29922" title="Override language, scores, cutoff, and upgrade settings for this sync only" @click="pdOverrideActive = true">Customize overrides</button>
             </template>
@@ -2648,6 +2662,10 @@
                 <button class="btn" style="font-size:11px;padding:3px 10px" @click="pdFinishOverrides()">Done</button>
               </div>
             </template>
+          </div>
+          <div x-show="advancedScoringEnabled" style="width:100%;margin-top:8px;padding:8px 12px;background:rgba(210,153,34,0.08);border-left:3px solid #d29922;border-radius:3px;font-size:11px;color:#8b949e;line-height:1.5;display:flex;align-items:flex-start;gap:8px">
+            <span style="color:#d29922;font-size:13px;flex-shrink:0;line-height:1.3">&#9888;</span>
+            <span>Per-CF score overrides active. Edit scores inline below — changes apply on next sync.</span>
           </div>
         </div>
 
@@ -2675,9 +2693,16 @@
                       <template x-for="cf in cat.cfs" :key="cf.trashId">
                         <div class="cf-row">
                           <div class="cf-name" x-text="cf.name"></div>
-                          <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'">
-                            <span x-text="(cf.score > 0 ? '+' : '') + cf.score"></span>
-                          </div>
+                          <template x-if="advancedScoringEnabled">
+                            <input type="number" class="pb-score-input" style="flex-shrink:0"
+                                   :value="syncScoreOverrides[cf.trashId] !== undefined ? syncScoreOverrides[cf.trashId] : cf.score"
+                                   @input="syncScoreOverrides[cf.trashId] = $event.target.value !== '' ? parseInt($event.target.value) : undefined; syncScoreOverrides = {...syncScoreOverrides}">
+                          </template>
+                          <template x-if="!advancedScoringEnabled">
+                            <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'">
+                              <span x-text="(cf.score > 0 ? '+' : '') + cf.score"></span>
+                            </div>
+                          </template>
                         </div>
                       </template>
                     </div>
@@ -2787,10 +2812,22 @@
                 <div class="section-desc" x-show="detailSections.core">
                   Required for this profile. Always included when syncing.
                 </div>
-                <div x-show="detailSections.core"
-                     :style="'padding:14px 28px;column-count:' + (profileDetail.detail.formatItemNames.length > 20 ? 3 : profileDetail.detail.formatItemNames.length > 10 ? 2 : 1) + ';column-gap:32px'">
+                <div x-show="detailSections.core" style="padding:4px 16px">
                   <template x-for="fi in profileDetail.detail.formatItemNames" :key="fi.trashId">
-                    <div style="font-size:12px;color:#8b949e;padding:2px 0;break-inside:avoid" x-text="fi.name"></div>
+                    <div class="cf-row">
+                      <span style="font-size:11px;color:#484f58;width:28px;text-align:center;flex-shrink:0" title="Required for this profile">🔒</span>
+                      <div class="cf-name" x-text="fi.name"></div>
+                      <template x-if="advancedScoringEnabled">
+                        <input type="number" class="pb-score-input" style="flex-shrink:0"
+                               :value="syncScoreOverrides[fi.trashId] !== undefined ? syncScoreOverrides[fi.trashId] : fi.score"
+                               @input="syncScoreOverrides[fi.trashId] = $event.target.value !== '' ? parseInt($event.target.value) : undefined; syncScoreOverrides = {...syncScoreOverrides}">
+                      </template>
+                      <template x-if="!advancedScoringEnabled">
+                        <div class="cf-score" :class="fi.score > 0 ? 'positive' : fi.score < 0 ? 'negative' : 'zero'">
+                          <span x-text="(fi.score > 0 ? '+' : '') + fi.score"></span>
+                        </div>
+                      </template>
+                    </div>
                   </template>
                 </div>
               </div>
@@ -2859,9 +2896,62 @@
                         <span class="cf-info" x-show="cf.description" @mouseenter="showCFTooltip($event, cf.description)" @mouseleave="hideCFTooltip()">ⓘ</span>
                         <span class="cf-default-badge" x-show="cf.default">recommended</span>
                       </div>
-                      <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'">
-                        <span x-text="cf.hasScore ? ((cf.score > 0 ? '+' : '') + cf.score) : '—'"></span>
-                      </div>
+                      <template x-if="advancedScoringEnabled">
+                        <input type="number" class="pb-score-input" style="flex-shrink:0"
+                               :value="syncScoreOverrides[cf.trashId] !== undefined ? syncScoreOverrides[cf.trashId] : cf.score"
+                               @input="syncScoreOverrides[cf.trashId] = $event.target.value !== '' ? parseInt($event.target.value) : undefined; syncScoreOverrides = {...syncScoreOverrides}">
+                      </template>
+                      <template x-if="!advancedScoringEnabled">
+                        <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'">
+                          <span x-text="cf.hasScore ? ((cf.score > 0 ? '+' : '') + cf.score) : '—'"></span>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </template>
+          </div>
+        </template>
+
+        <!-- Custom CFs section -->
+        <template x-if="syncCustomCFs.length > 0 && profileDetail?.detail?.trashGroups">
+          <div>
+            <div style="font-size:11px;color:#6e7681;text-transform:uppercase;letter-spacing:0.5px;padding:12px 0 6px;font-weight:600">
+              Custom Formats
+              <span style="text-transform:none;letter-spacing:0;font-weight:400"> — user-created CFs to include in sync</span>
+            </div>
+            <template x-for="catGroup in (() => { const map = {}; for (const cf of syncCustomCFs) { const cat = cf.category || 'Uncategorized'; if (!map[cat]) map[cat] = []; map[cat].push(cf); } return Object.entries(map).map(([name, cfs]) => ({ name, cfs })); })()" :key="catGroup.name">
+              <div class="detail-section" style="margin-bottom:4px;border-left:3px solid #d29922">
+                <div class="detail-section-header" @click="toggleGroupExpanded('ccf', catGroup.name)">
+                  <span class="detail-section-chevron" :class="{ open: groupExpanded['ccf/' + catGroup.name] }">&#9654;</span>
+                  <div style="font-size:13px;font-weight:500;color:#d29922" x-text="catGroup.name"></div>
+                  <div style="font-size:11px;color:#484f58;margin-right:auto;margin-left:8px"
+                       x-text="catGroup.cfs.filter(cf => selectedOptionalCFs[cf.id]).length + '/' + catGroup.cfs.length"></div>
+                  <label class="toggle toggle-sm" @click.stop>
+                    <input type="checkbox"
+                           :checked="catGroup.cfs.every(cf => selectedOptionalCFs[cf.id])"
+                           @change="catGroup.cfs.forEach(cf => { selectedOptionalCFs[cf.id] = $event.target.checked }); selectedOptionalCFs = {...selectedOptionalCFs}">
+                    <span class="slider"></span>
+                  </label>
+                </div>
+                <div x-show="groupExpanded['ccf/' + catGroup.name]">
+                  <template x-for="cf in catGroup.cfs" :key="cf.id">
+                    <div class="cf-row" :style="selectedOptionalCFs[cf.id] ? '' : 'opacity:0.35'">
+                      <label class="toggle toggle-sm">
+                        <input type="checkbox" :checked="selectedOptionalCFs[cf.id]"
+                               @change="selectedOptionalCFs[cf.id] = $event.target.checked; selectedOptionalCFs = {...selectedOptionalCFs}">
+                        <span class="slider"></span>
+                      </label>
+                      <div class="cf-name" style="color:#d29922" x-text="cf.name"></div>
+                      <template x-if="selectedOptionalCFs[cf.id]">
+                        <input type="number" class="pb-score-input" style="flex-shrink:0"
+                               :value="syncScoreOverrides[cf.id] !== undefined ? syncScoreOverrides[cf.id] : (cf.score || 0)"
+                               @input="syncScoreOverrides[cf.id] = $event.target.value !== '' ? parseInt($event.target.value) : 0; syncScoreOverrides = {...syncScoreOverrides}">
+                      </template>
+                      <template x-if="!selectedOptionalCFs[cf.id]">
+                        <div class="cf-score zero"><span x-text="cf.score || 0"></span></div>
+                      </template>
                     </div>
                   </template>
                 </div>
@@ -3055,6 +3145,26 @@
               <span style="color:#8b949e">Not cloned yet. Click Pull in the nav bar.</span>
             </template>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Advanced Scoring -->
+    <div class="settings-section">
+      <div class="settings-title">Advanced Scoring</div>
+      <div class="settings-body">
+        <div class="setting-row">
+          <div class="setting-label">Advanced Scoring</div>
+          <div class="setting-value" style="display:flex;align-items:center;gap:10px">
+            <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
+              <input type="checkbox" x-model="config.advancedScoring" @change="saveConfig(['advancedScoring'])" style="accent-color:#d29922">
+              <span style="font-size:12px;color:#8b949e">Allow per-CF score overrides on TRaSH profiles</span>
+            </label>
+          </div>
+        </div>
+        <div style="margin:8px 16px;padding:8px 12px;background:rgba(210,153,34,0.08);border-left:3px solid #d29922;border-radius:3px;font-size:11px;color:#8b949e;line-height:1.5;display:flex;align-items:flex-start;gap:8px">
+          <span style="color:#d29922;font-size:13px;flex-shrink:0;line-height:1.3">&#9888;</span>
+          <span>Deviating from TRaSH recommended scores may produce unexpected results. Use with caution.</span>
         </div>
       </div>
     </div>
@@ -3439,8 +3549,8 @@
           <div x-show="syncPreview?.error" style="color:#f47067" x-text="syncPreview?.error"></div>
         </div>
       </div>
-      <!-- Sync behavior rules (update mode only) -->
-      <div x-show="syncMode === 'update'" style="margin-bottom:12px;padding:10px 12px;background:#161b22;border:1px solid #30363d;border-radius:6px">
+      <!-- Sync behavior rules -->
+      <div style="margin-bottom:12px;padding:10px 12px;background:#161b22;border:1px solid #30363d;border-radius:6px">
         <div style="font-size:12px;font-weight:600;color:#e1e4e8;margin-bottom:8px">Custom Formats</div>
         <div style="display:flex;flex-direction:column;gap:8px">
           <div style="display:flex;align-items:center;gap:10px">
@@ -3467,6 +3577,7 @@
           </div>
         </div>
         <div style="font-size:10px;color:#484f58;margin-top:6px">Add: when to create missing CFs &bull; Scores: whether to overwrite manual changes &bull; Reset: what happens to scores of removed CFs</div>
+        <div style="font-size:11px;color:#8b949e;margin-top:4px">CFs and scores will be synced according to the Custom Formats rules below. Use overrides on the profile page for score adjustments.</div>
       </div>
 
       <!-- Auto-sync toggle -->
@@ -3888,12 +3999,19 @@
   </div>
 
   <!-- Toast notifications -->
-  <div style="position:fixed;top:16px;right:16px;z-index:10000;display:flex;flex-direction:column;gap:8px;max-width:400px">
+  <div style="position:fixed;top:84px;right:20px;z-index:10000;display:flex;flex-direction:column;gap:8px;max-width:420px;pointer-events:none">
     <template x-for="toast in toasts" :key="toast.id">
-      <div style="padding:10px 14px;border-radius:6px;font-size:12px;line-height:1.5;box-shadow:0 4px 12px rgba(0,0,0,0.4);cursor:pointer;animation:fadeIn 0.2s"
-           :style="toast.type === 'warning' ? 'background:#2d1b00;border:1px solid #d29922;color:#e3b341' : toast.type === 'error' ? 'background:#3d1f1f;border:1px solid #f85149;color:#f85149' : 'background:#0d2818;border:1px solid #238636;color:#3fb950'"
-           @click="toasts = toasts.filter(t => t.id !== toast.id)"
-           x-text="toast.message">
+      <div style="position:relative;border-radius:6px;font-size:12px;line-height:1.5;box-shadow:0 4px 12px rgba(0,0,0,0.4);overflow:hidden;pointer-events:auto"
+           :class="toast.exiting ? 'toast-exit' : 'toast-enter'"
+           :style="toast.type === 'warning' ? 'background:#2d1b00;border:1px solid #d29922;color:#e3b341' : toast.type === 'error' ? 'background:#3d1f1f;border:1px solid #f85149;color:#f85149' : 'background:#0d2818;border:1px solid #238636;color:#3fb950'">
+        <div style="display:flex;align-items:center;gap:8px;padding:10px 32px 10px 14px">
+          <span x-text="toast.type === 'error' ? '✕' : toast.type === 'warning' ? '⚠' : '✓'" style="font-size:14px;flex-shrink:0"></span>
+          <span x-text="toast.message" style="flex:1"></span>
+          <button @click="dismissToast(toast.id)" style="position:absolute;top:6px;right:8px;background:none;border:none;color:inherit;cursor:pointer;font-size:14px;opacity:0.6;padding:0;line-height:1">&times;</button>
+        </div>
+        <div style="height:2px;width:100%;position:relative">
+          <div :style="'height:100%;animation:toastProgress ' + (toast.duration || 4000) + 'ms linear forwards;' + (toast.type === 'warning' ? 'background:#d29922' : toast.type === 'error' ? 'background:#f85149' : 'background:#3fb950')"></div>
+        </div>
       </div>
     </template>
   </div>
@@ -4423,7 +4541,10 @@ function clonarr() {
     qsSyncResult: {},    // per app-type: { ok, message }
     qsAutoSync: {},      // per app-type: { enabled, type }
     confirmModal: { show: false, title: '', message: '', confirmLabel: '', onConfirm: null, onCancel: null },
-    toasts: [], // { id, message, type: 'info'|'warning'|'error', timeout }
+    toasts: [], // { id, message, type: 'info'|'warning'|'error', duration }
+    syncScoreOverrides: {}, // trash_id → custom score
+    advancedScoringEnabled: false, // toggle for advanced score editing
+    syncCustomCFs: [], // user-created CFs for adding to TRaSH profiles
 
     // Naming schemes (cached per app type)
     namingData: {},  // { radarr: { folder: {...}, file: {...} }, sonarr: { season: {...}, series: {...}, episodes: {...} } }
@@ -4668,6 +4789,7 @@ function clonarr() {
         if (fields && fields.includes('pullInterval')) body.pullInterval = this.config.pullInterval;
         if (fields && fields.includes('devMode')) body.devMode = this.config.devMode;
         if (fields && fields.includes('debugLogging')) body.debugLogging = this.config.debugLogging;
+        if (fields && fields.includes('advancedScoring')) body.advancedScoring = this.config.advancedScoring;
         if (fields && fields.includes('prowlarr')) body.prowlarr = this.config.prowlarr;
         await fetch('/api/config', {
           method: 'PUT',
@@ -7980,7 +8102,7 @@ function clonarr() {
         if (!groups[g]) groups[g] = { name: g, profiles: [] };
         groups[g].profiles.push(p);
       }
-      const order = { 'SQP': 0, 'Standard': 1, 'Anime': 2 };
+      const order = { 'Standard': 0, 'Anime': 1, 'SQP': 2 };
       return Object.values(groups).sort((a, b) => {
         return (order[a.name] ?? 99) - (order[b.name] ?? 99);
       });
@@ -8338,10 +8460,18 @@ function clonarr() {
 
     // --- Notifications ---
 
-    showToast(message, type = 'info', duration = 8000) {
+    showToast(message, type = 'info', duration = 4000) {
       const id = Date.now() + Math.random();
-      this.toasts = [...this.toasts, { id, message, type }];
-      setTimeout(() => { this.toasts = this.toasts.filter(t => t.id !== id); }, duration);
+      this.toasts = [...this.toasts, { id, message, type, duration, exiting: false }];
+      setTimeout(() => this.dismissToast(id), duration);
+    },
+
+    dismissToast(id) {
+      const toast = this.toasts.find(t => t.id === id);
+      if (!toast || toast.exiting) return;
+      toast.exiting = true;
+      this.toasts = [...this.toasts];
+      setTimeout(() => { this.toasts = this.toasts.filter(t => t.id !== id); }, 300);
     },
 
     async checkCleanupEvents() {
@@ -8350,7 +8480,7 @@ function clonarr() {
         if (!r.ok) return;
         const events = await r.json();
         for (const ev of events) {
-          this.showToast(`"${ev.profileName}" removed — profile was deleted from ${ev.instanceName}`, 'warning', 10000);
+          this.showToast(`"${ev.profileName}" removed — profile was deleted from ${ev.instanceName}`, 'warning', 5000);
         }
       } catch (e) { /* ignore */ }
     },
@@ -8398,7 +8528,12 @@ function clonarr() {
       this.selectedOptionalCFs = {};
 
       this.showProfileInfo = false;
+      this.syncScoreOverrides = {};
+      this.advancedScoringEnabled = false;
+      this.syncCustomCFs = [];
       this.profileDetail = { instance: inst, profile: profile, detail: null };
+      // Load custom CFs for this app type
+      fetch(`/api/custom-cfs/${inst.type}`).then(r => r.ok ? r.json() : []).then(d => this.syncCustomCFs = d || []).catch(() => {});
       // Pre-load languages and quality presets for this instance (for override dropdowns)
       this.getLanguagesForInstance(inst.id);
       if (!this.pbQualityPresets.length) {
@@ -8688,7 +8823,7 @@ function clonarr() {
         const gn = p.groupName || 'Other';
         if (!seen.has(gn)) { seen.add(gn); groups.push(gn); }
       }
-      const order = { 'SQP': 0, 'Standard': 1, 'Anime': 2 };
+      const order = { 'Standard': 0, 'Anime': 1, 'SQP': 2 };
       return groups.sort((a, b) => (order[a] ?? 99) - (order[b] ?? 99));
     },
 
@@ -8955,6 +9090,9 @@ function clonarr() {
           }
         }
       }
+      for (const cf of (this.syncCustomCFs || [])) {
+        if (this.selectedOptionalCFs[cf.id]) idSet.add(cf.id);
+      }
       return [...idSet];
     },
 
@@ -9116,6 +9254,7 @@ function clonarr() {
       if (hasOverrides) body.overrides = overrides;
       // Sync behavior rules
       if (this.syncForm.behavior) body.behavior = this.syncForm.behavior;
+      if (Object.keys(this.syncScoreOverrides).length > 0) body.scoreOverrides = this.syncScoreOverrides;
       return body;
     },
 
@@ -9189,6 +9328,18 @@ function clonarr() {
         }
         this.syncResult = result;
         this.syncPlan = null;
+        // Show toast notification
+        if (result.errors && result.errors.length > 0) {
+          this.showToast(`Sync completed with ${result.errors.length} error${result.errors.length !== 1 ? 's' : ''} — ${result.errors[0]}`, 'warning', 5000);
+        } else {
+          const parts = [];
+          if (result.cfsCreated > 0) parts.push(`${result.cfsCreated} CFs created`);
+          if (result.cfsUpdated > 0) parts.push(`${result.cfsUpdated} updated`);
+          if (result.scoresUpdated > 0) parts.push(`${result.scoresUpdated} scores set`);
+          const summary = parts.length > 0 ? parts.join(', ') : 'no changes needed';
+          const mode = this.syncMode === 'create' ? 'Created' : 'Synced';
+          this.showToast(`${mode} "${this.syncForm.profileName}" — ${summary}`);
+        }
         // Reload Arr profiles first (new profile may have been created), then sync history + rules
         const inst = this.instances.find(i => i.id === this.syncForm.instanceId);
         if (inst) await this.loadInstanceProfiles(inst);
@@ -9286,6 +9437,90 @@ function clonarr() {
       // Restore behavior from sync history
       if (sh.behavior) {
         this.syncForm.behavior = { ...this.syncForm.behavior, ...sh.behavior };
+      }
+      // Restore score overrides from sync history or auto-sync rule
+      const rule = this.autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId);
+      const scoreOv = rule?.scoreOverrides || sh.scoreOverrides;
+      if (scoreOv && Object.keys(scoreOv).length > 0) {
+        this.syncScoreOverrides = { ...scoreOv };
+        this.advancedScoringEnabled = true;
+      }
+    },
+
+    async editSyncedProfile(inst, sh) {
+      await this.resyncProfile(inst, sh);
+    },
+
+    async quickSyncProfile(inst, sh) {
+      const rule = this.autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId);
+      const body = {
+        instanceId: inst.id,
+        profileTrashId: sh.profileTrashId,
+        arrProfileId: sh.arrProfileId,
+        selectedCFs: rule?.selectedCFs || [],
+        behavior: rule?.behavior || sh.behavior || { addMode: 'add_missing', removeMode: 'remove_custom', resetMode: 'reset_to_zero' },
+        overrides: rule?.overrides || sh.overrides || null,
+        scoreOverrides: rule?.scoreOverrides || sh.scoreOverrides || null
+      };
+      this.showToast(`Syncing "${sh.profileName}" to ${inst.name}...`, 'info', 5000);
+      try {
+        const r = await fetch('/api/sync/apply', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body)
+        });
+        if (!r.ok) {
+          const e = await r.json().catch(() => ({ error: 'Sync failed' }));
+          this.showToast(`Sync failed for "${sh.profileName}": ${e.error || 'Unknown error'}`, 'error', 6000);
+          return;
+        }
+        const result = await r.json();
+        if (result.errors?.length > 0) {
+          this.showToast(`Sync "${sh.profileName}": completed with errors — ${result.errors[0]}`, 'warning', 5000);
+        } else {
+          const changes = [];
+          if (result.cfsCreated > 0) changes.push(`${result.cfsCreated} CFs created`);
+          if (result.cfsUpdated > 0) changes.push(`${result.cfsUpdated} CFs updated`);
+          if (result.scoresUpdated > 0) changes.push(`${result.scoresUpdated} scores set`);
+          const summary = changes.length > 0 ? changes.join(', ') : 'no changes needed';
+          this.showToast(`Synced "${sh.profileName}" to ${inst.name} — ${summary}`, 'info', 4000);
+        }
+        await this.loadSyncHistory(inst.id);
+      } catch (e) {
+        this.showToast(`Sync failed for "${sh.profileName}": ${e.message}`, 'error', 6000);
+      }
+    },
+
+    async syncAllProfiles(appType) {
+      const instances = this.instancesOfType(appType);
+      let total = 0;
+      const tasks = [];
+      for (const inst of instances) {
+        const history = this.syncHistory[inst.id] || [];
+        for (const sh of history) {
+          tasks.push({ inst, sh });
+          total++;
+        }
+      }
+      if (total === 0) {
+        this.showToast('No synced profiles to sync', 'warning');
+        return;
+      }
+      this.showToast(`Syncing ${total} profile${total !== 1 ? 's' : ''}...`, 'info', 5000);
+      let succeeded = 0;
+      let failed = 0;
+      for (const { inst, sh } of tasks) {
+        try {
+          await this.quickSyncProfile(inst, sh);
+          succeeded++;
+        } catch (e) {
+          failed++;
+        }
+      }
+      if (failed > 0) {
+        this.showToast(`Sync All complete: ${succeeded} succeeded, ${failed} failed`, 'warning', 5000);
+      } else {
+        this.showToast(`Sync All complete: ${succeeded} profile${succeeded !== 1 ? 's' : ''} synced`, 'info', 4000);
       }
     },
 

--- a/ui/sync.go
+++ b/ui/sync.go
@@ -72,6 +72,8 @@ type SyncRequest struct {
 	Overrides *SyncOverrides `json:"overrides,omitempty"`
 	// Sync behavior rules (nil = defaults: add_missing, remove_custom, reset_to_zero)
 	Behavior *SyncBehavior `json:"behavior,omitempty"`
+	// Per-CF score overrides (trash_id → score)
+	ScoreOverrides map[string]int `json:"scoreOverrides,omitempty"`
 }
 
 // SyncOverrides allows users to override specific profile settings from TRaSH defaults.
@@ -160,6 +162,16 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 
 	if scoreCtx == "" {
 		scoreCtx = "default"
+	}
+
+	// Merge user score overrides into cfScoreOverrides
+	if len(req.ScoreOverrides) > 0 {
+		if cfScoreOverrides == nil {
+			cfScoreOverrides = make(map[string]int, len(req.ScoreOverrides))
+		}
+		for tid, score := range req.ScoreOverrides {
+			cfScoreOverrides[tid] = score
+		}
 	}
 
 	// Resolve sync behavior rules
@@ -530,6 +542,16 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 
 	if scoreCtx == "" {
 		scoreCtx = "default"
+	}
+
+	// Merge user score overrides into cfScoreOverrides
+	if len(req.ScoreOverrides) > 0 {
+		if cfScoreOverrides == nil {
+			cfScoreOverrides = make(map[string]int, len(req.ScoreOverrides))
+		}
+		for tid, score := range req.ScoreOverrides {
+			cfScoreOverrides[tid] = score
+		}
 	}
 
 	client := NewArrClient(instance.URL, instance.APIKey)
@@ -1317,12 +1339,24 @@ func findProfile(ad *AppData, trashID string) *TrashQualityProfile {
 
 // --- Custom CF helpers for sync ---
 
-// customCFToArr converts a CustomCF (specs already in Arr format) to an ArrCF for create/update.
+// customCFToArr converts a CustomCF to an ArrCF for create/update.
+// Specification fields are normalized to Arr array format in case they were
+// stored in TRaSH object format ({"value": X} → [{"name":"value","value":X}]).
 func customCFToArr(cf *CustomCF) *ArrCF {
+	specs := make([]ArrSpecification, len(cf.Specifications))
+	for i, s := range cf.Specifications {
+		specs[i] = ArrSpecification{
+			Name:           s.Name,
+			Implementation: s.Implementation,
+			Negate:         s.Negate,
+			Required:       s.Required,
+			Fields:         convertFieldsToArr(s.Fields),
+		}
+	}
 	return &ArrCF{
 		Name:                            cf.Name,
 		IncludeCustomFormatWhenRenaming: cf.IncludeInRename,
-		Specifications:                  cf.Specifications,
+		Specifications:                  specs,
 	}
 }
 

--- a/ui/sync_test.go
+++ b/ui/sync_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCustomCFToArr_ConvertsObjectFields(t *testing.T) {
+	// TRaSH format: {"value": "regex"}
+	cf := &CustomCF{
+		Name:    "Test CF",
+		AppType: "radarr",
+		Specifications: []ArrSpecification{
+			{
+				Name:           "spec1",
+				Implementation: "ReleaseTitleSpecification",
+				Fields:         json.RawMessage(`{"value":"test\\.regex"}`),
+			},
+		},
+	}
+
+	arr := customCFToArr(cf)
+
+	if arr.Name != "Test CF" {
+		t.Fatalf("Name = %q, want Test CF", arr.Name)
+	}
+	if len(arr.Specifications) != 1 {
+		t.Fatalf("specs = %d, want 1", len(arr.Specifications))
+	}
+
+	// Fields should be converted to array format
+	var fields []map[string]any
+	if err := json.Unmarshal(arr.Specifications[0].Fields, &fields); err != nil {
+		t.Fatalf("fields not array format: %v", err)
+	}
+	if len(fields) != 1 {
+		t.Fatalf("fields length = %d, want 1", len(fields))
+	}
+	if fields[0]["name"] != "value" {
+		t.Fatalf("field name = %v, want value", fields[0]["name"])
+	}
+	if fields[0]["value"] != "test\\.regex" {
+		t.Fatalf("field value = %v, want test\\.regex", fields[0]["value"])
+	}
+}
+
+func TestCustomCFToArr_PassthroughArrayFields(t *testing.T) {
+	// Already in Arr format: [{"name":"value","value":"x"}]
+	cf := &CustomCF{
+		Name:    "Test CF",
+		AppType: "radarr",
+		Specifications: []ArrSpecification{
+			{
+				Name:           "spec1",
+				Implementation: "ReleaseTitleSpecification",
+				Fields:         json.RawMessage(`[{"name":"value","value":"already.arr"}]`),
+			},
+		},
+	}
+
+	arr := customCFToArr(cf)
+
+	var fields []map[string]any
+	if err := json.Unmarshal(arr.Specifications[0].Fields, &fields); err != nil {
+		t.Fatalf("fields parse failed: %v", err)
+	}
+	if fields[0]["value"] != "already.arr" {
+		t.Fatalf("field value = %v, want already.arr", fields[0]["value"])
+	}
+}
+
+func TestCustomCFToArr_MultipleSpecs(t *testing.T) {
+	cf := &CustomCF{
+		Name:    "Multi",
+		AppType: "radarr",
+		Specifications: []ArrSpecification{
+			{Name: "s1", Implementation: "Impl1", Negate: true, Required: false, Fields: json.RawMessage(`{"value":"a"}`)},
+			{Name: "s2", Implementation: "Impl2", Negate: false, Required: true, Fields: json.RawMessage(`{"value":"b"}`)},
+		},
+	}
+
+	arr := customCFToArr(cf)
+
+	if len(arr.Specifications) != 2 {
+		t.Fatalf("specs = %d, want 2", len(arr.Specifications))
+	}
+	if arr.Specifications[0].Name != "s1" || !arr.Specifications[0].Negate {
+		t.Fatalf("spec0 = %+v, want s1/negate=true", arr.Specifications[0])
+	}
+	if arr.Specifications[1].Name != "s2" || !arr.Specifications[1].Required {
+		t.Fatalf("spec1 = %+v, want s2/required=true", arr.Specifications[1])
+	}
+}
+
+func TestCustomCFToArr_EmptySpecs(t *testing.T) {
+	cf := &CustomCF{Name: "Empty", AppType: "radarr"}
+	arr := customCFToArr(cf)
+	if len(arr.Specifications) != 0 {
+		t.Fatalf("specs = %d, want 0", len(arr.Specifications))
+	}
+}
+
+func TestConvertFieldsToArr_ObjectToArray(t *testing.T) {
+	input := json.RawMessage(`{"value":"test"}`)
+	out := convertFieldsToArr(input)
+
+	var fields []map[string]any
+	if err := json.Unmarshal(out, &fields); err != nil {
+		t.Fatalf("not array format: %v", err)
+	}
+	if len(fields) != 1 || fields[0]["name"] != "value" || fields[0]["value"] != "test" {
+		t.Fatalf("unexpected: %s", string(out))
+	}
+}
+
+func TestConvertFieldsToArr_ArrayPassthrough(t *testing.T) {
+	input := json.RawMessage(`[{"name":"value","value":"x"}]`)
+	out := convertFieldsToArr(input)
+	if string(out) != string(input) {
+		t.Fatalf("array should pass through: got %s", string(out))
+	}
+}
+
+func TestConvertFieldsToArr_MultipleKeys(t *testing.T) {
+	input := json.RawMessage(`{"exceptLanguage":false,"value":"test"}`)
+	out := convertFieldsToArr(input)
+
+	var fields []map[string]any
+	if err := json.Unmarshal(out, &fields); err != nil {
+		t.Fatalf("not array: %v", err)
+	}
+	if len(fields) != 2 {
+		t.Fatalf("fields = %d, want 2", len(fields))
+	}
+	// Keys should be sorted alphabetically
+	if fields[0]["name"] != "exceptLanguage" {
+		t.Fatalf("first key = %v, want exceptLanguage (sorted)", fields[0]["name"])
+	}
+	if fields[1]["name"] != "value" {
+		t.Fatalf("second key = %v, want value (sorted)", fields[1]["name"])
+	}
+}

--- a/ui/trash.go
+++ b/ui/trash.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // --- TRaSH Data Types ---
@@ -979,30 +981,11 @@ func SnapshotAppData(snap *TrashData, app string) *AppData {
 	default:
 		return nil
 	}
-	cp := *src
-	if src.CustomFormats != nil {
-		cp.CustomFormats = make(map[string]*TrashCF, len(src.CustomFormats))
-		for k, v := range src.CustomFormats {
-			cp.CustomFormats[k] = v
-		}
+	copied, err := copystructure.Copy(src)
+	if err != nil {
+		log.Fatalf("BUG: AppData deep-copy failed: %v", err)
 	}
-	if src.CFGroups != nil {
-		cp.CFGroups = make([]*TrashCFGroup, len(src.CFGroups))
-		copy(cp.CFGroups, src.CFGroups)
-	}
-	if src.Profiles != nil {
-		cp.Profiles = make([]*TrashQualityProfile, len(src.Profiles))
-		copy(cp.Profiles, src.Profiles)
-	}
-	if src.ProfileGroups != nil {
-		cp.ProfileGroups = make([]*ProfileGroup, len(src.ProfileGroups))
-		copy(cp.ProfileGroups, src.ProfileGroups)
-	}
-	if src.QualitySizes != nil {
-		cp.QualitySizes = make([]*TrashQualitySize, len(src.QualitySizes))
-		copy(cp.QualitySizes, src.QualitySizes)
-	}
-	return &cp
+	return copied.(*AppData)
 }
 
 // ResolvedCF is a single CF with resolved score.


### PR DESCRIPTION
> **Depends on:** #6 — merge that first.

## Why
The sync workflow currently requires too many clicks and gives too little feedback. Users can't quickly re-sync a profile, can't see what happened after a sync, and have no way to sync all their profiles at once. The UI also lacks support for the new backend features (sync behavior, advanced scoring) added in #6, and custom CFs are dumped in a flat list rather than organized by category. These gaps make the tool harder to use for anyone managing multiple profiles or wanting fine-grained control.

## Summary
- **Sync behavior dropdowns** visible in both Create and Update mode (was previously hidden in create mode)
- **Advanced scoring UI**: per-CF editable score inputs appear inline in the CF list when enabled in Settings. Includes scoring for core/required CFs (Profile section), not just optional groups.
- **Synced profile management**:
  - *Edit* button navigates to profile detail without auto-opening the sync modal
  - *Sync* button triggers immediate re-sync with saved settings
  - *Sync All* button syncs every configured profile sequentially
- **Custom CFs section**: grouped by category with amber styling, toggle per-category
- **Toast notifications**: redesigned — slide down from top-right below the subtab bar, progress bar, auto-dismiss (4s default for info, 5s warnings, 6s errors), close button. Toasts now appear on sync complete showing what changed (e.g. "Created 'HD Bluray + WEB' — 5 CFs created, 3 scores set").
- **SQP profiles sorted to bottom** of the profile list (Standard → Anime → SQP) since they're special-use-case profiles
- **Bug fix**: custom CF sync was failing with HTTP 400 because spec fields in TRaSH object format (`{"value": X}`) weren't being converted to Arr array format (`[{"name":"value","value":X}]`). Now runs `convertFieldsToArr` on all custom CF specs before sending to Radarr/Sonarr.
- **Styled warnings**: Advanced Scoring warnings use border-left accent matching the rest of the app

## Changed files
- `ui/static/index.html` — all UI features (287 lines changed)
- `ui/sync.go` — `customCFToArr` field normalization fix
- `ui/sync_test.go` — tests for `customCFToArr` and `convertFieldsToArr`
- `ui/config_test.go` — `ResolveSyncBehavior` tests

## Test plan
- [ ] `cd ui && go test -run "TestCustomCF|TestConvert|TestResolve" -v ./...` — 11 tests pass
- [ ] Sync behavior dropdowns appear in both create and update modes
- [ ] Enable Advanced Scoring in Settings → per-CF score inputs appear, including in the Profile (core CFs) section
- [ ] Edit synced profile → navigates to detail, does NOT auto-open sync modal
- [ ] Sync button → immediate re-sync with toast showing results
- [ ] Sync All → syncs all profiles with individual toasts
- [ ] Custom CFs grouped by category with amber styling
- [ ] Toasts: slide-down animation, progress bar, auto-dismiss, close button
- [ ] Custom CFs with TRaSH-format JSON sync without HTTP 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)