### PR TITLE
fix(profile-builder): isolate Radarr and Sonarr profiles with same names

### DIFF
--- a/internal/core/filestore.go
+++ b/internal/core/filestore.go
@@ -172,7 +172,7 @@ func (fs *FileStore[T, PT]) Update(item T) error {
 	defer fs.mu.Unlock()
 
 	p := PT(&item)
-	newFilename := sanitizeFilename(p.GetName(), p.GetID()) + ".json"
+	newFilename := sanitizeFilename(p.GetName(), p.GetAppType(), p.GetID()) + ".json"
 
 	// Find and remove old file if it exists under a different name (migration/rename)
 	found := false
@@ -227,7 +227,7 @@ func (fs *FileStore[T, PT]) writeItem(item *T) error {
 
 	// Use sanitized name as filename for readability. Falls back to ID if name is empty.
 	// The file contains the full item JSON (including ID), so the filename is purely cosmetic.
-	filename := sanitizeFilename(p.GetName(), id) + ".json"
+	filename := sanitizeFilename(p.GetName(), p.GetAppType(), id) + ".json"
 	path := filepath.Join(fs.dir, filename)
 
 	tmp := path + ".tmp"
@@ -239,7 +239,7 @@ func (fs *FileStore[T, PT]) writeItem(item *T) error {
 
 // sanitizeFilename converts a name to a safe filesystem filename.
 // Strips path separators, .., and special characters. Falls back to ID if name is empty.
-func sanitizeFilename(name, id string) string {
+func sanitizeFilename(name, appType, id string) string {
 	if name == "" {
 		name = id
 	}
@@ -260,6 +260,9 @@ func sanitizeFilename(name, id string) string {
 	}
 	if result == "" {
 		result = id
+	}
+	if appType != "" {
+		result = result + "-" + appType
 	}
 	return result
 }
@@ -291,7 +294,7 @@ func (fs *FileStore[T, PT]) MigrateFilenames() int {
 			continue
 		}
 		p := PT(&item)
-		expectedFilename := sanitizeFilename(p.GetName(), p.GetID()) + ".json"
+		expectedFilename := sanitizeFilename(p.GetName(), p.GetAppType(), p.GetID()) + ".json"
 		if e.Name() != expectedFilename {
 			newPath := filepath.Join(fs.dir, expectedFilename)
 			if err := os.WriteFile(newPath, data, 0644); err == nil {

--- a/internal/core/filestore.go
+++ b/internal/core/filestore.go
@@ -172,6 +172,17 @@ func (fs *FileStore[T, PT]) Update(item T) error {
 	defer fs.mu.Unlock()
 
 	p := PT(&item)
+
+	// Prevent renaming to a name that already exists for this appType
+	existing := fs.listLocked(p.GetAppType())
+	for _, ex := range existing {
+		exP := PT(&ex)
+		// same name in the same app type, but a different item ID
+		if exP.GetName() == p.GetName() && exP.GetID() != p.GetID() {
+			return fmt.Errorf("an item with name %q already exists for %s", p.GetName(), p.GetAppType())
+		}
+	}
+
 	newFilename := sanitizeFilename(p.GetName(), p.GetAppType(), p.GetID()) + ".json"
 
 	// Find and remove old file if it exists under a different name (migration/rename)
@@ -262,7 +273,16 @@ func sanitizeFilename(name, appType, id string) string {
 		result = id
 	}
 	if appType != "" {
-		result = result + "-" + appType
+		safeAppType := strings.ToLower(appType)
+		var ab strings.Builder
+		for _, r := range safeAppType {
+			if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+				ab.WriteRune(r)
+			}
+		}
+		if clean := ab.String(); clean != "" {
+			result = result + "-" + clean
+		}
 	}
 	return result
 }

--- a/internal/core/filestore_test.go
+++ b/internal/core/filestore_test.go
@@ -201,3 +201,49 @@ func TestFileStore_UpdateNotFound(t *testing.T) {
 		t.Error("expected error for updating nonexistent item")
 	}
 }
+
+func TestFileStore_AppTypeSeparation(t *testing.T) {
+fs := newTestStore(t)
+
+// Add two items with the exact same name but different AppTypes.
+// Both should be saved into the store since their filenames should not collide.
+items := []testItem{
+{ID: "1", Name: "Identical", AppType: "radarr", Value: "a"},
+{ID: "2", Name: "Identical", AppType: "sonarr", Value: "b"},
+}
+
+added, skipped, err := fs.Add(items)
+if err != nil {
+t.Fatalf("Add failed: %v", err)
+}
+if added != 2 {
+t.Errorf("expected 2 added, got %d (skipped: %d)", added, skipped)
+}
+
+// Verify both physically exist as files
+entries, err := os.ReadDir(fs.dir)
+if err != nil {
+t.Fatalf("failed to read dir: %v", err)
+}
+
+// There should be exactly 2 JSON files
+jsonCount := 0
+for _, e := range entries {
+if !e.IsDir() {
+jsonCount++
+}
+}
+if jsonCount != 2 {
+t.Errorf("expected 2 JSON files, got %d", jsonCount)
+}
+
+// Verify we can retrieve both distinct items
+rItem, rok := fs.Get("1")
+sItem, sok := fs.Get("2")
+if !rok || !sok {
+t.Fatal("could not retrieve both items")
+}
+if rItem.Value != "a" || sItem.Value != "b" {
+t.Errorf("items corrupted or overwritten: radarr=%q, sonarr=%q", rItem.Value, sItem.Value)
+}
+}

--- a/internal/core/filestore_test.go
+++ b/internal/core/filestore_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -230,7 +231,7 @@ func TestFileStore_AppTypeSeparation(t *testing.T) {
 	jsonCount := 0
 	files := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		if !e.IsDir() {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
 			jsonCount++
 			files[e.Name()] = true
 		}

--- a/internal/core/filestore_test.go
+++ b/internal/core/filestore_test.go
@@ -203,47 +203,55 @@ func TestFileStore_UpdateNotFound(t *testing.T) {
 }
 
 func TestFileStore_AppTypeSeparation(t *testing.T) {
-fs := newTestStore(t)
+	fs := newTestStore(t)
 
-// Add two items with the exact same name but different AppTypes.
-// Both should be saved into the store since their filenames should not collide.
-items := []testItem{
-{ID: "1", Name: "Identical", AppType: "radarr", Value: "a"},
-{ID: "2", Name: "Identical", AppType: "sonarr", Value: "b"},
-}
+	// Add two items with the exact same name but different AppTypes.
+	// Both should be saved into the store since their filenames should not collide.
+	items := []testItem{
+		{ID: "1", Name: "Identical", AppType: "radarr", Value: "a"},
+		{ID: "2", Name: "Identical", AppType: "sonarr", Value: "b"},
+	}
 
-added, skipped, err := fs.Add(items)
-if err != nil {
-t.Fatalf("Add failed: %v", err)
-}
-if added != 2 {
-t.Errorf("expected 2 added, got %d (skipped: %d)", added, skipped)
-}
+	added, skipped, err := fs.Add(items)
+	if err != nil {
+		t.Fatalf("Add failed: %v", err)
+	}
+	if added != 2 {
+		t.Errorf("expected 2 added, got %d (skipped: %d)", added, skipped)
+	}
 
-// Verify both physically exist as files
-entries, err := os.ReadDir(fs.dir)
-if err != nil {
-t.Fatalf("failed to read dir: %v", err)
-}
+	// Verify both physically exist as files
+	entries, err := os.ReadDir(fs.dir)
+	if err != nil {
+		t.Fatalf("failed to read dir: %v", err)
+	}
 
-// There should be exactly 2 JSON files
-jsonCount := 0
-for _, e := range entries {
-if !e.IsDir() {
-jsonCount++
-}
-}
-if jsonCount != 2 {
-t.Errorf("expected 2 JSON files, got %d", jsonCount)
-}
+	// There should be exactly 2 JSON files with app-scoped names
+	jsonCount := 0
+	files := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() {
+			jsonCount++
+			files[e.Name()] = true
+		}
+	}
+	if jsonCount != 2 {
+		t.Errorf("expected 2 JSON files, got %d", jsonCount)
+	}
+	if !files["identical-radarr.json"] {
+		t.Error("expected identical-radarr.json to exist")
+	}
+	if !files["identical-sonarr.json"] {
+		t.Error("expected identical-sonarr.json to exist")
+	}
 
-// Verify we can retrieve both distinct items
-rItem, rok := fs.Get("1")
-sItem, sok := fs.Get("2")
-if !rok || !sok {
-t.Fatal("could not retrieve both items")
-}
-if rItem.Value != "a" || sItem.Value != "b" {
-t.Errorf("items corrupted or overwritten: radarr=%q, sonarr=%q", rItem.Value, sItem.Value)
-}
+	// Verify we can retrieve both distinct items
+	rItem, rok := fs.Get("1")
+	sItem, sok := fs.Get("2")
+	if !rok || !sok {
+		t.Fatal("could not retrieve both items")
+	}
+	if rItem.Value != "a" || sItem.Value != "b" {
+		t.Errorf("items corrupted or overwritten: radarr=%q, sonarr=%q", rItem.Value, sItem.Value)
+	}
 }


### PR DESCRIPTION
## Summary
This PR fixes a profile builder bug where Radarr and Sonarr profiles with the same name could overwrite each other after refresh.

## Problem
Profiles were stored with filenames derived only from the profile name.  
If a Radarr profile and a Sonarr profile shared the same name, one could replace the other on disk.  
After refresh, one profile would disappear from its section.

## What Changed
- Updated file naming to include app scope in the filename, so Radarr and Sonarr profiles no longer collide.
- Updated update-path filename resolution to use name + app type + ID.
- Added an explicit same-app conflict check during updates so a rename cannot overwrite another profile with the same name in the same section.
- Hardened filename generation by sanitizing `appType` before appending it to the stored filename.
- Updated filename migration logic so existing files are migrated to app-scoped names.
- Added regression coverage in `TestFileStore_AppTypeSeparation`.

## Result
- The same profile name is now allowed across Radarr and Sonarr.
- Name uniqueness remains enforced within each app section.
- Refresh no longer causes cross-app profile overwrites or disappearance.

## Validation
- Ran full test suite: `go test ./... -v`
- Ran build verification: `go build ./...`
- All checks passed.