### PR TITLE
Remove stale shallow.lock before git fetch

### DIFF
--- a/ui/trash.go
+++ b/ui/trash.go
@@ -589,16 +589,13 @@ func (ts *trashStore) CloneOrPull(repoURL, branch string) error {
 
         // Remove stale shallow.lock if left behind by a previously interrupted fetch
        // (e.g. container restart mid-pull). Git refuses to fetch if this file exists.
-shallowLock := filepath.Join(ts.dataDir, ".git", "shallow.lock")
-if _, err := os.Stat(shallowLock); err == nil {
-    log.Printf("Removing stale shallow.lock from previous interrupted fetch")
-    if err := os.Remove(shallowLock); err != nil {
+        shallowLock := filepath.Join(ts.dataDir, ".git", "shallow.lock")
+        if _, err := os.Stat(shallowLock); err == nil {
+        log.Printf("Removing stale shallow.lock from previous interrupted fetch")
+        if err := os.Remove(shallowLock); err != nil {
         log.Printf("Warning: failed to remove shallow.lock: %v", err)
-    }
-}
-
-cmd := exec.Command("git", "-C", ts.dataDir, "fetch", "--deepen=1", "origin", branch)
-
+        }
+      }
 		cmd := exec.Command("git", "-C", ts.dataDir, "fetch", "--deepen=1", "origin", branch)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/ui/trash.go
+++ b/ui/trash.go
@@ -586,6 +586,19 @@ func (ts *trashStore) CloneOrPull(repoURL, branch string) error {
 
 		// M13: Pull with explicit branch (deepen=1 so previous commit is available for diff)
 		log.Printf("Pulling TRaSH repo in %s (branch: %s)", ts.dataDir, branch)
+
+        // Remove stale shallow.lock if left behind by a previously interrupted fetch
+       // (e.g. container restart mid-pull). Git refuses to fetch if this file exists.
+shallowLock := filepath.Join(ts.dataDir, ".git", "shallow.lock")
+if _, err := os.Stat(shallowLock); err == nil {
+    log.Printf("Removing stale shallow.lock from previous interrupted fetch")
+    if err := os.Remove(shallowLock); err != nil {
+        log.Printf("Warning: failed to remove shallow.lock: %v", err)
+    }
+}
+
+cmd := exec.Command("git", "-C", ts.dataDir, "fetch", "--deepen=1", "origin", branch)
+
 		cmd := exec.Command("git", "-C", ts.dataDir, "fetch", "--deepen=1", "origin", branch)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/ui/trash.go
+++ b/ui/trash.go
@@ -586,16 +586,15 @@ func (ts *trashStore) CloneOrPull(repoURL, branch string) error {
 
 		// M13: Pull with explicit branch (deepen=1 so previous commit is available for diff)
 		log.Printf("Pulling TRaSH repo in %s (branch: %s)", ts.dataDir, branch)
-
-        // Remove stale shallow.lock if left behind by a previously interrupted fetch
-       // (e.g. container restart mid-pull). Git refuses to fetch if this file exists.
-        shallowLock := filepath.Join(ts.dataDir, ".git", "shallow.lock")
-        if _, err := os.Stat(shallowLock); err == nil {
-        log.Printf("Removing stale shallow.lock from previous interrupted fetch")
-        if err := os.Remove(shallowLock); err != nil {
-        log.Printf("Warning: failed to remove shallow.lock: %v", err)
-        }
-      }
+		// Remove stale shallow.lock if left behind by a previously interrupted fetch
+		// (e.g. container restart mid-pull). Git refuses to fetch if this file exists.
+		shallowLock := filepath.Join(ts.dataDir, ".git", "shallow.lock")
+		if _, err := os.Stat(shallowLock); err == nil {
+			log.Printf("Removing stale shallow.lock from previous interrupted fetch")
+			if err := os.Remove(shallowLock); err != nil {
+				log.Printf("Warning: failed to remove shallow.lock: %v", err)
+			}
+		}
 		cmd := exec.Command("git", "-C", ts.dataDir, "fetch", "--deepen=1", "origin", branch)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
// M13: Pull with explicit branch (deepen=1 so previous commit is available for diff)
log.Printf("Pulling TRaSH repo in %s (branch: %s)", ts.dataDir, branch)

// Remove stale shallow.lock if left behind by a previously interrupted fetch
// (e.g. container restart mid-pull). Git refuses to fetch if this file exists.
shallowLock := filepath.Join(ts.dataDir, ".git", "shallow.lock")
if _, err := os.Stat(shallowLock); err == nil {
    log.Printf("Removing stale shallow.lock from previous interrupted fetch")
    if err := os.Remove(shallowLock); err != nil {
        log.Printf("Warning: failed to remove shallow.lock: %v", err)
    }
}

cmd := exec.Command("git", "-C", ts.dataDir, "fetch", "--deepen=1", "origin", branch)
