### PR TITLE
fix(notifications): restore updates webhook validation; add migration tests; clean route comment

### DIFF
--- a/internal/api/notifications.go
+++ b/internal/api/notifications.go
@@ -58,6 +58,13 @@ func validateAgentConfig(agent core.NotificationAgent) error {
 			!strings.HasPrefix(webhook, "https://discordapp.com/api/webhooks/") {
 			return fmt.Errorf("discord webhook must start with https://discord.com/api/webhooks/")
 		}
+		// Validate the optional updates webhook only when it has been provided.
+		if u := strings.TrimSpace(agent.Config.DiscordWebhookUpdates); u != "" {
+			if !strings.HasPrefix(u, "https://discord.com/api/webhooks/") &&
+				!strings.HasPrefix(u, "https://discordapp.com/api/webhooks/") {
+				return fmt.Errorf("discord updates webhook must start with https://discord.com/api/webhooks/")
+			}
+		}
 	case "gotify":
 		if strings.TrimSpace(agent.Config.GotifyURL) == "" || strings.TrimSpace(agent.Config.GotifyToken) == "" {
 			return fmt.Errorf("gotify URL and token are required")

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -79,9 +79,10 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// Auto-Sync
 	mux.HandleFunc("GET /api/auto-sync/settings", s.handleGetAutoSyncSettings)
 	mux.HandleFunc("PUT /api/auto-sync/settings", s.handleSaveAutoSyncSettings)
-	// Notification agents (PR #15) replace the old flat test-gotify / test-discord /
-	// test-pushover endpoints. Each provider is an independent agent tested via
-	// the inline or saved-agent routes.
+	// Notification agents: each provider (Discord, Gotify, Pushover) is
+	// configured as an independent agent with its own credentials and event
+	// subscriptions. Use the inline route to test before saving, or the
+	// saved-agent route to re-test an existing agent by ID.
 	mux.HandleFunc("GET /api/auto-sync/notification-agents", s.handleListNotificationAgents)
 	mux.HandleFunc("POST /api/auto-sync/notification-agents", s.handleCreateNotificationAgent)
 	mux.HandleFunc("PUT /api/auto-sync/notification-agents/{id}", s.handleUpdateNotificationAgent)

--- a/internal/core/config_test.go
+++ b/internal/core/config_test.go
@@ -1,0 +1,164 @@
+package core
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestMigrateFlatNotifications verifies that a v2.0.x config file containing
+// the legacy flat notification fields (discordWebhook, gotifyUrl, etc.) is
+// promoted to the new NotificationAgents slice on Load(), with correct names,
+// types, credentials, and event subscriptions preserved.
+func TestMigrateFlatNotifications(t *testing.T) {
+	// Build a minimal config JSON that mimics a pre-agent v2.0.x file.
+	oldCfg := map[string]any{
+		"autoSync": map[string]any{
+			"enabled":            true,
+			"notifyOnSuccess":    true,
+			"notifyOnFailure":    true,
+			"notifyOnRepoUpdate": false,
+			// Discord
+			"discordWebhook":        "https://discord.com/api/webhooks/111/aaa",
+			"discordWebhookUpdates": "https://discord.com/api/webhooks/222/bbb",
+			"discordEnabled":        true,
+			// Gotify
+			"gotifyUrl":              "https://gotify.example.com",
+			"gotifyToken":            "tok123",
+			"gotifyEnabled":          false,
+			"gotifyPriorityCritical": true,
+			"gotifyPriorityWarning":  true,
+			"gotifyPriorityInfo":     false,
+			"gotifyCriticalValue":    8,
+			"gotifyWarningValue":     5,
+			"gotifyInfoValue":        3,
+			// Pushover
+			"pushoverUserKey":  "ukey456",
+			"pushoverAppToken": "atoken789",
+			"pushoverEnabled":  false,
+		},
+	}
+
+	raw, err := json.Marshal(oldCfg)
+	if err != nil {
+		t.Fatalf("marshal old config: %v", err)
+	}
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "clonarr.json")
+	if err := os.WriteFile(cfgPath, raw, 0600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+
+	cs := NewConfigStore(dir)
+	if err := cs.Load(); err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+
+	agents := cs.Get().AutoSync.NotificationAgents
+	if len(agents) != 3 {
+		t.Fatalf("want 3 agents after migration, got %d", len(agents))
+	}
+
+	// Build a map by type for order-independent assertions.
+	byType := make(map[string]NotificationAgent, 3)
+	for _, a := range agents {
+		byType[a.Type] = a
+	}
+
+	// --- Discord ---
+	d, ok := byType["discord"]
+	if !ok {
+		t.Fatal("no discord agent after migration")
+	}
+	if d.Name != "Discord" {
+		t.Errorf("discord name = %q, want %q", d.Name, "Discord")
+	}
+	if !d.Enabled {
+		t.Error("discord agent should be enabled (discordEnabled=true)")
+	}
+	if d.Config.DiscordWebhook != "https://discord.com/api/webhooks/111/aaa" {
+		t.Errorf("discord webhook = %q", d.Config.DiscordWebhook)
+	}
+	if d.Config.DiscordWebhookUpdates != "https://discord.com/api/webhooks/222/bbb" {
+		t.Errorf("discord updates webhook = %q", d.Config.DiscordWebhookUpdates)
+	}
+	if !d.Events.OnSyncSuccess {
+		t.Error("discord: OnSyncSuccess should be true")
+	}
+	if !d.Events.OnSyncFailure {
+		t.Error("discord: OnSyncFailure should be true")
+	}
+	if d.Events.OnRepoUpdate {
+		t.Error("discord: OnRepoUpdate should be false")
+	}
+
+	// --- Gotify ---
+	g, ok := byType["gotify"]
+	if !ok {
+		t.Fatal("no gotify agent after migration")
+	}
+	if g.Name != "Gotify" {
+		t.Errorf("gotify name = %q, want %q", g.Name, "Gotify")
+	}
+	if g.Enabled {
+		t.Error("gotify agent should be disabled (gotifyEnabled=false)")
+	}
+	if g.Config.GotifyURL != "https://gotify.example.com" {
+		t.Errorf("gotify url = %q", g.Config.GotifyURL)
+	}
+	if g.Config.GotifyToken != "tok123" {
+		t.Errorf("gotify token = %q", g.Config.GotifyToken)
+	}
+	if g.Config.GotifyCriticalValue == nil || *g.Config.GotifyCriticalValue != 8 {
+		t.Errorf("gotify critical value wrong")
+	}
+
+	// --- Pushover ---
+	p, ok := byType["pushover"]
+	if !ok {
+		t.Fatal("no pushover agent after migration")
+	}
+	if p.Name != "Pushover" {
+		t.Errorf("pushover name = %q, want %q", p.Name, "Pushover")
+	}
+	if p.Enabled {
+		t.Error("pushover agent should be disabled (pushoverEnabled=false)")
+	}
+	if p.Config.PushoverUserKey != "ukey456" {
+		t.Errorf("pushover user key = %q", p.Config.PushoverUserKey)
+	}
+	if p.Config.PushoverAppToken != "atoken789" {
+		t.Errorf("pushover app token = %q", p.Config.PushoverAppToken)
+	}
+
+	// --- Idempotency: second Load() must not duplicate agents ---
+	if err := cs.Load(); err != nil {
+		t.Fatalf("second Load(): %v", err)
+	}
+	agents2 := cs.Get().AutoSync.NotificationAgents
+	if len(agents2) != 3 {
+		t.Errorf("idempotency: want 3 agents on second load, got %d", len(agents2))
+	}
+}
+
+// TestMigrateFlatNotificationsEmpty verifies that Load() on a config with no
+// flat notification fields produces zero agents (no phantom entries).
+func TestMigrateFlatNotificationsEmpty(t *testing.T) {
+	emptyCfg := map[string]any{
+		"autoSync": map[string]any{"enabled": false},
+	}
+	raw, _ := json.Marshal(emptyCfg)
+
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "clonarr.json"), raw, 0600)
+
+	cs := NewConfigStore(dir)
+	if err := cs.Load(); err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+	if n := len(cs.Get().AutoSync.NotificationAgents); n != 0 {
+		t.Errorf("want 0 agents for empty config, got %d", n)
+	}
+}


### PR DESCRIPTION
Three fixes identified during review of PR #17 against the notification agent feature.

**1. `internal/api/notifications.go` — Discord updates webhook validation restored**
`DiscordWebhookUpdates` was not validated on save. An invalid URL passed silently and would only fail at runtime. Added the same prefix check as the primary webhook, gated on non-empty since the field is optional.

**2. `internal/core/config_test.go` — Migration tests recreated (new file)**
`TestMigrateFlatNotifications` and `TestMigrateFlatNotificationsEmpty` existed in `ui/config_test.go` but were not ported during the layout refactor. These cover the flat-to-agent migration path that runs on first load for any user upgrading from v2.0.x. Ported to `package core`, adapted to `NewConfigStore` / `cs.Get()` / `cs.Load()`. Both pass.

**3. `internal/api/routes.go` — Route comment updated**
Replaced the internal `(PR #15)` reference with a plain-English description of what the notification agent routes do and how the inline vs saved-agent test split works.