### PR TITLE
ci: add workflow_dispatch + fix Docker Hub conditional + bump setup-qemu to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU (for multi-arch arm64 builds)
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -39,7 +39,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Only runs when DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets are configured.
+      # Forks without Docker Hub credentials skip this step gracefully.
       - name: Log in to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -51,7 +54,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            docker.io/${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+            ${{ secrets.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/{1}', secrets.DOCKERHUB_USERNAME, env.IMAGE_NAME) || '' }}
           tags: |
             type=raw,value=dev,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: 'Push image to registries after build'
+        required: false
+        default: true
+        type: boolean
 
 env:
   IMAGE_NAME: clonarr
@@ -49,6 +56,7 @@ jobs:
             type=raw,value=dev,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
             type=semver,pattern=v{{version}}
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Determine version
         id: version
@@ -63,7 +71,7 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
-          push: true
+          push: ${{ github.event_name != 'workflow_dispatch' || inputs.push_image }}
           platforms: linux/amd64,linux/arm64
           build-args: VERSION=${{ steps.version.outputs.value }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      # Promote to job env so we can reference it in `if:` conditions.
+      # The secrets context is unavailable to the workflow validator, causing
+      # "Unrecognized named-value: 'secrets'" if used directly in `if:`.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     steps:
       - name: Checkout
@@ -42,7 +47,7 @@ jobs:
       # Only runs when DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets are configured.
       # Forks without Docker Hub credentials skip this step gracefully.
       - name: Log in to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -54,7 +59,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            ${{ secrets.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/{1}', secrets.DOCKERHUB_USERNAME, env.IMAGE_NAME) || '' }}
+            ${{ env.DOCKERHUB_USERNAME != '' && format('docker.io/{0}/{1}', env.DOCKERHUB_USERNAME, env.IMAGE_NAME) || '' }}
           tags: |
             type=raw,value=dev,enable={{is_default_branch}}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}


### PR DESCRIPTION
## Summary

Two quality-of-life improvements to the GitHub Actions workflows, plus a dependency bump and a tweak to better enable forks without Docker Hub credentials.

---

## What this accomplishes

- **Manual triggers** — both the CI and Docker workflows can now be dispatched from the Actions UI on any branch, without needing a push or PR event. The Docker workflow gains an optional `push_image` boolean input (defaults `true`) so you can do a build-only dry run.
- **Fork-safe Docker Hub login** — the Docker Hub login step is now skipped gracefully when `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets are absent (e.g. in forks), eliminating the `Username and password required` error that previously failed the build.
- **Node.js 24 runtime** — `docker/setup-qemu-action` bumped from v3.6.0 (Node.js 20, deprecated) to v4.0.0 (Node.js 24), clearing the deprecation warning in Action logs.

---

## Changes by file

| File | What changed |
|------|--------------|
| `.github/workflows/ci.yml` | Added `workflow_dispatch:` trigger (no inputs) so the test + govulncheck jobs can be run manually on any branch from the Actions UI. |
| `.github/workflows/docker.yml` | Added `workflow_dispatch:` trigger with a `push_image` boolean input. Added `sha-` prefixed image tag for dispatch runs. Added job-level `env: DOCKERHUB_USERNAME` to expose the secret safely in `if:` conditions (the `secrets` context is unavailable to the workflow validator). Gated the Docker Hub login step on `env.DOCKERHUB_USERNAME != ''`. Made the Docker Hub entry in the `images:` list conditional so metadata-action doesn't emit an empty tag set when credentials are absent. Bumped `docker/setup-qemu-action` SHA from v3.6.0 (`29109295…`) to v4.0.0 (`ce360397…`). |

---

## AI Disclosure

This PR was created leveraging Claude Sonnet 4.6. No AI restrictions noted in project guidelines.