### PR TITLE
docs: optimize Dockerfile with BuildKit caches and OCI labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
+# Dockerfile for Clonarr
+#
+# Architecture: Multi-stage build (Builder -> Runtime)
+# 
+# Environment Variables:
+#   - PUID : User ID for file permissions mapping (default: 99 - nobody)
+#   - PGID : Group ID for file permissions mapping (default: 100 - users)
+#   - PORT : The port the Clonarr web interface listens on (default: 6060)
+#
+# Volumes:
+#   - /config : Persistent storage for Clonarr's database and configuration
+
 FROM golang:1.25-alpine AS builder
 
 ARG VERSION=2.2.1
@@ -5,35 +17,60 @@ ARG VERSION=2.2.1
 RUN apk add --no-cache git
 
 WORKDIR /build
+# Copy dependency files first for layer caching
 COPY go.mod go.sum ./
-RUN go mod download
 
+# Use cache mounts for go modules to speed up subsequent builds
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy the remaining application source code
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w -X main.Version=${VERSION}" -o clonarr .
+
+# Build the application binary.
+# Uses cache mounts for Go build cache and explicitly sets GOOS=linux for cross-compilation compatibility.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w -X main.Version=${VERSION}" -o clonarr .
 
 FROM alpine:3.21
 
 ARG VERSION=2.2.1
-LABEL org.opencontainers.image.version=${VERSION}
 
+# Open Container Initiative (OCI) labels for registry metadata
+LABEL org.opencontainers.image.version=${VERSION} \
+      org.opencontainers.image.title="clonarr" \
+      org.opencontainers.image.description="Clonarr application" \
+      org.opencontainers.image.source="https://github.com/ProphetSe7en/clonarr"
+
+# Install runtime dependencies (git, tini, timezone data, certs) and su-exec for stepping down from root.
+# Also ensures the nobody:users combination exists for permission mapping.
 RUN apk add --no-cache git tini tzdata ca-certificates su-exec && \
     addgroup -g 100 users 2>/dev/null || true && \
     adduser -D -u 99 -G users nobody 2>/dev/null || true && \
     mkdir -p /config && \
     chown -R nobody:users /config
 
+# Copy the compiled binary from the builder stage
 COPY --from=builder /build/clonarr /usr/local/bin/clonarr
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
+# Copy the startup script (using --chmod to avoid an extra RUN layer setting permissions)
+COPY --chmod=755 entrypoint.sh /entrypoint.sh
+
+# Define the volume for persistent application data
 VOLUME /config
 
-ENV PUID=99
-ENV PGID=100
-ENV PORT=6060
+# Default environment variables for permission handling and web port
+ENV PUID=99 \
+    PGID=100 \
+    PORT=6060
+
+# Expose the application web port
 EXPOSE 6060
 
+# Healthcheck to ensure the container is routing traffic properly
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD wget -qO- http://localhost:6060/api/health || exit 1
 
+# Use tini as the init system to handle process reaping and signal forwarding
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Dockerfile for Clonarr
 #
 # Architecture: Multi-stage build (Builder -> Runtime)
@@ -70,7 +71,7 @@ EXPOSE 6060
 
 # Healthcheck to ensure the container is routing traffic properly
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD wget -qO- http://localhost:6060/api/health || exit 1
+  CMD sh -c 'wget -qO- "http://localhost:${PORT}/api/health" || exit 1'
 
 # Use tini as the init system to handle process reaping and signal forwarding
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]


### PR DESCRIPTION
## Optimize Dockerfile with BuildKit, OCI metadata, and dynamic healthcheck

### Description
This PR improves the Dockerfile with performance optimizations, better container registry integration, and dynamic runtime configurations.

### Changes
- **BuildKit Syntaxes & Cache Mounts**: 
  - Added `# syntax=docker/dockerfile:1` directive to explicitly enforce BuildKit usage.
  - Added cache mounts for Go modules (`/go/pkg/mod`) and build cache (`/root/.cache/go-build`) to significantly speed up rebuilds when dependencies haven't changed.
- **Explicit Cross-Compilation**: Set `GOOS=linux` explicitly in the build step to ensure consistent compilation across different host architectures (e.g., building from macOS/Windows).
- **Dynamic Healthcheck**: Updated the `HEALTHCHECK` command to use the `${PORT}` environment variable instead of hardcoding `6060`, preventing false "unhealthy" states if the port is overridden at runtime.
- **Reduced Image Layers**: 
  - Use `COPY --chmod=755` instead of a separate `RUN chmod` command to eliminate an unnecessary layer.
  - Combined multiple `ENV` statements into a single instruction.
- **OCI Image Labels**: Added standardized OpenContainers metadata labels for better container registry integration:
  - `org.opencontainers.image.version`
  - `org.opencontainers.image.title`
  - `org.opencontainers.image.description`
  - `org.opencontainers.image.source` (links to the repository for GitHub Container Registry).
- **Documentation**: Added clear comments explaining each build step and the rationale behind key decisions.

### Benefits
- ✅ Faster rebuild times when only source code changes (modules cached).
- ✅ Smaller image layer count.
- ✅ Reliable healthchecks even when deploying with custom ports.
- ✅ Better discoverability when publishing to GitHub Container Registry (GHCR).
- ✅ Guaranteed BuildKit execution regardless of older legacy Docker configurations.
- ✅ Improved maintainability with comprehensive inline documentation.

### Testing
- [x] Image builds successfully with BuildKit enabled (`docker build -t clonarr:latest .`).
- [x] Container runs without errors: `docker run --rm -it -p 6060:6060 clonarr:latest`.
- [x] Healthcheck passes dynamically based on the `$PORT` variable configuration.