### PR TITLE
{feat} Adds Pushover Notifications + Tweaks Notifications UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dev/
 ui/clonarr
+run-dev.cmd

--- a/ui/autosync.go
+++ b/ui/autosync.go
@@ -411,6 +411,29 @@ func (app *App) sendGotify(title, message, level string) {
 	resp.Body.Close()
 }
 
+// sendPushover sends a Pushover push notification at normal priority.
+func (app *App) sendPushover(title, message string) {
+	cfg := app.config.Get()
+	if !cfg.AutoSync.PushoverEnabled || cfg.AutoSync.PushoverUserKey == "" || cfg.AutoSync.PushoverAppToken == "" {
+		return
+	}
+
+	payload := map[string]any{
+		"token":    cfg.AutoSync.PushoverAppToken,
+		"user":     cfg.AutoSync.PushoverUserKey,
+		"title":    title,
+		"message":  message,
+		"priority": 0, // normal priority
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := app.notifyClient.Post("https://api.pushover.net/1/messages.json", "application/json", bytes.NewReader(body))
+	if err != nil {
+		log.Printf("Pushover: send failed: %v", err)
+		return
+	}
+	resp.Body.Close()
+}
+
 // notifyCleanup sends a Discord notification for auto-cleanup events.
 func (app *App) notifyCleanup(events []CleanupEvent) {
 	cfg := app.config.Get()
@@ -425,7 +448,7 @@ func (app *App) notifyCleanup(events []CleanupEvent) {
 	description = strings.TrimSpace(description)
 
 	// Discord notification
-	if webhook := cfg.AutoSync.DiscordWebhook; webhook != "" {
+	if webhook := cfg.AutoSync.DiscordWebhook; webhook != "" && (cfg.AutoSync.DiscordEnabled == nil || *cfg.AutoSync.DiscordEnabled) {
 		embed := map[string]any{
 			"title":       "Sync Rules Cleaned Up",
 			"description": description,
@@ -443,6 +466,8 @@ func (app *App) notifyCleanup(events []CleanupEvent) {
 
 	// Gotify notification
 	go app.sendGotify("Clonarr: Sync Rules Cleaned Up", description, "warning")
+	// Pushover notification
+	go app.sendPushover("Clonarr: Sync Rules Cleaned Up", description)
 }
 
 // isConnectionError checks if an error is a network/connection problem (instance unreachable).
@@ -548,7 +573,7 @@ func (app *App) notifyAutoSync(rule AutoSyncRule, inst Instance, profileName str
 	}
 
 	// Discord notification
-	if webhook := cfg.AutoSync.DiscordWebhook; webhook != "" {
+	if webhook := cfg.AutoSync.DiscordWebhook; webhook != "" && (cfg.AutoSync.DiscordEnabled == nil || *cfg.AutoSync.DiscordEnabled) {
 		embed := map[string]any{
 			"title":       title,
 			"description": description,
@@ -570,6 +595,8 @@ func (app *App) notifyAutoSync(rule AutoSyncRule, inst Instance, profileName str
 		level = "critical"
 	}
 	go app.sendGotify("Clonarr: "+title, description, level)
+	// Pushover notification
+	go app.sendPushover("Clonarr: "+title, description)
 }
 
 // notifyRepoUpdate sends a Discord notification when the TRaSH repo has new commits.
@@ -589,29 +616,33 @@ func (app *App) notifyRepoUpdate(prevCommit, newCommit string) {
 	}
 
 	// Discord notification — use updates webhook if set, otherwise fall back to main
-	webhook := cfg.AutoSync.DiscordWebhookUpdates
-	if webhook == "" {
-		webhook = cfg.AutoSync.DiscordWebhook
-	}
-	if webhook != "" {
-		embed := map[string]any{
-			"title":       "TRaSH Guides Updated",
-			"description": description,
-			"color":       0x58a6ff, // blue
-			"footer":      map[string]string{"text": "Clonarr " + Version + " by ProphetSe7en"},
+	if cfg.AutoSync.DiscordEnabled == nil || *cfg.AutoSync.DiscordEnabled {
+		webhook := cfg.AutoSync.DiscordWebhookUpdates
+		if webhook == "" {
+			webhook = cfg.AutoSync.DiscordWebhook
 		}
-		if payload, err := json.Marshal(map[string]any{"embeds": []any{embed}}); err == nil {
-			if resp, err := app.notifyClient.Post(webhook, "application/json", bytes.NewReader(payload)); err != nil {
-				log.Printf("Repo update: Discord notification failed: %v", err)
-			} else {
-				resp.Body.Close()
-				log.Printf("Repo update: Discord notification sent (%s → %s)", prevCommit, newCommit)
+		if webhook != "" {
+			embed := map[string]any{
+				"title":       "TRaSH Guides Updated",
+				"description": description,
+				"color":       0x58a6ff, // blue
+				"footer":      map[string]string{"text": "Clonarr " + Version + " by ProphetSe7en"},
+			}
+			if payload, err := json.Marshal(map[string]any{"embeds": []any{embed}}); err == nil {
+				if resp, err := app.notifyClient.Post(webhook, "application/json", bytes.NewReader(payload)); err != nil {
+					log.Printf("Repo update: Discord notification failed: %v", err)
+				} else {
+					resp.Body.Close()
+					log.Printf("Repo update: Discord notification sent (%s → %s)", prevCommit, newCommit)
+				}
 			}
 		}
 	}
 
 	// Gotify notification
 	go app.sendGotify("Clonarr: TRaSH Guides Updated", description, "info")
+	// Pushover notification
+	go app.sendPushover("Clonarr: TRaSH Guides Updated", description)
 }
 
 // notifyChangelog sends a separate Discord notification when updates.txt has a new date section.
@@ -643,23 +674,25 @@ func (app *App) notifyChangelog(section ChangelogSection) {
 	}
 
 	// Discord notification — use updates webhook if set, otherwise fall back to main
-	webhook := cfg.AutoSync.DiscordWebhookUpdates
-	if webhook == "" {
-		webhook = cfg.AutoSync.DiscordWebhook
-	}
-	if webhook != "" {
-		embed := map[string]any{
-			"title":       "TRaSH Weekly Changelog",
-			"description": description,
-			"color":       0xd29922, // amber
-			"footer":      map[string]string{"text": "Clonarr " + Version + " by ProphetSe7en"},
+	if cfg.AutoSync.DiscordEnabled == nil || *cfg.AutoSync.DiscordEnabled {
+		webhook := cfg.AutoSync.DiscordWebhookUpdates
+		if webhook == "" {
+			webhook = cfg.AutoSync.DiscordWebhook
 		}
-		if payload, err := json.Marshal(map[string]any{"embeds": []any{embed}}); err == nil {
-			if resp, err := app.notifyClient.Post(webhook, "application/json", bytes.NewReader(payload)); err != nil {
-				log.Printf("Changelog: Discord notification failed: %v", err)
-			} else {
-				resp.Body.Close()
-				log.Printf("Changelog: Discord notification sent (week of %s)", section.Date)
+		if webhook != "" {
+			embed := map[string]any{
+				"title":       "TRaSH Weekly Changelog",
+				"description": description,
+				"color":       0xd29922, // amber
+				"footer":      map[string]string{"text": "Clonarr " + Version + " by ProphetSe7en"},
+			}
+			if payload, err := json.Marshal(map[string]any{"embeds": []any{embed}}); err == nil {
+				if resp, err := app.notifyClient.Post(webhook, "application/json", bytes.NewReader(payload)); err != nil {
+					log.Printf("Changelog: Discord notification failed: %v", err)
+				} else {
+					resp.Body.Close()
+					log.Printf("Changelog: Discord notification sent (week of %s)", section.Date)
+				}
 			}
 		}
 	}
@@ -686,4 +719,6 @@ func (app *App) notifyChangelog(section ChangelogSection) {
 		gotifyMsg += line + "\n"
 	}
 	go app.sendGotify("Clonarr: TRaSH Weekly Changelog", gotifyMsg, "info")
+	// Pushover notification
+	go app.sendPushover("Clonarr: TRaSH Weekly Changelog", gotifyMsg)
 }

--- a/ui/config.go
+++ b/ui/config.go
@@ -41,11 +41,12 @@ type ProwlarrConfig struct {
 // AutoSyncConfig holds global auto-sync settings and rules.
 type AutoSyncConfig struct {
 	Enabled            bool           `json:"enabled"`
-	NotifyOnSuccess    bool           `json:"notifyOnSuccess"`
-	NotifyOnFailure    bool           `json:"notifyOnFailure"`
-	NotifyOnRepoUpdate bool           `json:"notifyOnRepoUpdate"`
-	DiscordWebhook     string         `json:"discordWebhook,omitempty"`
-	DiscordWebhookUpdates string      `json:"discordWebhookUpdates,omitempty"` // separate webhook for TRaSH repo updates (falls back to main if empty)
+	NotifyOnSuccess       bool           `json:"notifyOnSuccess"`
+	NotifyOnFailure       bool           `json:"notifyOnFailure"`
+	NotifyOnRepoUpdate    bool           `json:"notifyOnRepoUpdate"`
+	DiscordEnabled        *bool          `json:"discordEnabled,omitempty"` // pointer: nil = not yet set, defaults to true
+	DiscordWebhook        string         `json:"discordWebhook,omitempty"`
+	DiscordWebhookUpdates string         `json:"discordWebhookUpdates,omitempty"` // separate webhook for TRaSH repo updates (falls back to main if empty)
 	// Gotify
 	GotifyEnabled          bool   `json:"gotifyEnabled"`
 	GotifyURL              string `json:"gotifyUrl,omitempty"`
@@ -56,7 +57,11 @@ type AutoSyncConfig struct {
 	GotifyCriticalValue    *int   `json:"gotifyCriticalValue,omitempty"`
 	GotifyWarningValue     *int   `json:"gotifyWarningValue,omitempty"`
 	GotifyInfoValue        *int   `json:"gotifyInfoValue,omitempty"`
-	Rules                  []AutoSyncRule `json:"rules,omitempty"`
+	// Pushover
+	PushoverEnabled  bool   `json:"pushoverEnabled"`
+	PushoverUserKey  string `json:"pushoverUserKey,omitempty"`
+	PushoverAppToken string `json:"pushoverAppToken,omitempty"`
+	Rules                    []AutoSyncRule `json:"rules,omitempty"`
 }
 
 // AutoSyncRule defines one auto-sync binding (profile → instance).
@@ -223,6 +228,11 @@ func (cs *configStore) Load() error {
 	var cfg Config
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return fmt.Errorf("parse config: %w", err)
+	}
+	// DiscordEnabled defaults to true (preserves existing behaviour for users who already have a webhook)
+	if cfg.AutoSync.DiscordEnabled == nil {
+		v := true
+		cfg.AutoSync.DiscordEnabled = &v
 	}
 	// Apply defaults for Gotify priority values (nil = never set by user)
 	if cfg.AutoSync.GotifyCriticalValue == nil {

--- a/ui/handlers.go
+++ b/ui/handlers.go
@@ -3804,6 +3804,7 @@ func (app *App) handleGetAutoSyncSettings(w http.ResponseWriter, r *http.Request
 		"notifyOnSuccess":       cfg.AutoSync.NotifyOnSuccess,
 		"notifyOnFailure":       cfg.AutoSync.NotifyOnFailure,
 		"notifyOnRepoUpdate":    cfg.AutoSync.NotifyOnRepoUpdate,
+		"discordEnabled":        cfg.AutoSync.DiscordEnabled,
 		"discordWebhook":        cfg.AutoSync.DiscordWebhook,
 		"discordWebhookUpdates": cfg.AutoSync.DiscordWebhookUpdates,
 		"gotifyEnabled":         cfg.AutoSync.GotifyEnabled,
@@ -3815,6 +3816,9 @@ func (app *App) handleGetAutoSyncSettings(w http.ResponseWriter, r *http.Request
 		"gotifyCriticalValue":    cfg.AutoSync.GotifyCriticalValue,
 		"gotifyWarningValue":     cfg.AutoSync.GotifyWarningValue,
 		"gotifyInfoValue":        cfg.AutoSync.GotifyInfoValue,
+		"pushoverEnabled":  cfg.AutoSync.PushoverEnabled,
+		"pushoverUserKey":  cfg.AutoSync.PushoverUserKey,
+		"pushoverAppToken": cfg.AutoSync.PushoverAppToken,
 	})
 }
 
@@ -3826,6 +3830,7 @@ func (app *App) handleSaveAutoSyncSettings(w http.ResponseWriter, r *http.Reques
 		NotifyOnSuccess       bool   `json:"notifyOnSuccess"`
 		NotifyOnFailure       bool   `json:"notifyOnFailure"`
 		NotifyOnRepoUpdate    bool   `json:"notifyOnRepoUpdate"`
+		DiscordEnabled        bool   `json:"discordEnabled"`
 		DiscordWebhook        string `json:"discordWebhook"`
 		DiscordWebhookUpdates string `json:"discordWebhookUpdates"`
 		GotifyEnabled         bool   `json:"gotifyEnabled"`
@@ -3837,6 +3842,9 @@ func (app *App) handleSaveAutoSyncSettings(w http.ResponseWriter, r *http.Reques
 		GotifyCriticalValue    int   `json:"gotifyCriticalValue"`
 		GotifyWarningValue     int   `json:"gotifyWarningValue"`
 		GotifyInfoValue        int   `json:"gotifyInfoValue"`
+		PushoverEnabled  bool   `json:"pushoverEnabled"`
+		PushoverUserKey  string `json:"pushoverUserKey"`
+		PushoverAppToken string `json:"pushoverAppToken"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, 400, "Invalid JSON")
@@ -3868,6 +3876,8 @@ func (app *App) handleSaveAutoSyncSettings(w http.ResponseWriter, r *http.Reques
 		cfg.AutoSync.NotifyOnSuccess = req.NotifyOnSuccess
 		cfg.AutoSync.NotifyOnFailure = req.NotifyOnFailure
 		cfg.AutoSync.NotifyOnRepoUpdate = req.NotifyOnRepoUpdate
+		de := req.DiscordEnabled
+		cfg.AutoSync.DiscordEnabled = &de
 		cfg.AutoSync.DiscordWebhook = webhook
 		cfg.AutoSync.DiscordWebhookUpdates = webhookUpdates
 		cfg.AutoSync.GotifyEnabled = req.GotifyEnabled
@@ -3880,6 +3890,9 @@ func (app *App) handleSaveAutoSyncSettings(w http.ResponseWriter, r *http.Reques
 		cfg.AutoSync.GotifyCriticalValue = &cv
 		cfg.AutoSync.GotifyWarningValue = &wv
 		cfg.AutoSync.GotifyInfoValue = &iv
+		cfg.AutoSync.PushoverEnabled = req.PushoverEnabled
+		cfg.AutoSync.PushoverUserKey = strings.TrimSpace(req.PushoverUserKey)
+		cfg.AutoSync.PushoverAppToken = strings.TrimSpace(req.PushoverAppToken)
 	}); err != nil {
 		writeError(w, 500, "Failed to save settings")
 		return
@@ -3918,6 +3931,72 @@ func (app *App) handleTestGotify(w http.ResponseWriter, r *http.Request) {
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		writeError(w, resp.StatusCode, fmt.Sprintf("Gotify returned %d", resp.StatusCode))
+		return
+	}
+	writeJSON(w, map[string]string{"status": "ok"})
+}
+
+func (app *App) handleTestDiscord(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
+	var req struct {
+		Webhook string `json:"webhook"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Webhook == "" {
+		writeError(w, 400, "webhook required")
+		return
+	}
+	webhook := strings.TrimSpace(req.Webhook)
+	if !strings.HasPrefix(webhook, "https://discord.com/api/webhooks/") &&
+		!strings.HasPrefix(webhook, "https://discordapp.com/api/webhooks/") {
+		writeError(w, 400, "Discord webhook must start with https://discord.com/api/webhooks/")
+		return
+	}
+	embed := map[string]any{
+		"title":       "Clonarr Test",
+		"description": "If you see this, Discord is configured correctly!",
+		"color":       0x58a6ff,
+		"footer":      map[string]string{"text": "Clonarr " + Version + " by ProphetSe7en"},
+	}
+	payload, _ := json.Marshal(map[string]any{"embeds": []any{embed}})
+	resp, err := app.notifyClient.Post(webhook, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		writeError(w, 502, fmt.Sprintf("Failed to reach Discord: %v", err))
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		writeError(w, resp.StatusCode, fmt.Sprintf("Discord returned %d", resp.StatusCode))
+		return
+	}
+	writeJSON(w, map[string]string{"status": "ok"})
+}
+
+func (app *App) handleTestPushover(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
+	var req struct {
+		UserKey  string `json:"userKey"`
+		AppToken string `json:"appToken"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.UserKey == "" || req.AppToken == "" {
+		writeError(w, 400, "userKey and appToken required")
+		return
+	}
+	payload := map[string]any{
+		"token":    strings.TrimSpace(req.AppToken),
+		"user":     strings.TrimSpace(req.UserKey),
+		"title":    "Clonarr Test",
+		"message":  "If you see this, Pushover is configured correctly!",
+		"priority": 0,
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := app.notifyClient.Post("https://api.pushover.net/1/messages.json", "application/json", bytes.NewReader(body))
+	if err != nil {
+		writeError(w, 502, fmt.Sprintf("Failed to reach Pushover: %v", err))
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		writeError(w, resp.StatusCode, fmt.Sprintf("Pushover returned %d", resp.StatusCode))
 		return
 	}
 	writeJSON(w, map[string]string{"status": "ok"})

--- a/ui/main.go
+++ b/ui/main.go
@@ -273,6 +273,8 @@ func main() {
 	mux.HandleFunc("GET /api/auto-sync/settings", app.handleGetAutoSyncSettings)
 	mux.HandleFunc("PUT /api/auto-sync/settings", app.handleSaveAutoSyncSettings)
 	mux.HandleFunc("POST /api/auto-sync/test-gotify", app.handleTestGotify)
+	mux.HandleFunc("POST /api/auto-sync/test-discord", app.handleTestDiscord)
+	mux.HandleFunc("POST /api/auto-sync/test-pushover", app.handleTestPushover)
 	mux.HandleFunc("GET /api/auto-sync/rules", app.handleListAutoSyncRules)
 	mux.HandleFunc("POST /api/auto-sync/rules", app.handleCreateAutoSyncRule)
 	mux.HandleFunc("PUT /api/auto-sync/rules/{id}", app.handleUpdateAutoSyncRule)

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -4231,7 +4231,7 @@
         <!-- ===== Notifications ===== -->
         <div x-show="settingsSection === 'notifications'">
           <div class="settings-section-title">Notifications</div>
-          <div class="settings-section-desc">Auto-sync event notifications via Discord and Gotify.</div>
+          <div class="settings-section-desc">Auto-sync event notifications via Discord, Gotify, and Pushover.</div>
           <div class="setting-row">
             <div class="setting-label">Events</div>
             <div class="setting-value" style="display:flex;gap:16px">
@@ -4252,70 +4252,166 @@
 
           <!-- Discord -->
           <div style="border-top:1px solid #21262d;margin-top:12px;padding-top:12px">
-            <div style="font-size:13px;font-weight:600;color:#e1e4e8;margin-bottom:8px">Discord</div>
-            <div class="setting-row">
-              <div class="setting-label">Sync webhook</div>
-              <div class="setting-value">
-                <input class="input" style="width:400px" x-model="autoSyncSettings.discordWebhook" @change="saveAutoSyncSettings()" placeholder="https://discord.com/api/webhooks/..." autocomplete="one-time-code">
+            <div class="inst-row" style="padding:8px 0;cursor:pointer" @click="notifOpen.discord = !notifOpen.discord">
+              <span class="profile-group-chevron" :class="{ open: notifOpen.discord }">&#9654;</span>
+              <div style="font-size:13px;font-weight:600;color:#e1e4e8;min-width:80px;margin-left:8px">Discord</div>
+              <div style="font-size:13px;color:#8b949e;margin-left:4px" x-text="autoSyncSettings.discordWebhook ? (autoSyncSettings.discordEnabled ? 'Enabled' : 'Disabled') : 'Not configured'"></div>
+              <div style="margin-left:auto;display:flex;align-items:center;gap:8px;white-space:nowrap" @click.stop>
+                <template x-if="discordTesting">
+                  <span class="status-testing"><span class="spinner"></span></span>
+                </template>
+                <template x-if="!discordTesting && discordTestResult === 'Sent!'">
+                  <span class="status-connected">Sent!</span>
+                </template>
+                <template x-if="!discordTesting && discordTestResult && discordTestResult !== 'Sent!'">
+                  <span class="status-failed" x-text="discordTestResult"></span>
+                </template>
+                <template x-if="!discordTesting && !discordTestResult">
+                  <span style="font-size:12px;color:#aaa">Not tested</span>
+                </template>
               </div>
+              <button class="btn btn-sm" style="margin-left:8px" @click.stop="testDiscord()" :disabled="!autoSyncSettings.discordWebhook || discordTesting">Test</button>
             </div>
-            <div style="font-size:12px;color:#8b949e;margin:-4px 0 8px 160px">Sync success, failure, and cleanup</div>
-            <div class="setting-row">
-              <div class="setting-label">Updates webhook</div>
-              <div class="setting-value">
-                <input class="input" style="width:400px" x-model="autoSyncSettings.discordWebhookUpdates" @change="saveAutoSyncSettings()" placeholder="Optional — falls back to sync webhook if empty" autocomplete="one-time-code">
+            <div x-show="notifOpen.discord" style="padding-bottom:8px">
+              <div class="setting-row" style="margin-top:4px">
+                <div class="setting-label">Enable</div>
+                <div class="setting-value">
+                  <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
+                    <input type="checkbox" x-model="autoSyncSettings.discordEnabled" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
+                    Send notifications via Discord
+                  </label>
+                </div>
               </div>
+              <div class="setting-row">
+                <div class="setting-label">Sync webhook</div>
+                <div class="setting-value">
+                  <input class="input" style="width:400px" x-model="autoSyncSettings.discordWebhook" @change="saveAutoSyncSettings()" placeholder="https://discord.com/api/webhooks/..." autocomplete="one-time-code">
+                </div>
+              </div>
+              <div style="font-size:12px;color:#8b949e;margin:-4px 0 8px 160px">Sync success, failure, and cleanup</div>
+              <div class="setting-row">
+                <div class="setting-label">Updates webhook</div>
+                <div class="setting-value">
+                  <input class="input" style="width:400px" x-model="autoSyncSettings.discordWebhookUpdates" @change="saveAutoSyncSettings()" placeholder="Optional — falls back to sync webhook if empty" autocomplete="one-time-code">
+                </div>
+              </div>
+              <div style="font-size:12px;color:#8b949e;margin:-4px 0 4px 160px">TRaSH repo updates and weekly changelog</div>
             </div>
-            <div style="font-size:12px;color:#8b949e;margin:-4px 0 4px 160px">TRaSH repo updates and weekly changelog</div>
           </div>
 
           <!-- Gotify -->
-          <div style="border-top:1px solid #21262d;margin-top:12px;padding-top:12px">
-            <div style="font-size:13px;font-weight:600;color:#e1e4e8;margin-bottom:8px">Gotify</div>
-            <div class="setting-row">
-              <div class="setting-label">Enable</div>
-              <div class="setting-value">
-                <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
-                  <input type="checkbox" x-model="autoSyncSettings.gotifyEnabled" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
-                  Send push notifications via Gotify
-                </label>
+          <div style="border-top:1px solid #21262d;margin-top:4px;padding-top:4px">
+            <div class="inst-row" style="padding:8px 0;cursor:pointer" @click="notifOpen.gotify = !notifOpen.gotify">
+              <span class="profile-group-chevron" :class="{ open: notifOpen.gotify }">&#9654;</span>
+              <div style="font-size:13px;font-weight:600;color:#e1e4e8;min-width:80px;margin-left:8px">Gotify</div>
+              <div style="font-size:13px;color:#8b949e;margin-left:4px" x-text="(autoSyncSettings.gotifyUrl || autoSyncSettings.gotifyToken) ? (autoSyncSettings.gotifyEnabled ? 'Enabled' : 'Disabled') : 'Not configured'"></div>
+              <div style="margin-left:auto;display:flex;align-items:center;gap:8px;white-space:nowrap" @click.stop>
+                <template x-if="gotifyTesting">
+                  <span class="status-testing"><span class="spinner"></span></span>
+                </template>
+                <template x-if="!gotifyTesting && gotifyTestResult === 'Sent!'">
+                  <span class="status-connected">Sent!</span>
+                </template>
+                <template x-if="!gotifyTesting && gotifyTestResult && gotifyTestResult !== 'Sent!'">
+                  <span class="status-failed" x-text="gotifyTestResult"></span>
+                </template>
+                <template x-if="!gotifyTesting && !gotifyTestResult">
+                  <span style="font-size:12px;color:#aaa">Not tested</span>
+                </template>
+              </div>
+              <button class="btn btn-sm" style="margin-left:8px" @click.stop="testGotify()" :disabled="!autoSyncSettings.gotifyUrl || !autoSyncSettings.gotifyToken || gotifyTesting">Test</button>
+            </div>
+            <div x-show="notifOpen.gotify" style="padding-bottom:8px">
+              <div class="setting-row" style="margin-top:4px">
+                <div class="setting-label">Enable</div>
+                <div class="setting-value">
+                  <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
+                    <input type="checkbox" x-model="autoSyncSettings.gotifyEnabled" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
+                    Send push notifications via Gotify
+                  </label>
+                </div>
+              </div>
+              <div class="setting-row">
+                <div class="setting-label">URL</div>
+                <div class="setting-value">
+                  <input class="input" style="width:400px" x-model="autoSyncSettings.gotifyUrl" @change="saveAutoSyncSettings()" placeholder="https://gotify.example.com" autocomplete="one-time-code">
+                </div>
+              </div>
+              <div class="setting-row">
+                <div class="setting-label">App Token</div>
+                <div class="setting-value" style="display:flex;gap:8px;align-items:center">
+                  <input :type="gotifyTokenVisible ? 'text' : 'password'" autocomplete="one-time-code" class="input" style="width:300px" x-model="autoSyncSettings.gotifyToken" @change="saveAutoSyncSettings()" placeholder="App token from Gotify">
+                  <button class="btn btn-sm" @click="gotifyTokenVisible = !gotifyTokenVisible" x-text="gotifyTokenVisible ? '🔒' : '👁'" style="min-width:32px"></button>
+                </div>
+              </div>
+              <div class="setting-row">
+                <div class="setting-label">Levels</div>
+                <div class="setting-value" style="display:flex;gap:16px;flex-wrap:wrap">
+                  <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
+                    <input type="checkbox" x-model="autoSyncSettings.gotifyPriorityCritical" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
+                    Critical <input type="number" class="input" style="width:50px;text-align:center;margin-left:4px" min="0" max="10" x-model.number="autoSyncSettings.gotifyCriticalValue" @change="saveAutoSyncSettings()">
+                  </label>
+                  <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
+                    <input type="checkbox" x-model="autoSyncSettings.gotifyPriorityWarning" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
+                    Warning <input type="number" class="input" style="width:50px;text-align:center;margin-left:4px" min="0" max="10" x-model.number="autoSyncSettings.gotifyWarningValue" @change="saveAutoSyncSettings()">
+                  </label>
+                  <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
+                    <input type="checkbox" x-model="autoSyncSettings.gotifyPriorityInfo" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
+                    Info <input type="number" class="input" style="width:50px;text-align:center;margin-left:4px" min="0" max="10" x-model.number="autoSyncSettings.gotifyInfoValue" @change="saveAutoSyncSettings()">
+                  </label>
+                </div>
+              </div>
+              <div style="font-size:12px;color:#8b949e;margin:4px 0 0 160px">Critical: sync failures · Warning: stale cleanup · Info: sync success, repo updates, changelog</div>
+            </div>
+          </div>
+
+          <!-- Pushover -->
+          <div style="border-top:1px solid #21262d;margin-top:4px;padding-top:4px">
+            <div class="inst-row" style="padding:8px 0;cursor:pointer" @click="notifOpen.pushover = !notifOpen.pushover">
+              <span class="profile-group-chevron" :class="{ open: notifOpen.pushover }">&#9654;</span>
+              <div style="font-size:13px;font-weight:600;color:#e1e4e8;min-width:80px;margin-left:8px">Pushover</div>
+              <div style="font-size:13px;color:#8b949e;margin-left:4px" x-text="(autoSyncSettings.pushoverUserKey || autoSyncSettings.pushoverAppToken) ? (autoSyncSettings.pushoverEnabled ? 'Enabled' : 'Disabled') : 'Not configured'"></div>
+              <div style="margin-left:auto;display:flex;align-items:center;gap:8px;white-space:nowrap" @click.stop>
+                <template x-if="pushoverTesting">
+                  <span class="status-testing"><span class="spinner"></span></span>
+                </template>
+                <template x-if="!pushoverTesting && pushoverTestResult === 'Sent!'">
+                  <span class="status-connected">Sent!</span>
+                </template>
+                <template x-if="!pushoverTesting && pushoverTestResult && pushoverTestResult !== 'Sent!'">
+                  <span class="status-failed" x-text="pushoverTestResult"></span>
+                </template>
+                <template x-if="!pushoverTesting && !pushoverTestResult">
+                  <span style="font-size:12px;color:#aaa">Not tested</span>
+                </template>
+              </div>
+              <button class="btn btn-sm" style="margin-left:8px" @click.stop="testPushover()" :disabled="!autoSyncSettings.pushoverUserKey || !autoSyncSettings.pushoverAppToken || pushoverTesting">Test</button>
+            </div>
+            <div x-show="notifOpen.pushover" style="padding-bottom:8px">
+              <div class="setting-row" style="margin-top:4px">
+                <div class="setting-label">Enable</div>
+                <div class="setting-value">
+                  <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
+                    <input type="checkbox" x-model="autoSyncSettings.pushoverEnabled" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
+                    Send push notifications via Pushover
+                  </label>
+                </div>
+              </div>
+              <div class="setting-row">
+                <div class="setting-label">User Key</div>
+                <div class="setting-value" style="display:flex;gap:8px;align-items:center">
+                  <input :type="pushoverUserKeyVisible ? 'text' : 'password'" autocomplete="one-time-code" class="input" style="width:300px" x-model="autoSyncSettings.pushoverUserKey" @change="saveAutoSyncSettings()" placeholder="Your Pushover user key">
+                  <button class="btn btn-sm" @click="pushoverUserKeyVisible = !pushoverUserKeyVisible" x-text="pushoverUserKeyVisible ? '🔒' : '👁'" style="min-width:32px"></button>
+                </div>
+              </div>
+              <div class="setting-row">
+                <div class="setting-label">App Token</div>
+                <div class="setting-value" style="display:flex;gap:8px;align-items:center">
+                  <input :type="pushoverAppTokenVisible ? 'text' : 'password'" autocomplete="one-time-code" class="input" style="width:300px" x-model="autoSyncSettings.pushoverAppToken" @change="saveAutoSyncSettings()" placeholder="App/API token from Pushover">
+                  <button class="btn btn-sm" @click="pushoverAppTokenVisible = !pushoverAppTokenVisible" x-text="pushoverAppTokenVisible ? '🔒' : '👁'" style="min-width:32px"></button>
+                </div>
               </div>
             </div>
-            <div class="setting-row">
-              <div class="setting-label">URL</div>
-              <div class="setting-value">
-                <input class="input" style="width:400px" x-model="autoSyncSettings.gotifyUrl" @change="saveAutoSyncSettings()" placeholder="https://gotify.example.com" autocomplete="one-time-code">
-              </div>
-            </div>
-            <div class="setting-row">
-              <div class="setting-label">App Token</div>
-              <div class="setting-value" style="display:flex;gap:8px;align-items:center">
-                <input :type="gotifyTokenVisible ? 'text' : 'password'" autocomplete="one-time-code" class="input" style="width:300px" x-model="autoSyncSettings.gotifyToken" @change="saveAutoSyncSettings()" placeholder="App token from Gotify">
-                <button class="btn btn-sm" @click="gotifyTokenVisible = !gotifyTokenVisible" x-text="gotifyTokenVisible ? '🔒' : '👁'" style="min-width:32px"></button>
-                <button class="btn btn-sm" @click="testGotify()" :disabled="!autoSyncSettings.gotifyUrl || !autoSyncSettings.gotifyToken || gotifyTesting">
-                  <span x-show="!gotifyTesting">Test</span><span x-show="gotifyTesting">...</span>
-                </button>
-                <span x-show="gotifyTestResult" :style="gotifyTestResult === 'Sent!' ? 'color:#3fb950;font-size:12px' : 'color:#f85149;font-size:12px'" x-text="gotifyTestResult"></span>
-              </div>
-            </div>
-            <div class="setting-row">
-              <div class="setting-label">Levels</div>
-              <div class="setting-value" style="display:flex;gap:16px;flex-wrap:wrap">
-                <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
-                  <input type="checkbox" x-model="autoSyncSettings.gotifyPriorityCritical" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
-                  Critical <input type="number" class="input" style="width:50px;text-align:center;margin-left:4px" min="0" max="10" x-model.number="autoSyncSettings.gotifyCriticalValue" @change="saveAutoSyncSettings()">
-                </label>
-                <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
-                  <input type="checkbox" x-model="autoSyncSettings.gotifyPriorityWarning" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
-                  Warning <input type="number" class="input" style="width:50px;text-align:center;margin-left:4px" min="0" max="10" x-model.number="autoSyncSettings.gotifyWarningValue" @change="saveAutoSyncSettings()">
-                </label>
-                <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
-                  <input type="checkbox" x-model="autoSyncSettings.gotifyPriorityInfo" @change="saveAutoSyncSettings()" style="accent-color:#58a6ff">
-                  Info <input type="number" class="input" style="width:50px;text-align:center;margin-left:4px" min="0" max="10" x-model.number="autoSyncSettings.gotifyInfoValue" @change="saveAutoSyncSettings()">
-                </label>
-              </div>
-            </div>
-            <div style="font-size:12px;color:#8b949e;margin:4px 0 0 160px">Critical: sync failures · Warning: stale cleanup · Info: sync success, repo updates, changelog</div>
           </div>
         </div>
 
@@ -5899,13 +5995,20 @@ function clonarr() {
     syncPreviewLoading: false,
 
     // Auto-Sync
-    autoSyncSettings: { enabled: false, notifyOnSuccess: true, notifyOnFailure: true, notifyOnRepoUpdate: false, discordWebhook: '', discordWebhookUpdates: '', gotifyEnabled: false, gotifyUrl: '', gotifyToken: '', gotifyPriorityCritical: true, gotifyPriorityWarning: true, gotifyPriorityInfo: false, gotifyCriticalValue: 8, gotifyWarningValue: 5, gotifyInfoValue: 3 },
+    autoSyncSettings: { enabled: false, notifyOnSuccess: true, notifyOnFailure: true, notifyOnRepoUpdate: false, discordEnabled: true, discordWebhook: '', discordWebhookUpdates: '', gotifyEnabled: false, gotifyUrl: '', gotifyToken: '', gotifyPriorityCritical: true, gotifyPriorityWarning: true, gotifyPriorityInfo: false, gotifyCriticalValue: 8, gotifyWarningValue: 5, gotifyInfoValue: 3, pushoverEnabled: false, pushoverUserKey: '', pushoverAppToken: '' },
+    notifOpen: { discord: false, gotify: false, pushover: false },
     gotifyTokenVisible: false,
+    pushoverUserKeyVisible: false,
+    pushoverAppTokenVisible: false,
     settingsOpen: 'instances',  // legacy accordion (unused after sidebar redesign)
     settingsSection: 'instances',
     uiScale: localStorage.getItem('clonarr-ui-scale') || '1',
+    discordTesting: false,
+    discordTestResult: '',
     gotifyTesting: false,
     gotifyTestResult: '',
+    pushoverTesting: false,
+    pushoverTestResult: '',
     autoSyncRules: [],
     autoSyncRuleForSync: null, // existing rule that matches current syncForm (if any)
 
@@ -11937,6 +12040,29 @@ function clonarr() {
       } catch (e) { console.error('saveAutoSyncSettings:', e); }
     },
 
+    async testDiscord() {
+      if (!this.autoSyncSettings.discordWebhook) return;
+      this.discordTesting = true;
+      this.discordTestResult = '';
+      try {
+        const resp = await fetch('/api/auto-sync/test-discord', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ webhook: this.autoSyncSettings.discordWebhook }),
+        });
+        if (!resp.ok) {
+          const err = await resp.json();
+          this.discordTestResult = err.error || 'Failed';
+        } else {
+          this.discordTestResult = 'Sent!';
+        }
+      } catch (e) {
+        this.discordTestResult = e.message;
+      } finally {
+        this.discordTesting = false;
+      }
+    },
+
     async testGotify() {
       if (!this.autoSyncSettings.gotifyUrl || !this.autoSyncSettings.gotifyToken) return;
       this.gotifyTesting = true;
@@ -11957,7 +12083,29 @@ function clonarr() {
         this.gotifyTestResult = e.message;
       } finally {
         this.gotifyTesting = false;
-        setTimeout(() => { this.gotifyTestResult = ''; }, 5000);
+      }
+    },
+
+    async testPushover() {
+      if (!this.autoSyncSettings.pushoverUserKey || !this.autoSyncSettings.pushoverAppToken) return;
+      this.pushoverTesting = true;
+      this.pushoverTestResult = '';
+      try {
+        const resp = await fetch('/api/auto-sync/test-pushover', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userKey: this.autoSyncSettings.pushoverUserKey, appToken: this.autoSyncSettings.pushoverAppToken }),
+        });
+        if (!resp.ok) {
+          const err = await resp.json();
+          this.pushoverTestResult = err.error || 'Failed';
+        } else {
+          this.pushoverTestResult = 'Sent!';
+        }
+      } catch (e) {
+        this.pushoverTestResult = e.message;
+      } finally {
+        this.pushoverTesting = false;
       }
     },
 


### PR DESCRIPTION
## Summary

Closes #11. Adds Pushover as a third notification provider alongside Discord and Gotify, and reworks the notification settings UI to be cleaner and more consistent across all three.

Preserved existing UI structures where feasible; tried to add consistency to the notifications by having them follow the same logic with enable buttons, test button (matching the settings --> instances) view.

---

## Changes by file

| File | What changed |
|---|---|
| `ui/config.go` | . Added `PushoverEnabled`, `PushoverUserKey`, `PushoverAppToken` to `AutoSyncConfig`<br>. Added `DiscordEnabled *bool` - pointer so nil defaults to `true` on load, preserving existing webhook behaviour<br>. `Load()` applies the default when the field is absent from JSON |
| `ui/autosync.go` | . Added `sendPushover(title, message string)` - POSTs to the Pushover API at priority 0, no per-level knobs<br>. All four notify functions (`notifyCleanup`, `notifyAutoSync`, `notifyRepoUpdate`, `notifyChangelog`) now call `sendPushover`<br>. Discord sends in all four functions gated on `DiscordEnabled` |
| `ui/handlers.go` | . `handleGetAutoSyncSettings` returns `discordEnabled` and all three Pushover fields<br>. `handleSaveAutoSyncSettings` stores `DiscordEnabled` as a pointer<br>. New `handleTestDiscord` - validates webhook URL and sends a test embed<br>. New `handleTestPushover` - fires a test message to the Pushover API |
| `ui/main.go` | . Registered `POST /api/auto-sync/test-discord`<br>. Registered `POST /api/auto-sync/test-pushover` |
| `ui/static/index.html` | . Each provider is a collapsible row with chevron, status text, test result indicator, and a Test button<br>. Status text unified to **Enabled** / **Disabled** / **Not configured** across all three<br>. Status text colour matches `settings-section-desc` so it doesn't compete visually with the service name<br>. Test results persist until the next test - no 5s auto-clear<br>. All sections default to collapsed on page open<br>. Discord gets an Enable toggle to match Gotify and Pushover<br>. Pushover section: Enable + User Key + App Token only, intentionally simple |

---

## Screenshot References

Once user has navigated to the page

<img width="641" height="221" alt="image" src="https://github.com/user-attachments/assets/ff6f8445-077c-4d90-b898-9ad757dfc48e" />

Expanded

<img width="650" height="615" alt="image" src="https://github.com/user-attachments/assets/0e244f08-f758-43b7-a455-1eec1fc0cb8a" />

---

## AI Disclosure

This PR was created leveraging Claude Sonnet 4.6. I didn't see any 'no AI PR' language as part of this project/repo but lmk if I missed something and happy to withdraw.

---