### PR TITLE
Improve URL support for reverse proxy subpath hosting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ EXPOSE 6060
 
 # Healthcheck to ensure the container is routing traffic properly
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-  CMD sh -c 'wget -qO- "http://localhost:${PORT}/api/health" || exit 1'
+  CMD sh -c 'wget -qO- "http://localhost:${PORT}${URL_BASE:-}/api/health" || exit 1'
 
 # Use tini as the init system to handle process reaping and signal forwarding
 ENTRYPOINT ["/sbin/tini", "--", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The TRaSH repository is cloned to `/config/data/trash-guides/` and updated autom
 | `PUID` | No | `99` | User ID for file ownership |
 | `PGID` | No | `100` | Group ID for file ownership |
 | `PORT` | No | `6060` | Web UI port (inside container) |
+| `URL_BASE` | No | *(empty)* | URL path prefix for reverse proxy subpath hosting, such as `/clonarr`. Leave empty for standard root-path access. |
 | `TRUSTED_NETWORKS` | No | *(empty — uses Radarr-parity defaults)* | Lock **Trusted Networks** at host level. Comma-separated IPs/CIDRs (`192.168.86.0/24, 10.66.0.0/24`). When set, the UI field is disabled and cannot be changed via the web interface — only by editing the template and restarting. Useful for defense-in-depth: prevents a UI-takeover attacker from expanding the trust boundary. |
 | `TRUSTED_PROXIES` | No | *(empty)* | Lock **Trusted Proxies** at host level. Comma-separated IPs. Same UI-disabled behavior as `TRUSTED_NETWORKS`. Only needed when Clonarr sits behind a reverse proxy that terminates TLS (SWAG, Authelia, Traefik). |
 

--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -28,8 +28,9 @@ import (
 
 // AuthHandlers bundles the dependencies needed by each handler.
 type AuthHandlers struct {
-	Store   *auth.Store
-	Version string
+	Store    *auth.Store
+	Version  string
+	BasePath string // URL prefix, e.g. "/clonarr" — empty for root
 }
 
 // ---------- Setup wizard ----------
@@ -60,7 +61,7 @@ var setupTmpl = template.Must(template.New("setup").Parse(`<!DOCTYPE html>
   <h1>Welcome to Clonarr</h1>
   <p class="sub">Authentication is now required. Create the admin account to continue — you'll use this login every time you access Clonarr from outside your local network.</p>
   {{if .Error}}<div class="err">{{.Error}}</div>{{end}}
-  <form method="POST" action="/setup">
+  <form method="POST" action="{{.BasePath}}/setup">
     <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <label>Username</label>
     <input type="text" name="username" value="{{.Username}}" required autofocus autocomplete="username">
@@ -79,13 +80,14 @@ var setupTmpl = template.Must(template.New("setup").Parse(`<!DOCTYPE html>
 func (h *AuthHandlers) handleSetupPage(w http.ResponseWriter, r *http.Request) {
 	// If already configured, bounce to main app (don't let anyone hit this twice).
 	if h.Store.IsConfigured() {
-		http.Redirect(w, r, "/", http.StatusFound)
+		http.Redirect(w, r, h.BasePath+"/", http.StatusFound)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", "no-store")
 	if err := setupTmpl.Execute(w, map[string]any{
 		"Version":   h.Version,
+		"BasePath":  h.BasePath,
 		"CSRFToken": h.Store.EnsureCSRFCookie(w, r),
 	}); err != nil {
 		log.Printf("setup page render: %v", err)
@@ -119,11 +121,11 @@ func (h *AuthHandlers) handleSetupSubmit(w http.ResponseWriter, r *http.Request)
 	sessionID, err := h.Store.CreateSession()
 	if err != nil {
 		log.Printf("setup: create session after setup: %v", err)
-		http.Redirect(w, r, "/login", http.StatusFound)
+		http.Redirect(w, r, h.BasePath+"/login", http.StatusFound)
 		return
 	}
 	h.setSessionCookie(w, r, sessionID)
-	http.Redirect(w, r, "/", http.StatusFound)
+	http.Redirect(w, r, h.BasePath+"/", http.StatusFound)
 }
 
 func (h *AuthHandlers) renderSetupError(w http.ResponseWriter, r *http.Request, username, errMsg string) {
@@ -132,6 +134,7 @@ func (h *AuthHandlers) renderSetupError(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(http.StatusBadRequest)
 	if err := setupTmpl.Execute(w, map[string]any{
 		"Version":   h.Version,
+		"BasePath":  h.BasePath,
 		"Username":  username,
 		"Error":     errMsg,
 		"CSRFToken": h.Store.EnsureCSRFCookie(w, r),
@@ -165,7 +168,7 @@ var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
 <div class="card">
   <h1>Clonarr</h1>
   {{if .Error}}<div class="err">{{.Error}}</div>{{end}}
-  <form method="POST" action="/login{{if .NextEncoded}}?next={{.NextEncoded}}{{end}}">
+  <form method="POST" action="{{.BasePath}}/login{{if .NextEncoded}}?next={{.NextEncoded}}{{end}}">
     <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
     <label>Username</label>
     <input type="text" name="username" value="{{.Username}}" required autofocus autocomplete="username">
@@ -181,7 +184,7 @@ var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
 func (h *AuthHandlers) handleLoginPage(w http.ResponseWriter, r *http.Request) {
 	// Not configured yet — force setup first.
 	if !h.Store.IsConfigured() {
-		http.Redirect(w, r, "/setup", http.StatusFound)
+		http.Redirect(w, r, h.BasePath+"/setup", http.StatusFound)
 		return
 	}
 	next := sanitizeNext(r.URL.Query().Get("next"))
@@ -189,6 +192,7 @@ func (h *AuthHandlers) handleLoginPage(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 	if err := loginTmpl.Execute(w, map[string]any{
 		"Version":     h.Version,
+		"BasePath":    h.BasePath,
 		"Next":        next,
 		"NextEncoded": url.QueryEscape(next),
 		"CSRFToken":   h.Store.EnsureCSRFCookie(w, r),
@@ -199,7 +203,7 @@ func (h *AuthHandlers) handleLoginPage(w http.ResponseWriter, r *http.Request) {
 
 func (h *AuthHandlers) handleLoginSubmit(w http.ResponseWriter, r *http.Request) {
 	if !h.Store.IsConfigured() {
-		http.Redirect(w, r, "/setup", http.StatusFound)
+		http.Redirect(w, r, h.BasePath+"/setup", http.StatusFound)
 		return
 	}
 	r.Body = http.MaxBytesReader(w, r.Body, 8192)
@@ -226,7 +230,7 @@ func (h *AuthHandlers) handleLoginSubmit(w http.ResponseWriter, r *http.Request)
 
 	next := sanitizeNext(r.URL.Query().Get("next"))
 	if next == "" {
-		next = "/"
+		next = h.BasePath + "/"
 	}
 	http.Redirect(w, r, next, http.StatusFound)
 }
@@ -238,6 +242,7 @@ func (h *AuthHandlers) renderLoginError(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(http.StatusUnauthorized)
 	if err := loginTmpl.Execute(w, map[string]any{
 		"Version":     h.Version,
+		"BasePath":    h.BasePath,
 		"Username":    username,
 		"Error":       errMsg,
 		"Next":        next,
@@ -256,12 +261,12 @@ func (h *AuthHandlers) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.SessionCookieName,
 		Value:    "",
-		Path:     "/",
+		Path:     h.BasePath + "/",
 		MaxAge:   -1,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	})
-	http.Redirect(w, r, "/login", http.StatusFound)
+	http.Redirect(w, r, h.BasePath+"/login", http.StatusFound)
 }
 
 // ---------- Auth status (public — UI reads this to render correct state) ----------
@@ -290,6 +295,7 @@ func (h *AuthHandlers) handleAuthStatus(w http.ResponseWriter, r *http.Request) 
 		"authenticated":           authenticated,
 		"authentication":          string(cfg.Mode),        // needed for no-auth banner in UI
 		"authentication_required": string(cfg.Requirement), // needed for UI dropdown state
+		"url_base":                h.BasePath,
 	}
 	if adminEquivalent {
 		resp["username"] = h.Store.Username()
@@ -415,7 +421,7 @@ func (h *AuthHandlers) setSessionCookie(w http.ResponseWriter, r *http.Request, 
 	http.SetCookie(w, &http.Cookie{
 		Name:     auth.SessionCookieName,
 		Value:    sessionID,
-		Path:     "/",
+		Path:     h.BasePath + "/",
 		MaxAge:   int(ttl / time.Second),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
@@ -479,7 +485,7 @@ func requireAuthForAPI(w http.ResponseWriter) {
 //
 // Refuses to start (log.Fatal) on any unsafe combination (unknown enum
 // values) or on malformed auth.json.
-func InitAuth(ctx context.Context, configStore *core.ConfigStore, version string, mux *http.ServeMux) *auth.Store {
+func InitAuth(ctx context.Context, configStore *core.ConfigStore, version string, basePath string, mux *http.ServeMux) *auth.Store {
 	cfg := auth.DefaultConfig()
 
 	appCfg := configStore.Get()
@@ -492,6 +498,7 @@ func InitAuth(ctx context.Context, configStore *core.ConfigStore, version string
 	if appCfg.SessionTTLDays > 0 {
 		cfg.SessionTTL = time.Duration(appCfg.SessionTTLDays) * 24 * time.Hour
 	}
+	cfg.BasePath = basePath
 	// Env-var override for trust-boundary config.
 	if envNets := strings.TrimSpace(os.Getenv("TRUSTED_NETWORKS")); envNets != "" {
 		nets, err := netsec.ParseTrustedNetworks(envNets)
@@ -564,7 +571,7 @@ func InitAuth(ctx context.Context, configStore *core.ConfigStore, version string
 		}
 	})
 
-	authHandlers := &AuthHandlers{Store: store, Version: version}
+	authHandlers := &AuthHandlers{Store: store, Version: version, BasePath: basePath}
 
 	mux.HandleFunc("GET /setup", authHandlers.handleSetupPage)
 	mux.HandleFunc("POST /setup", authHandlers.handleSetupSubmit)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -3,9 +3,24 @@ package api
 import (
 	"clonarr/internal/auth"
 	"clonarr/internal/core"
+	"html/template"
 	"net/http"
 	"sync"
 )
+
+// IndexHandler renders index.html as a Go template so BasePath can be injected
+// at serve time. Registered at "GET /{$}" (exact root match) so Go 1.22+
+// ServeMux prefers it over the catch-all FileServer for GET /.
+type IndexHandler struct {
+	Tmpl     *template.Template
+	BasePath string
+}
+
+func (h *IndexHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = h.Tmpl.Execute(w, map[string]any{"BasePath": h.BasePath})
+}
 
 // Server wraps the core application and provides HTTP handlers.
 type Server struct {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -100,6 +100,11 @@ type Config struct {
 	TrustedNetworksRaw string
 	TrustedProxiesRaw  string
 	SessionTTL       time.Duration
+	// BasePath is the URL prefix when Clonarr is mounted at a sub-path
+	// (e.g. "/clonarr"). Empty means serve from root. Set via URL_BASE env
+	// var; never user-editable at runtime. Affects cookie Path, redirect
+	// targets, and form action URLs so browser-visible URLs include the prefix.
+	BasePath         string
 	AuthFilePath     string // default /config/auth.json
 	SessionsFilePath string // default /config/sessions.json — survives container restart
 	MaxSessions      int    // cap on concurrent sessions; 0 → 10000
@@ -700,6 +705,39 @@ func init() {
 	dummyHash = h
 }
 
+// NormalizeBasePath validates and normalizes a URL_BASE env-var value.
+// Returns the canonical base path (no trailing slash) or "" for root.
+// A leading "/" is required; "/" alone normalizes to "". Trailing slashes
+// are stripped. Double-slashes, query/fragment chars, and dot-segments
+// are rejected.
+func NormalizeBasePath(raw string) (string, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" || s == "/" {
+		return "", nil
+	}
+	if !strings.HasPrefix(s, "/") {
+		return "", fmt.Errorf("URL_BASE must start with '/' (got %q)", raw)
+	}
+	s = strings.TrimRight(s, "/")
+	if strings.Contains(s, "//") {
+		return "", fmt.Errorf("URL_BASE must not contain '//' (got %q)", raw)
+	}
+	if strings.ContainsAny(s, "?#") {
+		return "", fmt.Errorf("URL_BASE must not contain '?' or '#' (got %q)", raw)
+	}
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return "", fmt.Errorf("URL_BASE must not contain control characters")
+		}
+	}
+	for seg := range strings.SplitSeq(s[1:], "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return "", fmt.Errorf("URL_BASE has invalid path segment %q", seg)
+		}
+	}
+	return s, nil
+}
+
 // ===== Endpoint classification =====
 
 // publicExact is a set of paths that are always treated as public.
@@ -756,7 +794,7 @@ func (s *Store) Middleware(next http.Handler) http.Handler {
 
 		// If not configured yet, force users to the setup wizard.
 		if !s.IsConfigured() {
-			http.Redirect(w, r, "/setup", http.StatusFound)
+			http.Redirect(w, r, s.cfg.BasePath+"/setup", http.StatusFound)
 			return
 		}
 
@@ -798,7 +836,7 @@ func (s *Store) Middleware(next http.Handler) http.Handler {
 				http.SetCookie(w, &http.Cookie{
 					Name:     SessionCookieName,
 					Value:    "",
-					Path:     "/",
+					Path:     s.cfg.BasePath + "/",
 					MaxAge:   -1,
 					HttpOnly: true,
 					SameSite: http.SameSiteLaxMode,
@@ -808,7 +846,7 @@ func (s *Store) Middleware(next http.Handler) http.Handler {
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
-			http.Redirect(w, r, "/login", http.StatusFound)
+			http.Redirect(w, r, s.cfg.BasePath+"/login", http.StatusFound)
 
 		case ModeBasic:
 			user, pass, ok := r.BasicAuth()

--- a/internal/auth/csrf.go
+++ b/internal/auth/csrf.go
@@ -69,7 +69,7 @@ func (s *Store) EnsureCSRFCookie(w http.ResponseWriter, r *http.Request) string 
 	http.SetCookie(w, &http.Cookie{
 		Name:     CSRFCookieName,
 		Value:    token,
-		Path:     "/",
+		Path:     s.cfg.BasePath + "/",
 		HttpOnly: false, // JavaScript MUST read this cookie to echo it back
 		SameSite: http.SameSiteLaxMode,
 		Secure:   secure,

--- a/main.go
+++ b/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"io/fs"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -36,6 +38,14 @@ func main() {
 	dataDir := os.Getenv("DATA_DIR")
 	if dataDir == "" {
 		dataDir = filepath.Join(configDir, "data")
+	}
+
+	basePath, err := auth.NormalizeBasePath(os.Getenv("URL_BASE"))
+	if err != nil {
+		log.Fatalf("URL_BASE invalid: %v", err)
+	}
+	if basePath != "" {
+		log.Printf("URL base: %s (serving from this prefix)", basePath)
 	}
 
 	// Initialize stores
@@ -211,7 +221,7 @@ func main() {
 	})
 
 	// ==== Authentication =====================================================
-	authStore := api.InitAuth(ctx, cfgStore, Version, mux)
+	authStore := api.InitAuth(ctx, cfgStore, Version, basePath, mux)
 	server.AuthStore = authStore
 
 	// Static files
@@ -219,6 +229,18 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create static file system: %v", err)
 	}
+	// Render index.html as a template so BasePath can be injected at serve
+	// time. "GET /{$}" is an exact-match in Go 1.22+ ServeMux and takes
+	// priority over the catch-all "/" for GET / requests.
+	indexBytes, err := fs.ReadFile(staticFS, "index.html")
+	if err != nil {
+		log.Fatalf("Failed to read index.html: %v", err)
+	}
+	indexTmpl, err := template.New("index").Parse(string(indexBytes))
+	if err != nil {
+		log.Fatalf("Failed to parse index.html as template: %v", err)
+	}
+	mux.Handle("GET /{$}", &api.IndexHandler{Tmpl: indexTmpl, BasePath: basePath})
 	mux.Handle("/", http.FileServer(http.FS(staticFS)))
 
 	// Background: reap expired sessions every 5 min
@@ -236,10 +258,17 @@ func main() {
 	})
 
 	// Middleware chain — outermost first:
-	//   SecurityHeaders → CSRF → Auth → mux
+	//   [BasePath] → SecurityHeaders → CSRF → Auth → mux
+	// withBasePath wraps the chain only when URL_BASE is set: it 301-redirects
+	// the bare base path (no trailing slash) to base/, 404s anything outside
+	// the base, and strips the prefix before the inner handlers see the path.
+	// Inner handlers keep using root-relative paths (/api/..., /login, etc.).
 	var handler http.Handler = authStore.Middleware(mux)
 	handler = authStore.CSRFMiddleware(handler)
 	handler = auth.SecurityHeadersMiddleware(handler)
+	if basePath != "" {
+		handler = withBasePath(basePath, handler)
+	}
 
 	serverHTTP := &http.Server{
 		Addr:         ":" + port,
@@ -267,4 +296,28 @@ func main() {
 	if err := serverHTTP.ListenAndServe(); err != http.ErrServerClosed {
 		log.Fatalf("HTTP server error: %v", err)
 	}
+}
+
+// withBasePath wraps a handler so it is only reachable under base (e.g.
+// "/clonarr"). It:
+//   - 301-redirects the bare base path (no trailing slash) → base/
+//   - 404s anything whose path does not start with base/
+//   - strips the prefix before passing to the inner handler, so inner code
+//     continues to work with root-relative paths (/api/..., /login, etc.)
+func withBasePath(base string, inner http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == base {
+			target := base + "/"
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			http.Redirect(w, r, target, http.StatusMovedPermanently)
+			return
+		}
+		if !strings.HasPrefix(r.URL.Path, base+"/") {
+			http.NotFound(w, r)
+			return
+		}
+		http.StripPrefix(base, inner).ServeHTTP(w, r)
+	})
 }

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -1,12 +1,13 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-base="{{.BasePath}}">
 <head>
 <meta charset="UTF-8">
+<base href="{{.BasePath}}/">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Clonarr</title>
-<link rel="icon" type="image/png" href="/icons/clonarr.png">
+<link rel="icon" type="image/png" href="icons/clonarr.png">
 <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-<link rel="stylesheet" href="/css/styles.css">
+<link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
 
@@ -14,7 +15,7 @@
 
   <!-- Top Navigation -->
   <div class="topnav">
-    <div class="logo"><img src="/icons/clonarr.png" alt="" style="width:28px;height:28px;border-radius:6px;vertical-align:middle;margin-right:8px">Clonarr</div>
+    <div class="logo"><img src="icons/clonarr.png" alt="" style="width:28px;height:28px;border-radius:6px;vertical-align:middle;margin-right:8px">Clonarr</div>
     <div class="tabs">
       <div class="tab" :class="{ active: currentSection === 'profiles' }" @click="switchSection('profiles')">Profiles</div>
       <div class="tab" :class="{ active: currentSection === 'custom-formats' }" @click="switchSection('custom-formats')">Custom Formats</div>
@@ -103,7 +104,7 @@
         <div style="display:flex;align-items:center;gap:8px">
           <span x-text="authStatus.username" :title="'Logged in as ' + authStatus.username"
                 style="max-width:120px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></span>
-          <form method="POST" action="/logout" style="margin:0">
+          <form method="POST" action="logout" style="margin:0">
             <input type="hidden" name="csrf_token" :value="csrfToken()">
             <button type="submit" class="btn btn-secondary" style="padding:4px 10px;font-size:11px" title="Log out">Logout</button>
           </form>
@@ -4646,6 +4647,13 @@
               <span x-show="config.trashSchemaFields" style="font-size:12px;color:#d29922">Active</span>
             </div>
           </div>
+          <div class="setting-row" x-show="authStatus.urlBase">
+            <div class="setting-label">URL Base</div>
+            <div class="setting-value">
+              <input type="text" :value="authStatus.urlBase" disabled style="width:220px;opacity:0.7">
+              <span style="font-size:12px;color:#aaa;margin-left:8px">Set via <code>URL_BASE</code> env var. Restart to change.</span>
+            </div>
+          </div>
           <div class="setting-row">
             <div class="setting-label">Debug Logging</div>
             <div class="setting-value" style="display:flex;align-items:center;gap:10px">
@@ -4653,7 +4661,7 @@
                 <input type="checkbox" x-model="config.debugLogging" @change="saveConfig(['debugLogging'])" style="accent-color:#58a6ff">
                 <span style="font-size:12px;color:#aaa">Write to /config/debug.log (max 1MB, auto-rotates)</span>
               </label>
-              <a x-show="config.debugLogging" class="btn btn-sm" href="/api/debug/log/download" download="clonarr-debug.log" style="text-decoration:none;margin-left:8px">Download</a>
+              <a x-show="config.debugLogging" class="btn btn-sm" href="api/debug/log/download" download="clonarr-debug.log" style="text-decoration:none;margin-left:8px">Download</a>
             </div>
           </div>
         </div>
@@ -6151,7 +6159,7 @@
 
 <div id="cf-tooltip-portal" onmouseenter="clearTimeout(window._tooltipHideTimer)" onmouseleave="const el=document.getElementById('cf-tooltip-portal'); window._tooltipHideTimer=setTimeout(()=>{if(el)el.style.display='none'},200)"></div>
 
-<script src="/js/api.js"></script>
-<script src="/js/app.js"></script>
+<script src="js/api.js"></script>
+<script src="js/app.js"></script>
 </body>
 </html>

--- a/ui/static/js/api.js
+++ b/ui/static/js/api.js
@@ -21,9 +21,24 @@
 //         legitimate use is the disable-auth modal, where 401 means
 //         "confirm_password incorrect" not "session expired".
 (function() {
+  // Read the base path from the <html data-base="..."> attribute injected
+  // at serve time by the Go template. Avoids JS-context escaping issues that
+  // arise when embedding path values inside <script> string literals.
+  const BASE = (document.documentElement.dataset.base || '').replace(/\/$/, '');
+
+  // Prepend BASE to root-relative paths so all fetch('/api/...') calls reach
+  // the correct sub-path when URL_BASE is set. Has no effect when BASE is ''.
+  function rewriteInput(input) {
+    if (BASE === '') return input;
+    if (typeof input === 'string' && input.startsWith('/') && !input.startsWith(BASE + '/')) {
+      return BASE + input;
+    }
+    return input;
+  }
+
   const origFetch = window.fetch.bind(window);
   window.fetch = async function(input, init) {
-    const request = new Request(input, init);
+    const request = new Request(rewriteInput(input), init);
     const method = request.method.toUpperCase();
     const headers = new Headers(request.headers);
     if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
@@ -36,8 +51,8 @@
     const resp = await origFetch(new Request(request, { headers }));
     if (resp.status === 401 && !skipLoginRedirect) {
       const path = window.location.pathname;
-      if (path !== '/login' && path !== '/setup') {
-        window.location.href = '/login';
+      if (path !== BASE + '/login' && path !== BASE + '/setup') {
+        window.location.href = BASE + '/login';
         return new Promise(() => {});
       }
     }

--- a/ui/static/js/app.js
+++ b/ui/static/js/app.js
@@ -90,7 +90,7 @@ function clonarr() {
     disableAuthPassword: '',
     disableAuthError: '',
     // Auth status (for logout button + no-auth banner)
-    authStatus: { configured: false, authenticated: false, username: '', localBypass: false, authentication: '', authenticationRequired: '', trustedNetworksLocked: false, trustedProxiesLocked: false, trustedNetworksEffective: '', trustedProxiesEffective: '' },
+    authStatus: { configured: false, authenticated: false, username: '', localBypass: false, authentication: '', authenticationRequired: '', trustedNetworksLocked: false, trustedProxiesLocked: false, trustedNetworksEffective: '', trustedProxiesEffective: '', urlBase: '' },
     authStatusLoadError: false, // true after 2 fetchAuthStatus retries fail → Security save button warns
     noAuthBannerDismissed: false,
     securitySaveMsg: '',
@@ -641,6 +641,7 @@ function clonarr() {
           trustedProxiesLocked: !!data.trusted_proxies_locked,
           trustedNetworksEffective: data.trusted_networks_effective || '',
           trustedProxiesEffective: data.trusted_proxies_effective || '',
+          urlBase: data.url_base || '',
         };
         // When env-locked, reflect the effective value in the disabled input
         // so the user can see what's actually enforced. Only applies if
@@ -4507,8 +4508,8 @@ function clonarr() {
 
     instanceIconUrl(inst) {
       const is4k = /4k|uhd/i.test(inst.name);
-      if (inst.type === 'radarr') return is4k ? '/icons/radarr4kNew.png' : '/icons/radarrNew.png';
-      return is4k ? '/icons/sonarr4k.png' : '/icons/sonarr.png';
+      if (inst.type === 'radarr') return is4k ? 'icons/radarr4kNew.png' : 'icons/radarrNew.png';
+      return is4k ? 'icons/sonarr4k.png' : 'icons/sonarr.png';
     },
 
     trashProfileCount(type) {

--- a/ui/static/js/app.js
+++ b/ui/static/js/app.js
@@ -7514,9 +7514,9 @@ function clonarr() {
       // Most providers ship an SVG; Gotify and Apprise ship a PNG bitmap
       // because no clean SVG is available upstream.
       if (type === 'gotify' || type === 'apprise') {
-        return `/icons/${type}.png`;
+        return `icons/${type}.png`;
       }
-      return `/icons/${type}.svg`;
+      return `icons/${type}.svg`;
     },
 
     agentModalCanTest() {


### PR DESCRIPTION
## Description

Adds comprehensive URL base path support for running Clonarr behind a reverse proxy at a subpath (e.g., `/clonarr`). This enables deployments where Clonarr is not served from the root path, solving issues with authentication, static assets, and API calls in reverse proxy configurations.

## Changes

### Configuration
- New `URL_BASE` environment variable to specify the subpath prefix
- Added `NormalizeBasePath()` function to validate and normalize the path (rejects `//`, query strings, fragments, and dot-segments)
- BasePath is read at startup and passed throughout the application

### Authentication & Routing
- Updated all HTTP redirects to include the base path (login, setup, logout)
- Modified cookie paths to respect the base path for proper session handling
- Added `withBasePath()` middleware to:
  - 301-redirect bare base path (e.g., `/clonarr`) → `/clonarr/`
  - 404 requests outside the base path
  - Strip prefix before passing to inner handlers

### Frontend
- Converted `index.html` to a Go template for runtime BasePath injection
- Added `<base>` HTML tag to make relative URLs work correctly
- Changed absolute asset paths to relative paths (`/css/` → `css/`, etc.)
- Updated JavaScript to read BasePath from `<html data-base>` attribute
- Added URL base rewriting in `api.js` fetch interceptor
- Display URL base in UI settings panel (read-only, env-var controlled)

### Updates
- Updated healthcheck in Dockerfile to include URL_BASE
- Added URL_BASE documentation to README
- Updated form actions in auth templates (setup, login)
- Modified logout form and all navigation links to use relative paths

## Testing
- Verify authentication flow with and without URL_BASE set
- Test static asset loading at subpath
- Confirm API calls reach correct endpoints
- Check browser navigation and redirects work correctly
- Validate CSRF and session cookies work at subpath