### PR TITLE
Add light/dark theme + cross-browser parity fixes

### DIFF
--- a/internal/api/auth_handlers.go
+++ b/internal/api/auth_handlers.go
@@ -55,6 +55,19 @@ var setupTmpl = template.Must(template.New("setup").Parse(`<!DOCTYPE html>
   .err { background:#3a1a1a; color:#ff9a9a; border:1px solid #5a2a2a; border-radius:6px; padding:10px 12px; margin-bottom:14px; font-size:13px; }
   .hint { color:#888; font-size:12px; margin-top:4px; line-height:1.4; }
   footer { margin-top:18px; font-size:12px; color:#6a6e76; text-align:center; }
+  @media (prefers-color-scheme: light) {
+    body { background:#f6f8fa; color:#1f2328; }
+    .card { background:#ffffff; border-color:#d0d7de; box-shadow:0 8px 24px rgba(0,0,0,.08); }
+    .sub { color:#57606a; }
+    label { color:#24292f; }
+    input { background:#ffffff; color:#1f2328; border-color:#d0d7de; }
+    input:focus { border-color:#0969da; }
+    button { background:#0969da; }
+    button:hover { background:#0860ca; }
+    .err { background:#ffebe9; color:#82071e; border-color:#ffcecb; }
+    .hint { color:#6e7681; }
+    footer { color:#6e7681; }
+  }
 </style>
 </head>
 <body>
@@ -201,6 +214,17 @@ var loginTmpl = template.Must(template.New("login").Parse(`<!DOCTYPE html>
   button:hover { background:#5aa0f2; }
   .err { background:#3a1a1a; color:#ff9a9a; border:1px solid #5a2a2a; border-radius:6px; padding:10px 12px; margin-bottom:14px; font-size:13px; }
   footer { margin-top:18px; font-size:12px; color:#6a6e76; text-align:center; }
+  @media (prefers-color-scheme: light) {
+    body { background:#f6f8fa; color:#1f2328; }
+    .card { background:#ffffff; border-color:#d0d7de; box-shadow:0 8px 24px rgba(0,0,0,.08); }
+    label { color:#24292f; }
+    input { background:#ffffff; color:#1f2328; border-color:#d0d7de; }
+    input:focus { border-color:#0969da; }
+    button { background:#0969da; }
+    button:hover { background:#0860ca; }
+    .err { background:#ffebe9; color:#82071e; border-color:#ffcecb; }
+    footer { color:#6e7681; }
+  }
 </style>
 </head>
 <body>

--- a/ui/static/css/base.css
+++ b/ui/static/css/base.css
@@ -4,3 +4,13 @@
   [x-cloak] { display: none !important; }
   .group-desc-html b, .group-desc-html strong { color: var(--accent-orange); font-style: normal; }
 
+  /* Cross-browser scrollbar styling. Firefox has supported these properties
+     for years; Chromium added support in 121 (Jan 2024). Replaces the need
+     for ::-webkit-scrollbar rules. */
+  * { scrollbar-color: var(--text-muted-secondary) transparent; scrollbar-width: thin; }
+
+  /* Keyboard-only focus ring. :focus-visible avoids showing the ring on
+     mouse clicks while keeping it for Tab navigation. Applies to clickable
+     <div>s, buttons, links, and inputs uniformly. */
+  :focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; border-radius: 2px; }
+

--- a/ui/static/css/tokens.css
+++ b/ui/static/css/tokens.css
@@ -115,27 +115,27 @@
 :root[data-theme="light"] {
   color-scheme: light;
 
-  /* Surface */
-  --bg-app: #ffffff;
-  --bg-page: #f6f8fa;
+  /* Surface — muted warm-grey page; white cards pop on top */
+  --bg-app: #ebeef2;
+  --bg-page: #ebeef2;
   --bg-card: #ffffff;
   --bg-elevated: #f6f8fa;
   --bg-elevated-hover: #eef1f4;
-  --bg-muted: #eaeef2;
-  --bg-panel: #f0f3f6;
+  --bg-muted: #dee3e8;
+  --bg-panel: #e8ecf0;
 
   /* Border */
-  --border-subtle: #d0d7de;
-  --border-muted: #d8dee4;
-  --border-faint: #eaeef2;
+  --border-subtle: #c8cfd6;
+  --border-muted: #d0d7de;
+  --border-faint: #dde2e7;
 
-  /* Text */
+  /* Text — bumped contrast for legibility on muted bg */
   --text-primary: #1f2328;
   --text-body: #24292f;
-  --text-secondary: #57606a;
-  --text-muted: #57606a;
-  --text-muted-secondary: #6e7681;
-  --text-soft: #57606a;
+  --text-secondary: #4d535b;
+  --text-muted: #4d535b;
+  --text-muted-secondary: #57606a;
+  --text-soft: #4d535b;
   --text-inverse: #ffffff;
   --text-on-accent: #ffffff;
 

--- a/ui/static/css/tokens.css
+++ b/ui/static/css/tokens.css
@@ -97,6 +97,19 @@
   --grp-german: #f0883e;
   --grp-imported: #8b949e;
   --grp-other: #8b949e;
+
+  /* Code syntax (used in <pre>/<code> blocks rendering naming patterns) */
+  --code-string: #9ecbaa;
+
+  /* Status badges (used in changelog dropdown) */
+  --badge-feat-bg: #1b3a2a;
+  --badge-fix-bg: #3d2e0a;
+  --badge-other-bg: #1c2333;
+
+  /* No-auth warning banner */
+  --banner-warn-bg: #5a1f1f;
+  --banner-warn-border: #8b2d2d;
+  --banner-warn-text: #ffdada;
 }
 
 :root[data-theme="light"] {
@@ -120,8 +133,8 @@
   --text-primary: #1f2328;
   --text-body: #24292f;
   --text-secondary: #57606a;
-  --text-muted: #6e7681;
-  --text-muted-secondary: #8b949e;
+  --text-muted: #57606a;
+  --text-muted-secondary: #6e7681;
   --text-soft: #57606a;
   --text-inverse: #ffffff;
   --text-on-accent: #ffffff;
@@ -175,4 +188,17 @@
   /* CF categories / profile groups inherit dark-mode values from :root —
      they are decorative chips that read on either background, and the
      backend manifest may override them at runtime. */
+
+  /* Code syntax (light-mode override for naming-pattern blocks) */
+  --code-string: #1a7f37;
+
+  /* Status badges (light-mode override) */
+  --badge-feat-bg: #dafbe1;
+  --badge-fix-bg: #fff8c5;
+  --badge-other-bg: #ddf4ff;
+
+  /* No-auth warning banner (light-mode override) */
+  --banner-warn-bg: #ffebe9;
+  --banner-warn-border: #ffcecb;
+  --banner-warn-text: #82071e;
 }

--- a/ui/static/css/tokens.css
+++ b/ui/static/css/tokens.css
@@ -158,7 +158,7 @@
   --accent-orange-bright: #bc4c00;
   --accent-orange-strong: #7d4e00;
   --accent-purple: #8250df;
-  --accent-purple-soft: #c297ff;
+  --accent-purple-soft: #6639ba;
   --accent-sky: #218bff;
   --accent-teal: #0a7c84;
   --accent-mint: #1a7f37;

--- a/ui/static/css/tokens.css
+++ b/ui/static/css/tokens.css
@@ -1,4 +1,7 @@
-:root {
+:root,
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
   /* Surface */
   --bg-app: #0f1117;
   --bg-page: #0d1117;
@@ -94,4 +97,82 @@
   --grp-german: #f0883e;
   --grp-imported: #8b949e;
   --grp-other: #8b949e;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  /* Surface */
+  --bg-app: #ffffff;
+  --bg-page: #f6f8fa;
+  --bg-card: #ffffff;
+  --bg-elevated: #f6f8fa;
+  --bg-elevated-hover: #eef1f4;
+  --bg-muted: #eaeef2;
+  --bg-panel: #f0f3f6;
+
+  /* Border */
+  --border-subtle: #d0d7de;
+  --border-muted: #d8dee4;
+  --border-faint: #eaeef2;
+
+  /* Text */
+  --text-primary: #1f2328;
+  --text-body: #24292f;
+  --text-secondary: #57606a;
+  --text-muted: #6e7681;
+  --text-muted-secondary: #8b949e;
+  --text-soft: #57606a;
+  --text-inverse: #ffffff;
+  --text-on-accent: #ffffff;
+
+  /* Accent — keep hue, adjust lightness for contrast on light bg */
+  --accent-blue: #0969da;
+  --accent-blue-muted: #ddf4ff;
+  --accent-blue-strong: #0550ae;
+  --accent-blue-hover: #0860ca;
+  --accent-green: #1a7f37;
+  --accent-green-bg: #dafbe1;
+  --accent-green-strong: #116329;
+  --accent-green-hover: #1f883d;
+  --accent-red: #cf222e;
+  --accent-red-soft: #d1242f;
+  --accent-red-bg: #ffebe9;
+  --accent-red-strong: #a40e26;
+  --accent-orange: #9a6700;
+  --accent-orange-bg: #fff8c5;
+  --accent-orange-bright: #bc4c00;
+  --accent-orange-strong: #7d4e00;
+  --accent-purple: #8250df;
+  --accent-purple-soft: #c297ff;
+  --accent-sky: #218bff;
+  --accent-teal: #0a7c84;
+  --accent-mint: #1a7f37;
+  --accent-pink: #bf3989;
+
+  /* Semantic fills (light, low-saturation backgrounds) */
+  --fill-blue-soft: #ddf4ff;
+  --fill-blue-dark: #b6e3ff;
+  --fill-green-soft: #dafbe1;
+  --fill-orange-soft: #fff8c5;
+  --fill-radarr: #fff1c2;
+
+  /* Alpha overlays — invert to dark-on-light */
+  --alpha-overlay: rgba(0,0,0,0.4);
+  --alpha-shadow: rgba(0,0,0,0.08);
+  --alpha-hover: rgba(0,0,0,0.04);
+  --alpha-active: rgba(0,0,0,0.06);
+  --alpha-subtle: rgba(0,0,0,0.02);
+  --alpha-orange-soft: rgba(154,103,0,0.06);
+  --alpha-orange: rgba(154,103,0,0.15);
+  --alpha-blue-soft: rgba(9,105,218,0.06);
+  --alpha-blue: rgba(9,105,218,0.12);
+  --alpha-blue-border: rgba(9,105,218,0.25);
+  --alpha-blue-border-strong: rgba(9,105,218,0.4);
+  --alpha-green-soft: rgba(26,127,55,0.08);
+  --alpha-green: rgba(26,127,55,0.12);
+
+  /* CF categories / profile groups inherit dark-mode values from :root —
+     they are decorative chips that read on either background, and the
+     backend manifest may override them at runtime. */
 }

--- a/ui/static/css/tokens.css
+++ b/ui/static/css/tokens.css
@@ -70,7 +70,8 @@
   --alpha-blue-border: rgba(88,166,255,0.25);
   --alpha-blue-border-strong: rgba(88,166,255,0.3);
   --alpha-green-soft: rgba(63,185,80,0.1);
-  --alpha-green: rgba(63,185,80,0.12);
+  --alpha-green: rgba(63,185,80,0.15);
+  --alpha-purple: rgba(163,113,247,0.15);
 
   /* CF categories. The backend manifest may override these at runtime. */
   --cat-golden-rule: #d2a8ff;
@@ -183,7 +184,8 @@
   --alpha-blue-border: rgba(9,105,218,0.25);
   --alpha-blue-border-strong: rgba(9,105,218,0.4);
   --alpha-green-soft: rgba(26,127,55,0.08);
-  --alpha-green: rgba(26,127,55,0.12);
+  --alpha-green: rgba(26,127,55,0.15);
+  --alpha-purple: rgba(130,80,223,0.18);
 
   /* CF categories / profile groups inherit dark-mode values from :root —
      they are decorative chips that read on either background, and the

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -18,6 +18,17 @@
      warnings about cross-origin storage access. To upgrade, replace
      ui/static/js/vendor/alpine.min.js with the new cdn.min.js bundle. -->
 <script defer src="js/vendor/alpine.min.js"></script>
+<!-- Resolve theme synchronously before CSS paints to avoid a flash of
+     wrong theme. Mirrors the logic in applyTheme() (features/profiles.js). -->
+<script>
+  (function() {
+    var stored = localStorage.getItem('clonarr-theme') || 'system';
+    var resolved = stored === 'system'
+      ? (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
+      : stored;
+    document.documentElement.setAttribute('data-theme', resolved);
+  })();
+</script>
 <link rel="stylesheet" href="css/styles.css">
 <link rel="modulepreload" href="js/api.js">
 <link rel="modulepreload" href="js/state.js">

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -191,7 +191,7 @@ export default {
             show: true,
             title: 'Enable Advanced Mode',
             html: true,
-            message: 'Advanced Mode enables tools for power users and guide contributors:<br><br>• Profile Builder — create custom profiles with fixed scores <span style="color:#f85149;font-weight:600">(no auto-sync — scores will NOT update when TRaSH Guides change)</span><br>• Scoring Sandbox — test how releases score against profiles<br>• TRaSH JSON export — for contributing to TRaSH Guides<br><br><strong style="color:#d29922;font-size:14px">Most users don\'t need this.</strong> TRaSH Sync handles profiles, scores, and updates automatically. Only enable Advanced Mode if you have a specific need that TRaSH Sync doesn\'t cover.<br><br>Enable Advanced Mode?',
+            message: 'Advanced Mode enables tools for power users and guide contributors:<br><br>• Profile Builder — create custom profiles with fixed scores <span style="color:var(--accent-red);font-weight:600">(no auto-sync — scores will NOT update when TRaSH Guides change)</span><br>• Scoring Sandbox — test how releases score against profiles<br>• TRaSH JSON export — for contributing to TRaSH Guides<br><br><strong style="color:var(--accent-orange);font-size:14px">Most users don\'t need this.</strong> TRaSH Sync handles profiles, scores, and updates automatically. Only enable Advanced Mode if you have a specific need that TRaSH Sync doesn\'t cover.<br><br>Enable Advanced Mode?',
             onConfirm: () => resolve(true),
             onCancel: () => resolve(false)
           };

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -205,7 +205,7 @@ export default {
     setUIScale(value) {
       this.uiScale = value;
       localStorage.setItem('clonarr-ui-scale', value);
-      document.documentElement.style.zoom = value;
+      if (CSS.supports('zoom', '1')) document.documentElement.style.zoom = value;
     },
 
     setTheme(value) {

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -208,6 +208,19 @@ export default {
       document.documentElement.style.zoom = value;
     },
 
+    setTheme(value) {
+      this.theme = value;
+      localStorage.setItem('clonarr-theme', value);
+      this.applyTheme();
+    },
+
+    applyTheme() {
+      const resolved = this.theme === 'system'
+        ? (matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
+        : this.theme;
+      document.documentElement.setAttribute('data-theme', resolved);
+    },
+
     showToast(message, type = 'info', duration = 8000) {
       const id = Date.now() + Math.random();
       this.toasts = [...this.toasts, { id, message, type, duration }];

--- a/ui/static/js/features/quality-sizes.js
+++ b/ui/static/js/features/quality-sizes.js
@@ -84,12 +84,12 @@ export default {
 
     qsCellStyle(appType, trashQS, field) {
       const def = this._findInstanceDef(appType, trashQS.quality);
-      if (!def) return 'color:#aaa';
+      if (!def) return 'color:var(--text-muted)';
       const map = { min: 'minSize', preferred: 'preferredSize', max: 'maxSize' };
       const current = def[map[field]] ?? 0;
       const target = this._qsTargetVal(appType, trashQS, field);
-      if (Math.abs(current - target) < 0.05) return 'color:#3fb950'; // match
-      return 'color:#d29922'; // diff
+      if (Math.abs(current - target) < 0.05) return 'color:var(--accent-green)'; // match
+      return 'color:var(--accent-orange)'; // diff
     },
 
     _qsTargetVal(appType, trashQS, field) {
@@ -111,7 +111,7 @@ export default {
       const allMatch = ['min', 'preferred', 'max'].every(f =>
         Math.abs(this._defFieldVal(def, f) - this._qsTargetVal(appType, qs, f)) < 0.05
       );
-      return allMatch ? '' : 'background:#1c1f26';
+      return allMatch ? '' : 'background:var(--bg-elevated)';
     },
 
     isQSCustom(appType, qualityName) {

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -102,8 +102,10 @@ export function clonarr() {
       this.tt.show = false;
     },
     async init() {
-      // Apply saved UI scale
-      if (this.uiScale !== '1') document.documentElement.style.zoom = this.uiScale;
+      // Apply saved UI scale. `zoom` is a Chromium-original property that
+      // Firefox only added in v126 (May 2024); the CSS.supports guard avoids
+      // a no-op assignment on older Firefox. Modern browsers all support it.
+      if (this.uiScale !== '1' && CSS.supports('zoom', '1')) document.documentElement.style.zoom = this.uiScale;
       // Apply theme. The inline pre-paint script in index.html already set
       // data-theme to avoid FOUC; this re-applies it once Alpine state exists
       // and registers a matchMedia listener so "system" tracks OS changes live.

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -104,6 +104,13 @@ export function clonarr() {
     async init() {
       // Apply saved UI scale
       if (this.uiScale !== '1') document.documentElement.style.zoom = this.uiScale;
+      // Apply theme. The inline pre-paint script in index.html already set
+      // data-theme to avoid FOUC; this re-applies it once Alpine state exists
+      // and registers a matchMedia listener so "system" tracks OS changes live.
+      this.applyTheme();
+      matchMedia('(prefers-color-scheme: light)').addEventListener('change', () => {
+        if (this.theme === 'system') this.applyTheme();
+      });
       // Load the UI manifest first — it carries enum option lists, agent
       // field specs, and category-color tokens that downstream renders need.
       // Awaited so getCategoryClass() / agent modal lookups don't race on

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -365,6 +365,7 @@ export default function baseState() {
     settingsOpen: 'instances',  // legacy accordion (unused after sidebar redesign)
     settingsSection: 'instances',
     uiScale: localStorage.getItem('clonarr-ui-scale') || '1',
+    theme: localStorage.getItem('clonarr-theme') || 'system',
 
     // Scoring Sandbox (per app-type state)
     sandbox: {

--- a/ui/static/partials/layout/footer.html
+++ b/ui/static/partials/layout/footer.html
@@ -1,6 +1,6 @@
 {{define "layout/footer"}}
   <!-- Footer -->
-  <div style="text-align:center;padding:24px 0 8px;font-size:13px;color:#aaa">
-    Clonarr <span x-text="config.version || ''"></span> — Built by <a href="https://github.com/ProphetSe7en" target="_blank" rel="noopener" style="color:#aaa;text-decoration:none">ProphetSe7en</a>
+  <div style="text-align:center;padding:24px 0 8px;font-size:13px;color:var(--text-muted)">
+    Clonarr <span x-text="config.version || ''"></span> — Built by <a href="https://github.com/ProphetSe7en" target="_blank" rel="noopener" style="color:var(--text-muted);text-decoration:none">ProphetSe7en</a>
   </div>
 {{end}}

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -18,11 +18,11 @@
       <template x-if="trashStatus.cloned">
         <span @click="showChangelog = !showChangelog" style="cursor:pointer" x-tt="'Click for changelog'">
           <span class="sync-label">TRaSH synced</span> <span x-text="formatSyncTime(trashStatus.lastPull)"></span>
-          <span class="sync-commit" x-show="trashStatus.commitHash" style="color:#aaa;font-size:12px;margin-left:4px" x-text="trashStatus.commitHash"></span>
+          <span class="sync-commit" x-show="trashStatus.commitHash" style="color:var(--text-muted);font-size:12px;margin-left:4px" x-text="trashStatus.commitHash"></span>
           <span class="sync-next" x-show="config.pullInterval && config.pullInterval !== 'off' && trashStatus.lastPull"
-                style="color:#aaa;font-size:12px;margin-left:6px"
+                style="color:var(--text-muted);font-size:12px;margin-left:6px"
                 x-text="'· next ' + nextPullTime()"></span>
-          <span style="color:#aaa;font-size:12px;margin-left:2px;transition:transform 0.2s;display:inline-block"
+          <span style="color:var(--text-muted);font-size:12px;margin-left:2px;transition:transform 0.2s;display:inline-block"
                 :style="showChangelog ? 'transform:rotate(180deg)' : ''">&#9662;</span>
         </span>
       </template>
@@ -40,40 +40,40 @@
         <!-- Last pull diff -->
         <template x-if="trashStatus.lastDiff">
           <div>
-            <div style="padding:10px 16px 8px;font-size:13px;font-weight:600;color:#e1e4e8;border-bottom:1px solid #21262d;display:flex;justify-content:space-between;align-items:center">
-              <span>Latest Update <span style="font-size:12px;color:#aaa;font-weight:400" x-text="trashStatus.lastDiff.time ? formatSyncTime(trashStatus.lastDiff.time) : ''"></span></span>
-              <span style="font-size:12px;color:#aaa;font-weight:400" x-text="trashStatus.lastDiff.prevCommit + ' → ' + trashStatus.lastDiff.newCommit"></span>
+            <div style="padding:10px 16px 8px;font-size:13px;font-weight:600;color:var(--text-primary);border-bottom:1px solid var(--bg-muted);display:flex;justify-content:space-between;align-items:center">
+              <span>Latest Update <span style="font-size:12px;color:var(--text-muted);font-weight:400" x-text="trashStatus.lastDiff.time ? formatSyncTime(trashStatus.lastDiff.time) : ''"></span></span>
+              <span style="font-size:12px;color:var(--text-muted);font-weight:400" x-text="trashStatus.lastDiff.prevCommit + ' → ' + trashStatus.lastDiff.newCommit"></span>
             </div>
-            <div style="padding:10px 16px;border-bottom:1px solid #30363d;font-size:12px;color:#c9d1d9;white-space:pre-line;line-height:1.6"
+            <div style="padding:10px 16px;border-bottom:1px solid var(--border-subtle);font-size:12px;color:var(--text-body);white-space:pre-line;line-height:1.6"
                  x-text="trashStatus.lastDiff.summary.replace(/\*\*/g, '').replace(/^\n/, '')"></div>
           </div>
         </template>
 
         <!-- TRaSH Changelog (updates.txt) -->
-        <div style="padding:10px 16px 8px;font-size:13px;font-weight:600;color:#e1e4e8;border-bottom:1px solid #21262d;display:flex;justify-content:space-between;align-items:center">
+        <div style="padding:10px 16px 8px;font-size:13px;font-weight:600;color:var(--text-primary);border-bottom:1px solid var(--bg-muted);display:flex;justify-content:space-between;align-items:center">
           TRaSH Changelog
-          <span style="font-size:12px;color:#aaa;font-weight:400">from updates.txt</span>
+          <span style="font-size:12px;color:var(--text-muted);font-weight:400">from updates.txt</span>
         </div>
         <template x-if="!trashStatus.changelog || trashStatus.changelog.length === 0">
-          <div style="padding:16px;font-size:12px;color:#aaa;text-align:center">No changelog available</div>
+          <div style="padding:16px;font-size:12px;color:var(--text-muted);text-align:center">No changelog available</div>
         </template>
         <template x-for="section in (trashStatus.changelog || [])" :key="section.date">
-          <div style="padding:10px 16px;border-bottom:1px solid #21262d">
-            <div style="font-size:13px;font-weight:600;color:#aaa;margin-bottom:6px;display:flex;justify-content:space-between">
+          <div style="padding:10px 16px;border-bottom:1px solid var(--bg-muted)">
+            <div style="font-size:13px;font-weight:600;color:var(--text-muted);margin-bottom:6px;display:flex;justify-content:space-between">
               <span x-text="formatChangelogDate(section.date)"></span>
-              <span style="color:#aaa;font-weight:400" x-text="section.entries.length + (section.entries.length === 1 ? ' change' : ' changes')"></span>
+              <span style="color:var(--text-muted);font-weight:400" x-text="section.entries.length + (section.entries.length === 1 ? ' change' : ' changes')"></span>
             </div>
             <template x-for="entry in section.entries" :key="entry.pr || entry.msg">
               <div style="display:flex;align-items:flex-start;gap:8px;padding:3px 0;font-size:12px;line-height:1.4">
                 <span style="font-size:12px;font-weight:600;padding:1px 6px;border-radius:3px;flex-shrink:0;margin-top:1px"
-                      :style="entry.type === 'feat' ? 'background:#1b3a2a;color:#3fb950' : entry.type === 'fix' ? 'background:#3d2e0a;color:#d29922' : 'background:#1c2333;color:#58a6ff'"
+                      :style="entry.type === 'feat' ? 'background:var(--badge-feat-bg);color:var(--accent-green)' : entry.type === 'fix' ? 'background:var(--accent-orange-bg);color:var(--accent-orange)' : 'background:var(--bg-panel);color:var(--accent-blue)'"
                       x-text="entry.type"></span>
                 <span>
-                  <span style="color:#aaa" x-text="entry.scope + ':'"></span>
-                  <span style="color:#c9d1d9" x-text="entry.msg"></span>
+                  <span style="color:var(--text-muted)" x-text="entry.scope + ':'"></span>
+                  <span style="color:var(--text-body)" x-text="entry.msg"></span>
                   <a x-show="entry.pr" :href="'https://github.com/TRaSH-Guides/Guides/pull/' + entry.pr"
-                     target="_blank" rel="noopener" style="color:#aaa;font-size:12px;text-decoration:none;margin-left:4px"
-                     @mouseenter="$el.style.color='#58a6ff'" @mouseleave="$el.style.color='#aaa'"
+                     target="_blank" rel="noopener" style="color:var(--text-muted);font-size:12px;text-decoration:none;margin-left:4px"
+                     @mouseenter="$el.style.color='var(--accent-blue)'" @mouseleave="$el.style.color='var(--text-muted)'"
                      x-text="'#' + entry.pr"></a>
                 </span>
               </div>
@@ -85,7 +85,7 @@
     <!-- User menu: username + logout when authenticated, "Local" badge when
          reaching via Trusted-Networks bypass, nothing when auth=none. -->
     <div x-show="authStatus.authenticated || authStatus.localBypass" x-cloak
-         style="margin-left:12px;display:flex;align-items:center;gap:8px;font-size:12px;color:#8b949e">
+         style="margin-left:12px;display:flex;align-items:center;gap:8px;font-size:12px;color:var(--text-secondary)">
       <template x-if="authStatus.authenticated">
         <div style="display:flex;align-items:center;gap:8px">
           <span x-text="authStatus.username" x-tt="'Logged in as ' + authStatus.username"
@@ -97,7 +97,7 @@
         </div>
       </template>
       <template x-if="!authStatus.authenticated && authStatus.localBypass">
-        <span style="background:#1a2f45;color:#58a6ff;padding:3px 8px;border-radius:10px;font-size:10px;font-weight:500;letter-spacing:0.3px;border:1px solid #1f3b5a"
+        <span style="background:var(--fill-blue-dark);color:var(--accent-blue);padding:3px 8px;border-radius:10px;font-size:10px;font-weight:500;letter-spacing:0.3px;border:1px solid var(--fill-blue-dark)"
               x-tt="'Local network — authentication bypassed for this network'">Local</span>
       </template>
     </div>
@@ -106,12 +106,12 @@
   <!-- No-auth warning banner — dismissible per-browser via localStorage.
        Server logs a warning every 60s regardless of dismissal. -->
   <div x-show="authStatus.authentication === 'none' && !noAuthBannerDismissed" x-cloak
-       style="background:#5a1f1f;border-bottom:2px solid #8b2d2d;color:#ffdada;padding:10px 16px;display:flex;align-items:center;gap:12px;font-size:13px;font-weight:500">
+       style="background:var(--banner-warn-bg);border-bottom:2px solid var(--banner-warn-border);color:var(--banner-warn-text);padding:10px 16px;display:flex;align-items:center;gap:12px;font-size:13px;font-weight:500">
     <span style="flex:1;text-align:center">
       ⚠️ Authentication is disabled — anyone who reaches this URL is admin. Set Authentication to Forms or Basic in <strong>Settings → Security</strong>, or make sure another auth layer (reverse proxy, firewall) is in front.
     </span>
     <button @click="dismissNoAuthBanner()" x-tt="'Hide on this device'"
-            style="background:rgba(255,255,255,0.12);color:#ffdada;border:1px solid rgba(255,218,218,0.3);padding:4px 10px;border-radius:4px;font-size:11px;cursor:pointer">
+            style="background:rgba(255,255,255,0.12);color:var(--banner-warn-text);border:1px solid rgba(255,218,218,0.3);padding:4px 10px;border-radius:4px;font-size:11px;cursor:pointer">
       Dismiss
     </button>
   </div>

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -111,7 +111,7 @@
       ⚠️ Authentication is disabled — anyone who reaches this URL is admin. Set Authentication to Forms or Basic in <strong>Settings → Security</strong>, or make sure another auth layer (reverse proxy, firewall) is in front.
     </span>
     <button @click="dismissNoAuthBanner()" x-tt="'Hide on this device'"
-            style="background:rgba(255,255,255,0.12);color:var(--banner-warn-text);border:1px solid rgba(255,218,218,0.3);padding:4px 10px;border-radius:4px;font-size:11px;cursor:pointer">
+            style="background:color-mix(in srgb, var(--banner-warn-text) 12%, transparent);color:var(--banner-warn-text);border:1px solid color-mix(in srgb, var(--banner-warn-text) 30%, transparent);padding:4px 10px;border-radius:4px;font-size:11px;cursor:pointer">
       Dismiss
     </button>
   </div>

--- a/ui/static/partials/modals/backup-instance.html
+++ b/ui/static/partials/modals/backup-instance.html
@@ -3,7 +3,7 @@
   <div class="modal-overlay" x-show="showBackupModal" @click.self="showBackupModal = false" x-cloak>
     <div class="modal" style="max-width:600px">
       <div class="modal-title">Backup Instance</div>
-      <div style="font-size:12px;color:#aaa;margin-bottom:12px" x-text="backupInstance?.name || ''"></div>
+      <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px" x-text="backupInstance?.name || ''"></div>
 
       <template x-if="backupLoading && backupProfiles.length === 0 && backupCFs.length === 0">
         <div style="text-align:center;padding:20px"><span class="spinner"></span></div>
@@ -12,15 +12,15 @@
       <!-- Step 1: Choose backup mode -->
       <template x-if="backupStep === 'mode' && (backupProfiles.length > 0 || backupCFs.length > 0)">
         <div>
-          <div style="font-size:13px;font-weight:600;color:#e1e4e8;margin-bottom:12px">What do you want to backup?</div>
+          <div style="font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:12px">What do you want to backup?</div>
           <div style="display:flex;flex-direction:column;gap:8px">
             <button class="btn" style="text-align:left;padding:12px 16px" @click="backupMode = 'profiles'; backupStep = 'profiles'">
-              <div style="font-weight:600;color:#e1e4e8">Profiles + Custom Formats</div>
-              <div style="font-size:13px;color:#aaa;margin-top:2px">Select profiles — associated CFs with scores are auto-included</div>
+              <div style="font-weight:600;color:var(--text-primary)">Profiles + Custom Formats</div>
+              <div style="font-size:13px;color:var(--text-muted);margin-top:2px">Select profiles — associated CFs with scores are auto-included</div>
             </button>
             <button class="btn" style="text-align:left;padding:12px 16px" @click="backupMode = 'cfs-only'; backupStep = 'cfs-select'">
-              <div style="font-weight:600;color:#e1e4e8">Custom Formats Only</div>
-              <div style="font-size:13px;color:#aaa;margin-top:2px">Select individual CF definitions — no profiles or scores</div>
+              <div style="font-weight:600;color:var(--text-primary)">Custom Formats Only</div>
+              <div style="font-size:13px;color:var(--text-muted);margin-top:2px">Select individual CF definitions — no profiles or scores</div>
             </button>
           </div>
           <div class="modal-actions">
@@ -32,17 +32,17 @@
       <!-- Profile mode: Step 2a — Select profiles -->
       <template x-if="backupStep === 'profiles' && backupProfiles.length > 0">
         <div>
-          <div style="font-size:13px;font-weight:600;color:#e1e4e8;margin-bottom:8px">Select Profiles</div>
+          <div style="font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:8px">Select Profiles</div>
           <div style="display:flex;gap:8px;margin-bottom:10px">
             <button class="btn btn-sm" @click="backupProfiles.forEach(p => backupSelectedProfiles[p.id] = true)">Select All</button>
             <button class="btn btn-sm" @click="backupSelectedProfiles = {}">Deselect All</button>
           </div>
-          <div style="max-height:300px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+          <div style="max-height:300px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
             <template x-for="p in backupProfiles" :key="p.id">
-              <label style="display:flex;align-items:center;gap:8px;padding:8px 12px;border-bottom:1px solid #21262d;cursor:pointer;font-size:13px;color:#c9d1d9">
+              <label style="display:flex;align-items:center;gap:8px;padding:8px 12px;border-bottom:1px solid var(--bg-muted);cursor:pointer;font-size:13px;color:var(--text-body)">
                 <input type="checkbox" :checked="backupSelectedProfiles[p.id]" @change="backupSelectedProfiles[p.id] = $el.checked">
                 <span x-text="p.name"></span>
-                <span style="margin-left:auto;font-size:13px;color:#aaa" x-text="p.formatItems.filter(fi => fi.score !== 0).length + ' scored CFs'"></span>
+                <span style="margin-left:auto;font-size:13px;color:var(--text-muted)" x-text="p.formatItems.filter(fi => fi.score !== 0).length + ' scored CFs'"></span>
               </label>
             </template>
           </div>
@@ -58,18 +58,18 @@
       <!-- Profile mode: Step 2b — Select CFs -->
       <template x-if="backupStep === 'cfs'">
         <div>
-          <div style="font-size:13px;font-weight:600;color:#e1e4e8;margin-bottom:4px">Custom Formats</div>
-          <div style="font-size:12px;color:#aaa;margin-bottom:12px">
+          <div style="font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:4px">Custom Formats</div>
+          <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px">
             CFs with non-zero scores in selected profiles are auto-included. Optionally select additional score=0 CFs (info/naming CFs).
           </div>
 
           <!-- Auto-included CFs -->
           <template x-if="Object.keys(backupScoredCFs).length > 0">
             <div style="margin-bottom:12px">
-              <div style="font-size:12px;font-weight:600;color:#3fb950;margin-bottom:6px" x-text="'Auto-included (' + Object.keys(backupScoredCFs).length + ' CFs with scores)'"></div>
-              <div style="max-height:150px;overflow-y:auto;border:1px solid #21262d;border-radius:6px;background:#0d1117">
+              <div style="font-size:12px;font-weight:600;color:var(--accent-green);margin-bottom:6px" x-text="'Auto-included (' + Object.keys(backupScoredCFs).length + ' CFs with scores)'"></div>
+              <div style="max-height:150px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px;background:var(--bg-page)">
                 <template x-for="cf in backupCFs.filter(c => backupScoredCFs[c.id])" :key="cf.id">
-                  <div style="padding:4px 12px;font-size:12px;color:#aaa;border-bottom:1px solid #161b22" x-text="cf.name"></div>
+                  <div style="padding:4px 12px;font-size:12px;color:var(--text-muted);border-bottom:1px solid var(--bg-card)" x-text="cf.name"></div>
                 </template>
               </div>
             </div>
@@ -79,13 +79,13 @@
           <template x-if="backupCFs.filter(c => !backupScoredCFs[c.id]).length > 0">
             <div>
               <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px">
-                <div style="font-size:12px;font-weight:600;color:#d29922" x-text="'Optional (' + backupCFs.filter(c => !backupScoredCFs[c.id]).length + ' CFs with score 0)'"></div>
+                <div style="font-size:12px;font-weight:600;color:var(--accent-orange)" x-text="'Optional (' + backupCFs.filter(c => !backupScoredCFs[c.id]).length + ' CFs with score 0)'"></div>
                 <button class="btn btn-sm" style="font-size:12px;padding:2px 6px" @click="backupCFs.filter(c => !backupScoredCFs[c.id]).forEach(c => backupSelectedCFs[c.id] = true)">Select All</button>
                 <button class="btn btn-sm" style="font-size:12px;padding:2px 6px" @click="backupSelectedCFs = {}">Deselect All</button>
               </div>
-              <div style="max-height:200px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+              <div style="max-height:200px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
                 <template x-for="cf in backupCFs.filter(c => !backupScoredCFs[c.id])" :key="cf.id">
-                  <label style="display:flex;align-items:center;gap:8px;padding:4px 12px;border-bottom:1px solid #21262d;cursor:pointer;font-size:12px;color:#c9d1d9">
+                  <label style="display:flex;align-items:center;gap:8px;padding:4px 12px;border-bottom:1px solid var(--bg-muted);cursor:pointer;font-size:12px;color:var(--text-body)">
                     <input type="checkbox" :checked="backupSelectedCFs[cf.id]" @change="backupSelectedCFs[cf.id] = $el.checked">
                     <span x-text="cf.name"></span>
                   </label>
@@ -107,14 +107,14 @@
       <!-- CF-only mode: Select CFs -->
       <template x-if="backupStep === 'cfs-select'">
         <div>
-          <div style="font-size:13px;font-weight:600;color:#e1e4e8;margin-bottom:8px">Select Custom Formats</div>
+          <div style="font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:8px">Select Custom Formats</div>
           <div style="display:flex;gap:8px;margin-bottom:10px">
             <button class="btn btn-sm" @click="backupCFs.forEach(c => backupSelectedCFs[c.id] = true)">Select All</button>
             <button class="btn btn-sm" @click="backupSelectedCFs = {}">Deselect All</button>
           </div>
-          <div style="max-height:350px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+          <div style="max-height:350px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
             <template x-for="cf in backupCFs" :key="cf.id">
-              <label style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid #21262d;cursor:pointer;font-size:12px;color:#c9d1d9">
+              <label style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid var(--bg-muted);cursor:pointer;font-size:12px;color:var(--text-body)">
                 <input type="checkbox" :checked="backupSelectedCFs[cf.id]" @change="backupSelectedCFs[cf.id] = $el.checked">
                 <span x-text="cf.name"></span>
               </label>

--- a/ui/static/partials/modals/cf-editor.html
+++ b/ui/static/partials/modals/cf-editor.html
@@ -13,19 +13,19 @@
             <input class="input" x-model="cfEditorForm.name" placeholder="My Custom Format" style="padding-right:30px">
             <span x-show="cfEditorTrashMatch"
                   x-tt="'Also in TRaSH guide — you can still save.'"
-                  style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:#3a2d10;color:#e3b341;border:1px solid #d29922;border-radius:3px;padding:1px 6px;font-size:11px;font-weight:600;cursor:help;user-select:none">
+                  style="position:absolute;right:8px;top:50%;transform:translateY(-50%);background:var(--accent-orange-bg);color:var(--cat-hq-release-groups);border:1px solid var(--accent-orange);border-radius:3px;padding:1px 6px;font-size:11px;font-weight:600;cursor:help;user-select:none">
               ⚠ guide
             </span>
           </div>
-          <div style="font-size:12px;color:#8b949e;margin-top:4px;line-height:1.4">
+          <div style="font-size:12px;color:var(--text-secondary);margin-top:4px;line-height:1.4">
             Sonarr/Radarr require unique CF names within an app, so this can't match another custom CF you already have. Names are case-sensitive (Arr's own rule), so <code>PCOK</code> and <code>Pcok</code> are distinct.
           </div>
         </div>
         <div class="form-group" style="margin-bottom:0">
           <label>App Type</label>
-          <div class="input" style="background:#161b22;cursor:default;text-transform:capitalize;display:flex;align-items:center;gap:6px">
+          <div class="input" style="background:var(--bg-card);cursor:default;text-transform:capitalize;display:flex;align-items:center;gap:6px">
             <span style="width:8px;height:8px;border-radius:50%;flex-shrink:0"
-                  :style="cfEditorForm.appType === 'radarr' ? 'background:#f5c518' : 'background:#58a6ff'"></span>
+                  :style="cfEditorForm.appType === 'radarr' ? 'background:var(--accent-orange)' : 'background:var(--accent-blue)'"></span>
             <span x-text="cfEditorForm.appType"></span>
           </div>
         </div>
@@ -55,7 +55,7 @@
         </div>
         <div class="form-group" style="margin-bottom:0">
           <label>Include in Rename</label>
-          <label style="display:flex;align-items:center;gap:6px;cursor:pointer;margin-top:4px;color:#c9d1d9;font-size:13px">
+          <label style="display:flex;align-items:center;gap:6px;cursor:pointer;margin-top:4px;color:var(--text-body);font-size:13px">
             <input type="checkbox" x-model="cfEditorForm.includeInRename"> Yes
           </label>
         </div>
@@ -64,8 +64,8 @@
       <!-- Specifications -->
       <div style="margin-bottom:16px">
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
-          <label style="font-size:12px;color:#aaa;font-weight:600">Specifications</label>
-          <button class="btn btn-sm" style="background:#238636;color:#fff" @click="addCFSpec()">+ Add Spec</button>
+          <label style="font-size:12px;color:var(--text-muted);font-weight:600">Specifications</label>
+          <button class="btn btn-sm" style="background:var(--accent-green-strong);color:var(--text-on-accent)" @click="addCFSpec()">+ Add Spec</button>
         </div>
 
         <div x-show="cfEditorSchemaLoading" style="text-align:center;padding:12px">
@@ -73,21 +73,21 @@
         </div>
 
         <template x-if="cfEditorForm.specifications.length === 0 && !cfEditorSchemaLoading">
-          <div style="font-size:12px;color:#aaa;padding:16px;text-align:center;border:1px dashed #30363d;border-radius:6px">
+          <div style="font-size:12px;color:var(--text-muted);padding:16px;text-align:center;border:1px dashed var(--border-subtle);border-radius:6px">
             No specifications yet. Click "Add Spec" to add a matching rule.
           </div>
         </template>
 
         <template x-for="(spec, specIdx) in cfEditorForm.specifications" :key="spec._key">
-          <div style="border:1px solid #30363d;border-radius:6px;padding:12px;margin-bottom:8px;background:#0d1117">
+          <div style="border:1px solid var(--border-subtle);border-radius:6px;padding:12px;margin-bottom:8px;background:var(--bg-page)">
             <!-- Spec header row -->
             <div style="display:grid;grid-template-columns:1fr 1fr auto;gap:8px;margin-bottom:8px">
               <div>
-                <label style="font-size:13px;color:#aaa;display:block;margin-bottom:2px">Spec Name</label>
+                <label style="font-size:13px;color:var(--text-muted);display:block;margin-bottom:2px">Spec Name</label>
                 <input class="input" x-model="spec.name" placeholder="Rule name" style="font-size:12px;padding:4px 8px">
               </div>
               <div>
-                <label style="font-size:13px;color:#aaa;display:block;margin-bottom:2px">Type</label>
+                <label style="font-size:13px;color:var(--text-muted);display:block;margin-bottom:2px">Type</label>
                 <select class="input"
                         x-effect="populateImplSelect($el, spec.implementation)"
                         @change="spec.implementation = $el.value; onSpecTypeChange(specIdx)"
@@ -96,20 +96,20 @@
                 </select>
               </div>
               <div style="display:flex;align-items:flex-end">
-                <button class="btn btn-sm" style="color:#f85149;padding:4px 8px" @click="cfEditorForm.specifications.splice(specIdx, 1)" x-tt="'Remove spec'">&#10005;</button>
+                <button class="btn btn-sm" style="color:var(--accent-red);padding:4px 8px" @click="cfEditorForm.specifications.splice(specIdx, 1)" x-tt="'Remove spec'">&#10005;</button>
               </div>
             </div>
 
             <!-- Toggles row -->
             <div style="display:flex;gap:16px;margin-bottom:8px">
-              <label style="display:flex;align-items:center;gap:4px;font-size:12px;color:#aaa;cursor:pointer">
+              <label style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-muted);cursor:pointer">
                 <input type="checkbox" x-model="spec.required">
-                <span :style="spec.required ? 'color:#3fb950;font-weight:600' : ''">Required</span>
-                <span style="font-size:12px;color:#aaa" x-text="spec.required ? '(AND)' : '(OR)'"></span>
+                <span :style="spec.required ? 'color:var(--accent-green);font-weight:600' : ''">Required</span>
+                <span style="font-size:12px;color:var(--text-muted)" x-text="spec.required ? '(AND)' : '(OR)'"></span>
               </label>
-              <label style="display:flex;align-items:center;gap:4px;font-size:12px;color:#aaa;cursor:pointer">
+              <label style="display:flex;align-items:center;gap:4px;font-size:12px;color:var(--text-muted);cursor:pointer">
                 <input type="checkbox" x-model="spec.negate">
-                <span :style="spec.negate ? 'color:#d29922;font-weight:600' : ''">Negate</span>
+                <span :style="spec.negate ? 'color:var(--accent-orange);font-weight:600' : ''">Negate</span>
               </label>
             </div>
 
@@ -118,7 +118,7 @@
               <div>
                 <template x-for="(field, fieldIdx) in spec.fields" :key="field.name">
                   <div style="margin-bottom:6px">
-                    <label style="font-size:13px;color:#aaa;display:block;margin-bottom:2px" x-text="field.label || field.name"></label>
+                    <label style="font-size:13px;color:var(--text-muted);display:block;margin-bottom:2px" x-text="field.label || field.name"></label>
                     <!-- Text input (regex, release group, etc.) -->
                     <template x-if="field.type === 'textbox'">
                       <input class="input" x-model="field.value" :placeholder="field.placeholder || ''" style="font-size:12px;padding:4px 8px;font-family:monospace">
@@ -136,7 +136,7 @@
                     </template>
                     <!-- Checkbox (exceptLanguage, etc.) -->
                     <template x-if="field.type === 'checkbox'">
-                      <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:#c9d1d9">
+                      <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:12px;color:var(--text-body)">
                         <input type="checkbox" x-model="field.value"> <span x-text="field.label || field.name"></span>
                       </label>
                     </template>
@@ -150,15 +150,15 @@
 
       <!-- Logic display -->
       <template x-if="cfEditorForm.specifications.length > 0">
-        <div style="margin-bottom:16px;padding:8px 12px;background:#0d1117;border:1px solid #30363d;border-radius:6px">
-          <label style="font-size:13px;color:#aaa;display:block;margin-bottom:4px">Match Logic</label>
+        <div style="margin-bottom:16px;padding:8px 12px;background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px">
+          <label style="font-size:13px;color:var(--text-muted);display:block;margin-bottom:4px">Match Logic</label>
           <template x-for="(spec, si) in cfEditorForm.specifications" :key="spec._key">
             <div style="font-size:12px;display:flex;align-items:center;gap:6px;padding:2px 0">
-              <span x-show="spec.required" style="background:#238636;color:#fff;font-size:12px;padding:1px 5px;border-radius:3px">Required</span>
-              <span x-show="spec.negate" style="background:#d29922;color:#000;font-size:12px;padding:1px 5px;border-radius:3px">NOT</span>
-              <span style="color:#c9d1d9" x-text="spec.name || '(unnamed)'"></span>
-              <span style="color:#aaa;font-size:13px" x-text="'(' + (spec.implementation ? spec.implementation.replace('Specification','') : '?') + ')'"></span>
-              <span style="color:#aaa;font-size:12px;margin-left:auto" x-text="spec.required ? 'AND' : 'OR'"></span>
+              <span x-show="spec.required" style="background:var(--accent-green-strong);color:var(--text-on-accent);font-size:12px;padding:1px 5px;border-radius:3px">Required</span>
+              <span x-show="spec.negate" style="background:var(--accent-orange);color:var(--text-inverse);font-size:12px;padding:1px 5px;border-radius:3px">NOT</span>
+              <span style="color:var(--text-body)" x-text="spec.name || '(unnamed)'"></span>
+              <span style="color:var(--text-muted);font-size:13px" x-text="'(' + (spec.implementation ? spec.implementation.replace('Specification','') : '?') + ')'"></span>
+              <span style="color:var(--text-muted);font-size:12px;margin-left:auto" x-text="spec.required ? 'AND' : 'OR'"></span>
             </div>
           </template>
         </div>
@@ -166,8 +166,8 @@
 
       <!-- TRaSH schema fields — gated by CLONARR_DEV_FEATURES env + trashSchemaFields toggle. -->
       <template x-if="config.devFeatures && config.trashSchemaFields">
-        <div style="border:1px solid #30363d;border-radius:6px;padding:12px;margin-bottom:16px;background:#1c1c24">
-          <div style="font-size:12px;color:#d29922;font-weight:600;margin-bottom:8px">TRaSH schema fields</div>
+        <div style="border:1px solid var(--border-subtle);border-radius:6px;padding:12px;margin-bottom:16px;background:var(--bg-card)">
+          <div style="font-size:12px;color:var(--accent-orange);font-weight:600;margin-bottom:8px">TRaSH schema fields</div>
           <div class="form-group">
             <label>Trash ID</label>
             <div style="display:flex;gap:8px">
@@ -177,7 +177,7 @@
           </div>
           <div class="form-group">
             <label>Trash Scores</label>
-            <div style="border:1px solid #30363d;border-radius:4px;padding:8px">
+            <div style="border:1px solid var(--border-subtle);border-radius:4px;padding:8px">
               <template x-for="(ts, tsIdx) in cfEditorForm.trashScores" :key="ts._key || tsIdx">
                 <div style="display:flex;gap:8px;align-items:center;margin-bottom:4px">
                   <select class="input" x-model="ts.context" style="flex:1;font-size:12px;padding:3px 6px">
@@ -186,7 +186,7 @@
                     </template>
                   </select>
                   <input class="input" type="number" x-model.number="ts.score" style="width:80px;font-size:12px;padding:3px 6px" placeholder="0">
-                  <button class="btn btn-sm" style="color:#f85149;padding:2px 6px" @click="cfEditorForm.trashScores.splice(tsIdx, 1)">&#10005;</button>
+                  <button class="btn btn-sm" style="color:var(--accent-red);padding:2px 6px" @click="cfEditorForm.trashScores.splice(tsIdx, 1)">&#10005;</button>
                 </div>
               </template>
               <button class="btn btn-sm" style="margin-top:4px" @click="cfEditorForm.trashScores.push({_key: Date.now(), context:'default',score:0})">+ Add context</button>
@@ -201,26 +201,26 @@
 
       <!-- JSON Preview (collapsible) -->
       <div style="margin-bottom:16px">
-        <div style="font-size:12px;color:#58a6ff;cursor:pointer;user-select:none" @click="cfEditorShowPreview = !cfEditorShowPreview">
+        <div style="font-size:12px;color:var(--accent-blue);cursor:pointer;user-select:none" @click="cfEditorShowPreview = !cfEditorShowPreview">
           <span x-text="cfEditorShowPreview ? '▼' : '▶'"></span> JSON Preview
         </div>
         <div x-show="cfEditorShowPreview" style="margin-top:4px">
-          <pre style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:8px 12px;font-size:13px;color:#aaa;max-height:200px;overflow:auto;white-space:pre-wrap" x-text="getCFEditorPreviewJSON()"></pre>
+          <pre style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:8px 12px;font-size:13px;color:var(--text-muted);max-height:200px;overflow:auto;white-space:pre-wrap" x-text="getCFEditorPreviewJSON()"></pre>
         </div>
       </div>
 
       <!-- Result message -->
       <div x-show="cfEditorResult" style="margin-bottom:12px;font-size:12px;padding:8px 12px;border-radius:6px"
-           :style="cfEditorResult?.error ? 'background:#3d1f1f;color:#f85149' : 'background:#1f3d1f;color:#3fb950'"
+           :style="cfEditorResult?.error ? 'background:var(--accent-red-bg);color:var(--accent-red)' : 'background:var(--accent-green-bg);color:var(--accent-green)'"
            x-text="cfEditorResult?.message"></div>
 
       <!-- Footer actions -->
       <div class="modal-actions" style="flex-wrap:wrap">
         <template x-if="cfEditorMode === 'edit'">
-          <button class="btn" style="color:#f85149;margin-right:auto" @click="deleteCFFromEditor()">Delete</button>
+          <button class="btn" style="color:var(--accent-red);margin-right:auto" @click="deleteCFFromEditor()">Delete</button>
         </template>
         <template x-if="config.devFeatures && config.trashSchemaFields">
-          <button class="btn" style="color:#d29922" @click="exportTrashJSON()">Export TRaSH JSON</button>
+          <button class="btn" style="color:var(--accent-orange)" @click="exportTrashJSON()">Export TRaSH JSON</button>
         </template>
         <button class="btn" @click="showCFEditor = false">Cancel</button>
         <button class="btn btn-primary" @click="saveCFEditor()" :disabled="cfEditorSaving || !cfEditorForm.name.trim()">

--- a/ui/static/partials/modals/cf-export.html
+++ b/ui/static/partials/modals/cf-export.html
@@ -3,15 +3,15 @@
   <div class="modal-overlay" x-show="cfExportContent" @click.self="cfExportContent = ''" x-cloak>
     <div class="modal" style="max-width:700px">
       <div class="modal-title">Export TRaSH JSON</div>
-      <div style="font-size:12px;color:#aaa;margin-bottom:16px">
+      <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
         TRaSH Guides format — use this to share custom formats or contribute to the guides.
       </div>
       <div style="position:relative">
-        <pre style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px 16px;font-size:13px;font-family:monospace;color:#c9d1d9;max-height:400px;overflow:auto;white-space:pre;margin:0;line-height:1.5"><code x-text="cfExportContent"></code></pre>
+        <pre style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px 16px;font-size:13px;font-family:monospace;color:var(--text-body);max-height:400px;overflow:auto;white-space:pre;margin:0;line-height:1.5"><code x-text="cfExportContent"></code></pre>
         <button class="btn btn-sm" style="position:absolute;top:8px;right:8px;font-size:13px"
                 @click="copyToClipboard(cfExportContent); cfExportCopied = true; setTimeout(() => cfExportCopied = false, 2000)">
           <span x-show="!cfExportCopied">Copy</span>
-          <span x-show="cfExportCopied" style="color:#3fb950">Copied!</span>
+          <span x-show="cfExportCopied" style="color:var(--accent-green)">Copied!</span>
         </button>
       </div>
       <div class="modal-actions" style="margin-top:16px">

--- a/ui/static/partials/modals/cleanup-result.html
+++ b/ui/static/partials/modals/cleanup-result.html
@@ -12,8 +12,8 @@
           <template x-if="cleanupResult.applied === true">
             <div style="text-align:center;padding:24px">
               <div style="font-size:32px;margin-bottom:8px">&#10003;</div>
-              <div style="color:#3fb950;font-size:15px;font-weight:600;margin-bottom:12px">Cleanup Complete</div>
-              <div style="font-size:13px;color:#aaa">
+              <div style="color:var(--accent-green);font-size:15px;font-weight:600;margin-bottom:12px">Cleanup Complete</div>
+              <div style="font-size:13px;color:var(--text-muted)">
                 <template x-for="[k,v] in Object.entries(cleanupResult.applyResult)" :key="k">
                   <div x-text="k + ': ' + v" style="margin:2px 0"></div>
                 </template>
@@ -23,7 +23,7 @@
           <!-- Apply error -->
           <template x-if="cleanupResult.applied === false">
             <div style="padding:16px">
-              <div style="padding:10px;background:#3d1b1b;border:1px solid #f85149;border-radius:6px;font-size:13px;color:#f85149">
+              <div style="padding:10px;background:var(--accent-red-bg);border:1px solid var(--accent-red);border-radius:6px;font-size:13px;color:var(--accent-red)">
                 Apply failed: <span x-text="cleanupResult.applyError"></span>
               </div>
             </div>
@@ -32,15 +32,15 @@
           <template x-if="cleanupResult.applied === undefined">
             <div>
               <template x-if="cleanupResult.affectCount === 0">
-                <div style="text-align:center;padding:24px;color:#3fb950;font-size:14px">Nothing to clean up — all clear.</div>
+                <div style="text-align:center;padding:24px;color:var(--accent-green);font-size:14px">Nothing to clean up — all clear.</div>
               </template>
               <template x-if="cleanupResult.affectCount > 0">
                 <div>
                   <!-- Summary for delete-all operations -->
                   <template x-if="['delete-cfs-and-scores','delete-cfs-keep-scores'].includes(cleanupResult.action)">
                     <div style="text-align:center;padding:20px 16px">
-                      <div style="font-size:36px;margin-bottom:8px;color:#d29922">&#9888;</div>
-                      <div style="font-size:15px;color:#e1e4e8;margin-bottom:4px">
+                      <div style="font-size:36px;margin-bottom:8px;color:var(--accent-orange)">&#9888;</div>
+                      <div style="font-size:15px;color:var(--text-primary);margin-bottom:4px">
                         <strong x-text="cleanupResult.affectCount"></strong> <span x-text="cleanupResult.affectCount === 1 ? 'custom format' : 'custom formats'"></span> will be deleted
                       </div>
                     </div>
@@ -48,26 +48,26 @@
                   <!-- Detailed list for scan operations -->
                   <template x-if="!['delete-cfs-and-scores','delete-cfs-keep-scores'].includes(cleanupResult.action)">
                     <div>
-                      <div style="font-size:13px;color:#e1e4e8;margin-bottom:12px">
+                      <div style="font-size:13px;color:var(--text-primary);margin-bottom:12px">
                         Found <strong x-text="cleanupResult.affectCount"></strong> unmanaged items out of <span x-text="cleanupResult.totalCount"></span> total CFs.
                         <template x-if="cleanupResult.action === 'unused-by-clonarr' && cleanupResult.items.some(i => i.renamingFlag)">
-                          <span style="color:#aaa">
+                          <span style="color:var(--text-muted)">
                             (<span x-text="cleanupResult.items.filter(i => i.renamingFlag).length"></span> tagged for filename rendering — see info below)
                           </span>
                         </template>
                       </div>
                       <template x-if="cleanupResult.action === 'unused-by-clonarr' && cleanupResult.namingUsesCustomFormats && cleanupResult.items.some(i => i.renamingFlag)">
-                        <div style="margin-bottom:12px;padding:12px 14px;background:#0f2238;border:1px solid #2a4d7a;border-radius:6px;font-size:13px;color:#b3c7dc;line-height:1.6">
-                          <div style="font-weight:600;color:#79b8ff;margin-bottom:6px;font-size:14px">ⓘ About filename-rendering CFs</div>
-                          Your file naming format on this instance contains <code style="background:#161b22;padding:1px 5px;border-radius:3px;font-size:12px">{Custom Formats}</code>.
-                          The CFs marked <span style="background:#2d2410;border:1px solid #d29922;color:#e3b341;padding:1px 6px;border-radius:3px;font-size:12px;font-weight:500">rename tag</span> below contribute their names to filenames Radarr/Sonarr renders after import (e.g. <code style="background:#161b22;padding:1px 5px;border-radius:3px;font-size:12px">[AMZN]</code>, <code style="background:#161b22;padding:1px 5px;border-radius:3px;font-size:12px">[v2]</code>).
+                        <div style="margin-bottom:12px;padding:12px 14px;background:var(--fill-blue-soft);border:1px solid var(--fill-blue-dark);border-radius:6px;font-size:13px;color:var(--accent-sky);line-height:1.6">
+                          <div style="font-weight:600;color:var(--accent-sky);margin-bottom:6px;font-size:14px">ⓘ About filename-rendering CFs</div>
+                          Your file naming format on this instance contains <code style="background:var(--bg-card);padding:1px 5px;border-radius:3px;font-size:12px">{Custom Formats}</code>.
+                          The CFs marked <span style="background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--cat-hq-release-groups);padding:1px 6px;border-radius:3px;font-size:12px;font-weight:500">rename tag</span> below contribute their names to filenames Radarr/Sonarr renders after import (e.g. <code style="background:var(--bg-card);padding:1px 5px;border-radius:3px;font-size:12px">[AMZN]</code>, <code style="background:var(--bg-card);padding:1px 5px;border-radius:3px;font-size:12px">[v2]</code>).
                           Deleting them removes those tags from <em>future</em> renames; existing files on disk are unaffected. If you re-sync any TRaSH or builder profile that includes them, they're recreated automatically.
                         </div>
                       </template>
                       <template x-if="cleanupResult.action === 'unused-by-clonarr' && !cleanupResult.namingUsesCustomFormats && cleanupResult.items.some(i => i.renamingFlag)">
-                        <div style="margin-bottom:12px;padding:12px 14px;background:#0d2818;border:1px solid #1f6f3d;border-radius:6px;font-size:13px;color:#b3d4be;line-height:1.6">
-                          <div style="font-weight:600;color:#3fb950;margin-bottom:6px;font-size:14px">ⓘ Filename-rendering CFs are inert here</div>
-                          Some CFs below have a "rename tag" flag, but your file naming format on this instance does <strong>not</strong> use the <code style="background:#161b22;padding:1px 5px;border-radius:3px;font-size:12px">{Custom Formats}</code> token, so the flag has no functional effect. Safe to delete.
+                        <div style="margin-bottom:12px;padding:12px 14px;background:var(--fill-blue-soft);border:1px solid var(--accent-green-bg);border-radius:6px;font-size:13px;color:var(--accent-green);line-height:1.6">
+                          <div style="font-weight:600;color:var(--accent-green);margin-bottom:6px;font-size:14px">ⓘ Filename-rendering CFs are inert here</div>
+                          Some CFs below have a "rename tag" flag, but your file naming format on this instance does <strong>not</strong> use the <code style="background:var(--bg-card);padding:1px 5px;border-radius:3px;font-size:12px">{Custom Formats}</code> token, so the flag has no functional effect. Safe to delete.
                         </div>
                       </template>
 
@@ -75,18 +75,18 @@
                       <template x-if="cleanupResult.action === 'unused-by-clonarr'">
                         <div style="display:flex;gap:6px;margin-bottom:10px;flex-wrap:wrap">
                           <button class="btn"
-                            :style="cleanupFilter === 'all' ? 'background:#1f6feb;border-color:#1f6feb;color:#fff' : ''"
+                            :style="cleanupFilter === 'all' ? 'background:var(--accent-blue-strong);border-color:var(--accent-blue-strong);color:var(--text-on-accent)' : ''"
                             @click="cleanupFilter = 'all'"
                             x-text="'All unmanaged (' + cleanupResult.items.length + ')'"></button>
                           <template x-if="cleanupResult.items.some(i => i.renamingFlag)">
                             <button class="btn"
-                              :style="cleanupFilter === 'rename-flagged' ? 'background:#d29922;border-color:#d29922;color:#000' : ''"
+                              :style="cleanupFilter === 'rename-flagged' ? 'background:var(--accent-orange);border-color:var(--accent-orange);color:var(--text-inverse)' : ''"
                               @click="cleanupFilter = 'rename-flagged'"
                               x-text="'Rename-tagged only (' + cleanupResult.items.filter(i => i.renamingFlag).length + ')'"></button>
                           </template>
                           <template x-if="(cleanupResult.managedItems || []).length > 0">
                             <button class="btn"
-                              :style="cleanupFilter === 'managed' ? 'background:#238636;border-color:#238636;color:#fff' : ''"
+                              :style="cleanupFilter === 'managed' ? 'background:var(--accent-green-strong);border-color:var(--accent-green-strong);color:var(--text-on-accent)' : ''"
                               @click="cleanupFilter = 'managed'"
                               x-text="'Managed by Clonarr (' + (cleanupResult.managedItems || []).length + ')'"></button>
                           </template>
@@ -97,21 +97,21 @@
                       <template x-if="cleanupResult.action !== 'unused-by-clonarr' || cleanupFilter !== 'managed'">
                         <table style="width:100%;border-collapse:collapse;font-size:12px">
                           <thead>
-                            <tr style="text-align:left;color:#aaa;border-bottom:1px solid #30363d">
+                            <tr style="text-align:left;color:var(--text-muted);border-bottom:1px solid var(--border-subtle)">
                               <th style="padding:6px 8px;font-weight:500">Custom Format</th>
                               <th style="padding:6px 8px;font-weight:500;width:120px">Tag</th>
                             </tr>
                           </thead>
                           <tbody>
                             <template x-for="item in (cleanupResult.action === 'unused-by-clonarr' && cleanupFilter === 'rename-flagged' ? cleanupResult.items.filter(i => i.renamingFlag) : cleanupResult.items)" :key="item.id">
-                              <tr style="border-bottom:1px solid #21262d">
-                                <td style="padding:6px 8px;color:#e1e4e8">
+                              <tr style="border-bottom:1px solid var(--bg-muted)">
+                                <td style="padding:6px 8px;color:var(--text-primary)">
                                   <span x-text="item.name"></span>
-                                  <span x-show="item.detail" style="color:#aaa;display:block;font-size:11px;margin-top:2px" x-text="item.detail"></span>
+                                  <span x-show="item.detail" style="color:var(--text-muted);display:block;font-size:11px;margin-top:2px" x-text="item.detail"></span>
                                 </td>
                                 <td style="padding:6px 8px">
                                   <template x-if="item.renamingFlag">
-                                    <span style="background:#2d2410;border:1px solid #d29922;color:#e3b341;padding:1px 6px;border-radius:3px;font-size:11px;font-weight:500" x-tt="'includeCustomFormatWhenRenaming=true on this CF'">rename tag</span>
+                                    <span style="background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--cat-hq-release-groups);padding:1px 6px;border-radius:3px;font-size:11px;font-weight:500" x-tt="'includeCustomFormatWhenRenaming=true on this CF'">rename tag</span>
                                   </template>
                                 </td>
                               </tr>
@@ -123,12 +123,12 @@
                       <!-- Managed-by-clonarr table — read-only, with profile usage column -->
                       <template x-if="cleanupResult.action === 'unused-by-clonarr' && cleanupFilter === 'managed'">
                         <div>
-                          <div style="font-size:12px;color:#aaa;margin-bottom:8px;line-height:1.5">
+                          <div style="font-size:12px;color:var(--text-muted);margin-bottom:8px;line-height:1.5">
                             These CFs are referenced by one of your sync rules (selected, score-overridden, or required by the rule's TRaSH/builder profile). They cannot be deleted from this view. The "Used in profile(s)" column shows which Arr quality profile(s) currently have the CF at a non-zero score.
                           </div>
                           <table style="width:100%;border-collapse:collapse;font-size:12px">
                             <thead>
-                              <tr style="text-align:left;color:#aaa;border-bottom:1px solid #30363d">
+                              <tr style="text-align:left;color:var(--text-muted);border-bottom:1px solid var(--border-subtle)">
                                 <th style="padding:6px 8px;font-weight:500">Custom Format</th>
                                 <th style="padding:6px 8px;font-weight:500">Used in profile(s)</th>
                                 <th style="padding:6px 8px;font-weight:500;width:120px">Tag</th>
@@ -136,23 +136,23 @@
                             </thead>
                             <tbody>
                               <template x-for="item in (cleanupResult.managedItems || [])" :key="item.id">
-                                <tr style="border-bottom:1px solid #21262d">
-                                  <td style="padding:6px 8px;color:#e1e4e8;font-weight:500" x-text="item.name"></td>
-                                  <td style="padding:6px 8px;color:#aaa">
+                                <tr style="border-bottom:1px solid var(--bg-muted)">
+                                  <td style="padding:6px 8px;color:var(--text-primary);font-weight:500" x-text="item.name"></td>
+                                  <td style="padding:6px 8px;color:var(--text-muted)">
                                     <template x-if="(item.usedInProfiles || []).length > 0">
                                       <div style="display:flex;flex-wrap:wrap;gap:4px">
                                         <template x-for="prof in (item.usedInProfiles || [])" :key="prof">
-                                          <span style="background:#0d2818;border:1px solid #1f6f3d;color:#7ee787;padding:1px 7px;border-radius:10px;font-size:11px;font-weight:500;line-height:1.4" x-text="prof"></span>
+                                          <span style="background:var(--fill-blue-soft);border:1px solid var(--accent-green-bg);color:var(--accent-green);padding:1px 7px;border-radius:10px;font-size:11px;font-weight:500;line-height:1.4" x-text="prof"></span>
                                         </template>
                                       </div>
                                     </template>
                                     <template x-if="(item.usedInProfiles || []).length === 0">
-                                      <span style="color:#666;font-style:italic;font-size:11px">— (in sync rule but not yet at non-zero score in any profile)</span>
+                                      <span style="color:var(--text-muted-secondary);font-style:italic;font-size:11px">— (in sync rule but not yet at non-zero score in any profile)</span>
                                     </template>
                                   </td>
                                   <td style="padding:6px 8px">
                                     <template x-if="item.renamingFlag">
-                                      <span style="background:#2d2410;border:1px solid #d29922;color:#e3b341;padding:1px 6px;border-radius:3px;font-size:11px;font-weight:500">rename tag</span>
+                                      <span style="background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--cat-hq-release-groups);padding:1px 6px;border-radius:3px;font-size:11px;font-weight:500">rename tag</span>
                                     </template>
                                   </td>
                                 </tr>
@@ -164,12 +164,12 @@
                     </div>
                   </template>
                   <template x-if="cleanupResult.action === 'delete-cfs-and-scores'">
-                    <div style="margin-top:12px;padding:10px;background:#3d1b1b;border:1px solid #f85149;border-radius:6px;font-size:12px;color:#f85149">
+                    <div style="margin-top:12px;padding:10px;background:var(--accent-red-bg);border:1px solid var(--accent-red);border-radius:6px;font-size:12px;color:var(--accent-red)">
                       This will permanently delete all custom formats and reset all scores to 0. This action cannot be undone.
                     </div>
                   </template>
                   <template x-if="cleanupResult.action === 'delete-cfs-keep-scores'">
-                    <div style="margin-top:12px;padding:10px;background:#3d2e0a;border:1px solid #d29922;border-radius:6px;font-size:12px;color:#d29922">
+                    <div style="margin-top:12px;padding:10px;background:var(--accent-orange-bg);border:1px solid var(--accent-orange);border-radius:6px;font-size:12px;color:var(--accent-orange)">
                       This will delete all custom formats. Scores will be preserved in profiles so CFs can be re-added later.
                     </div>
                   </template>
@@ -186,7 +186,7 @@
                 <span x-show="cleanupApplying" class="spinner" style="width:10px;height:10px;border-width:1.5px"></span>
                 <span x-show="!cleanupApplying" x-text="'Delete safe (' + cleanupResult.items.filter(i => !i.renamingFlag).length + ')'"></span>
               </button>
-              <button class="btn" style="padding:5px 10px;font-size:12px;background:transparent;border:1px solid #f85149;color:#f85149" @click="cleanupApply({ skipRenameFlagged: false })" :disabled="cleanupApplying" x-tt="'Also delete CFs tagged for filename rendering'">
+              <button class="btn" style="padding:5px 10px;font-size:12px;background:transparent;border:1px solid var(--accent-red);color:var(--accent-red)" @click="cleanupApply({ skipRenameFlagged: false })" :disabled="cleanupApplying" x-tt="'Also delete CFs tagged for filename rendering'">
                 <span x-show="cleanupApplying" class="spinner" style="width:10px;height:10px;border-width:1.5px"></span>
                 <span x-show="!cleanupApplying" x-text="'Delete all (' + cleanupResult.affectCount + ')'"></span>
               </button>

--- a/ui/static/partials/modals/compare-quick-sync.html
+++ b/ui/static/partials/modals/compare-quick-sync.html
@@ -10,10 +10,10 @@
         <div style="margin-bottom:10px">
           <span x-text="compareQuickSync.summary"></span>
           <template x-if="compareQuickSync.cr && compareQuickSync.inst">
-            <div style="margin-top:8px;color:#8b949e;font-size:12px">
-              Target: <strong style="color:#c9d1d9" x-text="compareQuickSync.cr?.arrProfileName"></strong>
-              on <strong style="color:#c9d1d9" x-text="compareQuickSync.inst?.name"></strong>
-              — TRaSH profile: <strong style="color:#c9d1d9" x-text="compareQuickSync.cr?.trashProfileName"></strong>
+            <div style="margin-top:8px;color:var(--text-secondary);font-size:12px">
+              Target: <strong style="color:var(--text-body)" x-text="compareQuickSync.cr?.arrProfileName"></strong>
+              on <strong style="color:var(--text-body)" x-text="compareQuickSync.inst?.name"></strong>
+              — TRaSH profile: <strong style="color:var(--text-body)" x-text="compareQuickSync.cr?.trashProfileName"></strong>
             </div>
           </template>
         </div>

--- a/ui/static/partials/modals/confirm-dialog.html
+++ b/ui/static/partials/modals/confirm-dialog.html
@@ -4,8 +4,8 @@
   <div class="modal-overlay" style="z-index:2000" x-show="confirmModal.show" @click.self="confirmModal.show = false; if(confirmModal.onCancel) confirmModal.onCancel()" x-cloak>
     <div class="modal" style="max-width:420px">
       <div class="modal-title" x-text="confirmModal.title"></div>
-      <div style="font-size:13px;color:#aaa;white-space:pre-line;line-height:1.6" x-show="!confirmModal.html" x-text="confirmModal.message"></div>
-      <div style="font-size:13px;color:#aaa;line-height:1.6" x-show="confirmModal.html" x-html="confirmModal.message"></div>
+      <div style="font-size:13px;color:var(--text-muted);white-space:pre-line;line-height:1.6" x-show="!confirmModal.html" x-text="confirmModal.message"></div>
+      <div style="font-size:13px;color:var(--text-muted);line-height:1.6" x-show="confirmModal.html" x-html="confirmModal.message"></div>
       <div class="modal-actions">
         <button class="btn" @click="confirmModal.show = false; if(confirmModal.onCancel) confirmModal.onCancel()" x-text="confirmModal.cancelLabel || 'Cancel'"></button>
         <button x-show="confirmModal.secondaryLabel" x-cloak class="btn"

--- a/ui/static/partials/modals/disable-auth.html
+++ b/ui/static/partials/modals/disable-auth.html
@@ -4,24 +4,24 @@
        style="position:fixed;top:0;right:0;bottom:0;left:0;width:100vw;height:100vh;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;z-index:10000;padding:20px;box-sizing:border-box"
        @keydown.escape.window="disableAuthModalOpen = false; disableAuthError = ''">
     <div @click.outside="disableAuthModalOpen = false; disableAuthError = ''"
-         style="background:#1a1d24;border:2px solid #8b2d2d;border-radius:10px;padding:24px 28px;width:min(520px,100%);max-height:90vh;overflow-y:auto;box-shadow:0 12px 40px rgba(0,0,0,0.6)">
-      <h2 style="margin:0 0 10px;font-size:20px;color:#ff7a7a">⚠️ Disable authentication?</h2>
-      <p style="font-size:13px;line-height:1.5;color:#d4d4d4;margin:10px 0 8px">
+         style="background:var(--bg-card);border:2px solid var(--banner-warn-border);border-radius:10px;padding:24px 28px;width:min(520px,100%);max-height:90vh;overflow-y:auto;box-shadow:0 12px 40px rgba(0,0,0,0.6)">
+      <h2 style="margin:0 0 10px;font-size:20px;color:var(--accent-red-soft)">⚠️ Disable authentication?</h2>
+      <p style="font-size:13px;line-height:1.5;color:var(--text-body);margin:10px 0 8px">
         You are about to turn off login for <strong>Clonarr</strong>. After this change, anyone who reaches this UI will be admin — they can modify your Radarr/Sonarr/Prowlarr API keys, change Discord webhooks to their own server, and read every notification token.
       </p>
-      <p style="font-size:13px;line-height:1.5;color:#d4d4d4;margin:8px 0">
+      <p style="font-size:13px;line-height:1.5;color:var(--text-body);margin:8px 0">
         Pick this only if you have <em>another</em> authentication layer in front (Authelia, Cloudflare Access) or you are running on a machine that is not reachable from other devices.
       </p>
-      <div style="background:#281818;border:1px solid #5a2d2d;border-radius:6px;padding:10px 12px;margin:12px 0;font-size:12px;color:#ffcaca">
+      <div style="background:var(--accent-red-bg);border:1px solid var(--accent-red-bg);border-radius:6px;padding:10px 12px;margin:12px 0;font-size:12px;color:var(--accent-red-soft)">
         A persistent red warning banner will be shown at the top of every page while authentication is disabled, and the server logs a warning every 60 seconds.
       </div>
-      <label style="display:block;font-size:12px;color:#c3c7cc;margin:12px 0 6px">
+      <label style="display:block;font-size:12px;color:var(--text-body);margin:12px 0 6px">
         Enter your <strong>current admin password</strong> to confirm:
       </label>
       <input type="password" class="input" x-model="disableAuthPassword" autocomplete="current-password" placeholder="current password"
              @keydown.enter="disableAuthPassword && (disableAuthModalOpen = false, saveSecurityConfig(true))"
              style="width:100%;margin-bottom:8px">
-      <div x-show="disableAuthError" x-text="disableAuthError" style="color:#ff9a9a;font-size:12px;margin:0 0 10px"></div>
+      <div x-show="disableAuthError" x-text="disableAuthError" style="color:var(--accent-red-soft);font-size:12px;margin:0 0 10px"></div>
       <div style="display:flex;gap:8px;justify-content:flex-end">
         <button class="btn btn-secondary"
                 @click="disableAuthModalOpen = false; disableAuthError = ''; disableAuthPassword = ''; config.authentication = authStatus.authentication || 'forms'">Cancel</button>

--- a/ui/static/partials/modals/disable-auth.html
+++ b/ui/static/partials/modals/disable-auth.html
@@ -1,10 +1,10 @@
 {{define "modals/disable-auth"}}
   <!-- Disable-auth confirmation modal (requires password) -->
   <div x-show="disableAuthModalOpen" x-cloak
-       style="position:fixed;top:0;right:0;bottom:0;left:0;width:100vw;height:100vh;background:rgba(0,0,0,0.7);display:flex;align-items:center;justify-content:center;z-index:10000;padding:20px;box-sizing:border-box"
+       style="position:fixed;top:0;right:0;bottom:0;left:0;width:100vw;height:100vh;background:var(--alpha-overlay);display:flex;align-items:center;justify-content:center;z-index:10000;padding:20px;box-sizing:border-box"
        @keydown.escape.window="disableAuthModalOpen = false; disableAuthError = ''">
     <div @click.outside="disableAuthModalOpen = false; disableAuthError = ''"
-         style="background:var(--bg-card);border:2px solid var(--banner-warn-border);border-radius:10px;padding:24px 28px;width:min(520px,100%);max-height:90vh;overflow-y:auto;box-shadow:0 12px 40px rgba(0,0,0,0.6)">
+         style="background:var(--bg-card);border:2px solid var(--banner-warn-border);border-radius:10px;padding:24px 28px;width:min(520px,100%);max-height:90vh;overflow-y:auto;box-shadow:0 12px 40px var(--alpha-shadow)">
       <h2 style="margin:0 0 10px;font-size:20px;color:var(--accent-red-soft)">⚠️ Disable authentication?</h2>
       <p style="font-size:13px;line-height:1.5;color:var(--text-body);margin:10px 0 8px">
         You are about to turn off login for <strong>Clonarr</strong>. After this change, anyone who reaches this UI will be admin — they can modify your Radarr/Sonarr/Prowlarr API keys, change Discord webhooks to their own server, and read every notification token.

--- a/ui/static/partials/modals/export-profile.html
+++ b/ui/static/partials/modals/export-profile.html
@@ -4,7 +4,7 @@
   <div class="modal-overlay" x-show="showExportModal" @click.self="closeExportModal()" x-cloak>
     <div class="modal" style="max-width:700px">
       <div class="modal-title">Export Profile</div>
-      <div style="font-size:12px;color:#aaa;margin-bottom:16px">
+      <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
         Copy this profile configuration to use in other tools or share with others.
       </div>
 
@@ -14,11 +14,11 @@
       </div>
 
       <div style="position:relative">
-        <pre style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px 16px;font-size:13px;font-family:monospace;color:#c9d1d9;max-height:400px;overflow:auto;white-space:pre;margin:0;line-height:1.5"><code x-text="exportContent"></code></pre>
+        <pre style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px 16px;font-size:13px;font-family:monospace;color:var(--text-body);max-height:400px;overflow:auto;white-space:pre;margin:0;line-height:1.5"><code x-text="exportContent"></code></pre>
         <button class="btn btn-sm" style="position:absolute;top:8px;right:8px;font-size:13px"
                 @click="copyToClipboard(exportContent); exportCopied = true; setTimeout(() => exportCopied = false, 2000)">
           <span x-show="!exportCopied">Copy</span>
-          <span x-show="exportCopied" style="color:#3fb950">Copied!</span>
+          <span x-show="exportCopied" style="color:var(--accent-green)">Copied!</span>
         </button>
       </div>
 
@@ -26,19 +26,19 @@
       <template x-if="exportTab === 'trash' && exportGroupIncludes?.length > 0">
         <div style="margin-top:16px">
           <label style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;margin-bottom:8px">
-            <input type="checkbox" x-model="showExportGroupIncludes" style="accent-color:#58a6ff">
-            <span style="font-size:12px;color:#aaa">Show group includes</span>
-            <span style="font-size:12px;color:#aaa" x-text="'(' + exportGroupIncludes.length + ' groups)'"></span>
+            <input type="checkbox" x-model="showExportGroupIncludes" style="accent-color:var(--accent-blue)">
+            <span style="font-size:12px;color:var(--text-muted)">Show group includes</span>
+            <span style="font-size:12px;color:var(--text-muted)" x-text="'(' + exportGroupIncludes.length + ' groups)'"></span>
           </label>
           <div x-show="showExportGroupIncludes" x-cloak>
-            <div style="font-size:13px;color:#aaa;margin-bottom:8px;line-height:1.5">
-              Add these entries to each group's <code style="background:#21262d;padding:1px 4px;border-radius:2px;color:#aaa;font-size:12px">quality_profiles.include</code> section to link this profile.
+            <div style="font-size:13px;color:var(--text-muted);margin-bottom:8px;line-height:1.5">
+              Add these entries to each group's <code style="background:var(--bg-muted);padding:1px 4px;border-radius:2px;color:var(--text-muted);font-size:12px">quality_profiles.include</code> section to link this profile.
             </div>
             <template x-for="gi in exportGroupIncludes" :key="gi.groupTrashId">
               <div style="margin-bottom:8px">
-                <div style="font-size:13px;font-weight:500;color:#aaa;margin-bottom:4px" x-text="gi.groupName"></div>
+                <div style="font-size:13px;font-weight:500;color:var(--text-muted);margin-bottom:4px" x-text="gi.groupName"></div>
                 <div style="position:relative">
-                  <pre style="background:#0d1117;border:1px solid #21262d;border-radius:4px;padding:6px 10px;font-size:13px;font-family:monospace;color:#9ecbaa;margin:0"><code x-text="gi.snippet"></code></pre>
+                  <pre style="background:var(--bg-page);border:1px solid var(--bg-muted);border-radius:4px;padding:6px 10px;font-size:13px;font-family:monospace;color:var(--code-string);margin:0"><code x-text="gi.snippet"></code></pre>
                   <button class="btn btn-sm" style="position:absolute;top:4px;right:4px;font-size:12px;padding:1px 6px"
                           @click="copyToClipboard(gi.snippet)">Copy</button>
                 </div>

--- a/ui/static/partials/modals/import-cf.html
+++ b/ui/static/partials/modals/import-cf.html
@@ -3,7 +3,7 @@
   <div class="modal-overlay" x-show="showImportCFModal" @click.self="showImportCFModal = false" x-cloak>
     <div class="modal" style="max-width:600px">
       <div class="modal-title">Import Custom Formats</div>
-      <div style="font-size:12px;color:#aaa;margin-bottom:16px">
+      <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
         Import custom formats from an Arr instance or JSON. Imported CFs appear in the CF browser and are available in the profile builder.
       </div>
 
@@ -17,7 +17,7 @@
       <template x-if="importCFSource === 'instance'">
         <div>
           <div style="margin-bottom:12px">
-            <label style="font-size:12px;color:#aaa;display:block;margin-bottom:4px">Instance</label>
+            <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px">Instance</label>
             <select class="input" style="width:100%" x-model="importCFInstanceId" @change="fetchInstanceCFsForImport()">
               <option value="">Select instance...</option>
               <template x-for="inst in instances.filter(i => i.type === importCFAppType)" :key="inst.id">
@@ -34,7 +34,7 @@
           <!-- CF list with checkboxes -->
           <div x-show="importCFList.length > 0 && !importCFLoading">
             <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px">
-              <div style="font-size:12px;color:#aaa">
+              <div style="font-size:12px;color:var(--text-muted)">
                 <span x-text="importCFList.length"></span> CFs found
                 (<span x-text="importCFList.filter(c => c.selected).length"></span> selected)
               </div>
@@ -43,7 +43,7 @@
                 <button class="btn btn-sm" @click="importCFList.forEach(c => c.selected = false)">Deselect All</button>
               </div>
             </div>
-            <div style="display:grid;grid-template-columns:1fr 1fr;gap:4px 16px;max-height:300px;overflow-y:auto;border:1px solid #30363d;border-radius:6px;padding:8px 12px">
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:4px 16px;max-height:300px;overflow-y:auto;border:1px solid var(--border-subtle);border-radius:6px;padding:8px 12px">
               <template x-for="cf in importCFList" :key="cf.name">
                 <label style="display:flex;align-items:center;gap:6px;padding:4px 0;cursor:pointer;font-size:13px;min-width:0"
                        :style="cf.exists ? 'opacity:0.4' : ''">
@@ -52,7 +52,7 @@
                         x-tt="cf.exists ? cf.name + ' (already imported)' : cf.name"></span>
                   <span x-show="cf.trashMatch && !cf.exists"
                         x-tt="'Also in TRaSH guide — you can still import.'"
-                        style="background:#3a2d10;color:#e3b341;border:1px solid #d29922;border-radius:3px;padding:0 5px;font-size:10px;font-weight:600;flex-shrink:0;cursor:help">
+                        style="background:var(--accent-orange-bg);color:var(--cat-hq-release-groups);border:1px solid var(--accent-orange);border-radius:3px;padding:0 5px;font-size:10px;font-weight:600;flex-shrink:0;cursor:help">
                     ⚠ guide
                   </span>
                 </label>
@@ -66,20 +66,20 @@
       <template x-if="importCFSource === 'json'">
         <div>
           <div style="margin-bottom:12px">
-            <label style="font-size:12px;color:#aaa;display:block;margin-bottom:4px">Paste JSON (Arr CF format)</label>
+            <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px">Paste JSON (Arr CF format)</label>
             <textarea class="input" style="width:100%;height:150px;font-family:monospace;font-size:12px" x-model="importCFJsonText"
                       placeholder='[{"name":"My CF","specifications":[...]}]'></textarea>
-            <div style="font-size:11px;color:#aaa;margin-top:6px;line-height:1.5">
+            <div style="font-size:11px;color:var(--text-muted);margin-top:6px;line-height:1.5">
               Imports <code style="font-size:11px">name</code>, <code style="font-size:11px">specifications</code>, and <code style="font-size:11px">includeCustomFormatWhenRenaming</code>. TRaSH-specific fields (<code style="font-size:11px">trash_id</code>, <code style="font-size:11px">trash_scores</code>) are intentionally not imported — the new CF lives as your own custom format, separate from the TRaSH guide data path.
             </div>
           </div>
-          <div x-show="importCFJsonError" style="font-size:12px;color:#f85149;margin-bottom:8px" x-text="importCFJsonError"></div>
+          <div x-show="importCFJsonError" style="font-size:12px;color:var(--accent-red);margin-bottom:8px" x-text="importCFJsonError"></div>
         </div>
       </template>
 
       <!-- Category picker -->
       <div style="margin-top:12px">
-        <label style="font-size:12px;color:#aaa;display:block;margin-bottom:4px">Category</label>
+        <label style="font-size:12px;color:var(--text-muted);display:block;margin-bottom:4px">Category</label>
         <div style="display:flex;gap:8px">
           <select class="input" style="flex:1" x-model="importCFCategory">
             <option value="Custom">Custom</option>
@@ -102,7 +102,7 @@
 
       <!-- Result message -->
       <div x-show="importCFResult" style="margin-top:12px;font-size:12px;padding:8px 12px;border-radius:6px"
-           :style="importCFResult?.error ? 'background:#3d1f1f;color:#f85149' : 'background:#1f3d1f;color:#3fb950'"
+           :style="importCFResult?.error ? 'background:var(--accent-red-bg);color:var(--accent-red)' : 'background:var(--accent-green-bg);color:var(--accent-green)'"
            x-text="importCFResult?.message"></div>
 
       <div class="modal-actions">

--- a/ui/static/partials/modals/import-profile.html
+++ b/ui/static/partials/modals/import-profile.html
@@ -2,7 +2,7 @@
   <div class="modal-overlay" x-show="showImportModal !== false" @click.self="showImportModal = false" x-cloak>
     <div class="modal" style="max-width:600px">
       <div class="modal-title">Import Profile</div>
-      <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">
+      <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
         Paste or upload a profile configuration. Supports Recyclarr YAML, TRaSH JSON, and Clonarr JSON. Multiple profiles and both Radarr and Sonarr are detected automatically.
       </div>
 
@@ -18,21 +18,21 @@
       </div>
 
       <div x-show="importMode === 'file'" class="form-group">
-        <div style="border:2px dashed #30363d;border-radius:8px;padding:24px;text-align:center;cursor:pointer;transition:border-color 0.2s"
-             :style="importDragOver ? 'border-color:#58a6ff;background:#161b2280' : ''"
+        <div style="border:2px dashed var(--border-subtle);border-radius:8px;padding:24px;text-align:center;cursor:pointer;transition:border-color 0.2s"
+             :style="importDragOver ? 'border-color:var(--accent-blue);background:color-mix(in srgb, var(--bg-card) 50%, transparent)' : ''"
              @click="$refs.importFileInput.click()"
              @dragover.prevent="importDragOver = true"
              @dragleave.prevent="importDragOver = false"
              @drop.prevent="importDragOver = false; handleImportFiles($event.dataTransfer.files)">
-          <div style="color:#aaa;font-size:13px;margin-bottom:4px">Drop .yml or .json files here or click to browse</div>
-          <div style="color:#aaa;font-size:13px">Supports multiple files</div>
+          <div style="color:var(--text-muted);font-size:13px;margin-bottom:4px">Drop .yml or .json files here or click to browse</div>
+          <div style="color:var(--text-muted);font-size:13px">Supports multiple files</div>
         </div>
         <input type="file" accept=".yml,.yaml,.json" multiple x-ref="importFileInput" @change="handleImportFiles($event.target.files)" style="display:none">
         <template x-if="importFiles.length > 0">
-          <div style="margin-top:8px;font-size:12px;color:#58a6ff">
+          <div style="margin-top:8px;font-size:12px;color:var(--accent-blue)">
             <template x-for="f in importFiles" :key="f.name">
               <div style="display:flex;align-items:center;gap:6px;padding:2px 0">
-                <span style="color:#3fb950">&#10003;</span>
+                <span style="color:var(--accent-green)">&#10003;</span>
                 <span x-text="f.name"></span>
               </div>
             </template>
@@ -47,24 +47,24 @@
       </div>
 
       <!-- Include files (available for both paste and upload modes) -->
-      <label style="display:flex;align-items:center;gap:6px;margin-top:4px;cursor:pointer;font-size:13px;color:#aaa">
-        <input type="checkbox" x-model="importHasIncludes" style="accent-color:#58a6ff">
+      <label style="display:flex;align-items:center;gap:6px;margin-top:4px;cursor:pointer;font-size:13px;color:var(--text-muted)">
+        <input type="checkbox" x-model="importHasIncludes" style="accent-color:var(--accent-blue)">
         Config uses include files
       </label>
       <div x-show="importHasIncludes" style="margin-top:8px">
-        <div style="border:2px dashed #30363d;border-radius:8px;padding:16px;text-align:center;cursor:pointer;transition:border-color 0.2s"
+        <div style="border:2px dashed var(--border-subtle);border-radius:8px;padding:16px;text-align:center;cursor:pointer;transition:border-color 0.2s"
              @click="$refs.importIncludeInput.click()"
-             @dragover.prevent="$el.style.borderColor='#d29922'"
-             @dragleave.prevent="$el.style.borderColor='#30363d'"
-             @drop.prevent="$el.style.borderColor='#30363d'; handleImportIncludeFiles($event.dataTransfer.files)">
-          <div style="color:#aaa;font-size:13px">Drop include files here or click to browse</div>
+             @dragover.prevent="$el.style.borderColor='var(--accent-orange)'"
+             @dragleave.prevent="$el.style.borderColor='var(--border-subtle)'"
+             @drop.prevent="$el.style.borderColor='var(--border-subtle)'; handleImportIncludeFiles($event.dataTransfer.files)">
+          <div style="color:var(--text-muted);font-size:13px">Drop include files here or click to browse</div>
         </div>
         <input type="file" accept=".yml,.yaml" multiple x-ref="importIncludeInput" @change="handleImportIncludeFiles($event.target.files)" style="display:none">
         <template x-if="importIncludeFiles.length > 0">
-          <div style="margin-top:6px;font-size:12px;color:#d29922">
+          <div style="margin-top:6px;font-size:12px;color:var(--accent-orange)">
             <template x-for="f in importIncludeFiles" :key="f.name">
               <div style="display:flex;align-items:center;gap:6px;padding:2px 0">
-                <span style="color:#d29922">&#10003;</span>
+                <span style="color:var(--accent-orange)">&#10003;</span>
                 <span x-text="f.name"></span>
               </div>
             </template>
@@ -75,7 +75,7 @@
 
 
       <div x-show="importResult" style="font-size:12px;margin-bottom:8px;padding:8px;border-radius:4px"
-           :style="importError ? 'background:#3d1f1f;color:#f85149;border:1px solid #da3633' : 'background:#1a2e1a;color:#3fb950;border:1px solid #238636'"
+           :style="importError ? 'background:var(--accent-red-bg);color:var(--accent-red);border:1px solid var(--accent-red-strong)' : 'background:var(--accent-green-bg);color:var(--accent-green);border:1px solid var(--accent-green-strong)'"
            x-text="importResult"></div>
 
       <div class="modal-actions">

--- a/ui/static/partials/modals/input-dialog.html
+++ b/ui/static/partials/modals/input-dialog.html
@@ -5,7 +5,7 @@
   <div class="modal-overlay" style="z-index:2000" x-show="inputModal.show" @click.self="inputModal.show = false; if(inputModal.onCancel) inputModal.onCancel()" x-cloak>
     <div class="modal" style="max-width:420px">
       <div class="modal-title" x-text="inputModal.title"></div>
-      <div x-show="inputModal.message" style="font-size:13px;color:#aaa;white-space:pre-line;line-height:1.6;margin-bottom:8px" x-text="inputModal.message"></div>
+      <div x-show="inputModal.message" style="font-size:13px;color:var(--text-muted);white-space:pre-line;line-height:1.6;margin-bottom:8px" x-text="inputModal.message"></div>
       <input type="text" class="input" style="width:100%;font-size:13px;padding:6px 10px"
              x-model="inputModal.value"
              :placeholder="inputModal.placeholder || ''"

--- a/ui/static/partials/modals/instance.html
+++ b/ui/static/partials/modals/instance.html
@@ -21,12 +21,12 @@
       <div class="form-group">
         <label>API Key</label>
         <input class="input" x-model="instanceForm.apiKey" :placeholder="editingInstance ? 'Leave empty to keep current key' : 'Radarr/Sonarr API key'" :type="editingInstance && !instanceForm.apiKey ? 'text' : 'password'" autocomplete="one-time-code">
-        <div x-show="editingInstance && !instanceForm.apiKey" style="font-size:13px;color:#aaa;margin-top:4px">API key is saved — leave empty to keep it, or enter a new one to replace it.</div>
+        <div x-show="editingInstance && !instanceForm.apiKey" style="font-size:13px;color:var(--text-muted);margin-top:4px">API key is saved — leave empty to keep it, or enter a new one to replace it.</div>
       </div>
       <!-- Test result -->
       <div x-show="modalTestResult !== null">
         <template x-if="modalTestResult === 'testing'">
-          <div class="test-result" style="color:#d29922"><span class="spinner" style="width:12px;height:12px;border-width:1.5px"></span> Testing...</div>
+          <div class="test-result" style="color:var(--accent-orange)"><span class="spinner" style="width:12px;height:12px;border-width:1.5px"></span> Testing...</div>
         </template>
         <template x-if="modalTestResult && modalTestResult !== 'testing' && modalTestResult.connected">
           <div class="test-result ok" x-text="'Connected — ' + modalTestResult.appName + ' v' + modalTestResult.version"></div>

--- a/ui/static/partials/modals/restore-instance.html
+++ b/ui/static/partials/modals/restore-instance.html
@@ -3,13 +3,13 @@
   <div class="modal-overlay" x-show="showRestoreModal" @click.self="showRestoreModal = false" x-cloak>
     <div class="modal" style="max-width:600px">
       <div class="modal-title">Restore to Instance</div>
-      <div style="font-size:12px;color:#aaa;margin-bottom:12px" x-text="restoreInstance?.name || ''"></div>
+      <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px" x-text="restoreInstance?.name || ''"></div>
 
       <!-- Step 1: Upload file -->
       <template x-if="!restoreData">
         <div>
-          <div style="font-size:13px;color:#c9d1d9;margin-bottom:8px">Upload a Clonarr backup JSON file.</div>
-          <input type="file" accept=".json" @change="loadRestoreFile($event)" style="font-size:13px;color:#c9d1d9">
+          <div style="font-size:13px;color:var(--text-body);margin-bottom:8px">Upload a Clonarr backup JSON file.</div>
+          <input type="file" accept=".json" @change="loadRestoreFile($event)" style="font-size:13px;color:var(--text-body)">
           <div class="modal-actions">
             <button class="btn" @click="showRestoreModal = false">Cancel</button>
           </div>
@@ -19,7 +19,7 @@
       <!-- Step 2: Select what to restore -->
       <template x-if="restoreData && !restorePreview && !restoreResult">
         <div>
-          <div style="font-size:12px;color:#aaa;margin-bottom:12px">
+          <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px">
             From: <strong x-text="restoreData.instanceName"></strong> (<span x-text="restoreData.exportedAt?.split('T')[0]"></span>)
           </div>
 
@@ -27,16 +27,16 @@
           <template x-if="(restoreData.profiles || []).length > 0">
             <div style="margin-bottom:16px">
               <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-                <div style="font-size:13px;font-weight:600;color:#e1e4e8" x-text="'Profiles (' + (restoreData.profiles || []).length + ')'"></div>
+                <div style="font-size:13px;font-weight:600;color:var(--text-primary)" x-text="'Profiles (' + (restoreData.profiles || []).length + ')'"></div>
                 <button class="btn btn-sm" style="font-size:12px;padding:2px 6px" @click="(restoreData.profiles || []).forEach((_, i) => restoreSelectedProfiles[i] = true)">Select All</button>
                 <button class="btn btn-sm" style="font-size:12px;padding:2px 6px" @click="restoreSelectedProfiles = {}">Deselect All</button>
               </div>
-              <div style="max-height:200px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+              <div style="max-height:200px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
                 <template x-for="(p, i) in restoreData.profiles" :key="i">
-                  <label style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid #21262d;cursor:pointer;font-size:12px;color:#c9d1d9">
+                  <label style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid var(--bg-muted);cursor:pointer;font-size:12px;color:var(--text-body)">
                     <input type="checkbox" :checked="restoreSelectedProfiles[i]" @change="restoreSelectedProfiles[i] = $el.checked">
                     <span x-text="p.name"></span>
-                    <span style="margin-left:auto;font-size:13px;color:#aaa" x-text="(p.formatItems || []).filter(fi => fi.score !== 0).length + ' scored CFs'"></span>
+                    <span style="margin-left:auto;font-size:13px;color:var(--text-muted)" x-text="(p.formatItems || []).filter(fi => fi.score !== 0).length + ' scored CFs'"></span>
                   </label>
                 </template>
               </div>
@@ -47,13 +47,13 @@
           <template x-if="(restoreData.customFormats || []).length > 0">
             <div>
               <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-                <div style="font-size:13px;font-weight:600;color:#e1e4e8" x-text="'Custom Formats (' + (restoreData.customFormats || []).length + ')'"></div>
+                <div style="font-size:13px;font-weight:600;color:var(--text-primary)" x-text="'Custom Formats (' + (restoreData.customFormats || []).length + ')'"></div>
                 <button class="btn btn-sm" style="font-size:12px;padding:2px 6px" @click="(restoreData.customFormats || []).forEach((_, i) => restoreSelectedCFs[i] = true)">Select All</button>
                 <button class="btn btn-sm" style="font-size:12px;padding:2px 6px" @click="restoreSelectedCFs = {}">Deselect All</button>
               </div>
-              <div style="max-height:250px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+              <div style="max-height:250px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
                 <template x-for="(cf, i) in restoreData.customFormats" :key="i">
-                  <label style="display:flex;align-items:center;gap:8px;padding:4px 12px;border-bottom:1px solid #21262d;cursor:pointer;font-size:12px;color:#c9d1d9">
+                  <label style="display:flex;align-items:center;gap:8px;padding:4px 12px;border-bottom:1px solid var(--bg-muted);cursor:pointer;font-size:12px;color:var(--text-body)">
                     <input type="checkbox" :checked="restoreSelectedCFs[i]" @change="restoreSelectedCFs[i] = $el.checked">
                     <span x-text="cf.name"></span>
                   </label>
@@ -76,19 +76,19 @@
       <!-- Step 3: Preview -->
       <template x-if="restorePreview && !restoreResult">
         <div>
-          <div style="font-size:13px;font-weight:600;color:#e1e4e8;margin-bottom:8px">Preview</div>
-          <div style="max-height:300px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+          <div style="font-size:13px;font-weight:600;color:var(--text-primary);margin-bottom:8px">Preview</div>
+          <div style="max-height:300px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
             <template x-for="(a, i) in restorePreview.actions" :key="i">
-              <div style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid #21262d;font-size:12px">
+              <div style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid var(--bg-muted);font-size:12px">
                 <span style="padding:1px 6px;border-radius:3px;font-size:12px;font-weight:600"
-                  :style="a.action === 'create' ? 'background:#238636;color:#fff' : 'background:#1f6feb;color:#fff'"
+                  :style="a.action === 'create' ? 'background:var(--accent-green-strong);color:var(--text-on-accent)' : 'background:var(--accent-blue-strong);color:var(--text-on-accent)'"
                   x-text="a.action"></span>
-                <span style="padding:1px 6px;border-radius:3px;font-size:12px;background:#30363d;color:#aaa" x-text="a.type === 'cf' ? 'CF' : 'Profile'"></span>
-                <span style="color:#c9d1d9" x-text="a.name"></span>
+                <span style="padding:1px 6px;border-radius:3px;font-size:12px;background:var(--border-subtle);color:var(--text-muted)" x-text="a.type === 'cf' ? 'CF' : 'Profile'"></span>
+                <span style="color:var(--text-body)" x-text="a.name"></span>
               </div>
             </template>
           </div>
-          <div style="font-size:13px;color:#aaa;margin-top:8px">
+          <div style="font-size:13px;color:var(--text-muted);margin-top:8px">
             <span x-text="restorePreview.actions.filter(a => a.action === 'create').length + ' to create'"></span>,
             <span x-text="restorePreview.actions.filter(a => a.action === 'update').length + ' to update'"></span>
           </div>
@@ -106,23 +106,23 @@
       <!-- Step 4: Result -->
       <template x-if="restoreResult">
         <div>
-          <div style="font-size:13px;font-weight:600;color:#3fb950;margin-bottom:8px">Restore Complete</div>
-          <div style="max-height:300px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+          <div style="font-size:13px;font-weight:600;color:var(--accent-green);margin-bottom:8px">Restore Complete</div>
+          <div style="max-height:300px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
             <template x-for="(a, i) in restoreResult.actions" :key="i">
-              <div style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid #21262d;font-size:12px">
+              <div style="display:flex;align-items:center;gap:8px;padding:6px 12px;border-bottom:1px solid var(--bg-muted);font-size:12px">
                 <span style="padding:1px 6px;border-radius:3px;font-size:12px;font-weight:600"
-                  :style="a.error ? 'background:#da3633;color:#fff' : (a.action === 'create' ? 'background:#238636;color:#fff' : 'background:#1f6feb;color:#fff')"
+                  :style="a.error ? 'background:var(--accent-red-strong);color:var(--text-on-accent)' : (a.action === 'create' ? 'background:var(--accent-green-strong);color:var(--text-on-accent)' : 'background:var(--accent-blue-strong);color:var(--text-on-accent)')"
                   x-text="a.error ? 'error' : a.action"></span>
-                <span style="padding:1px 6px;border-radius:3px;font-size:12px;background:#30363d;color:#aaa" x-text="a.type === 'cf' ? 'CF' : 'Profile'"></span>
-                <span style="color:#c9d1d9" x-text="a.name"></span>
-                <span x-show="a.error" style="color:#f85149;font-size:13px;margin-left:auto" x-text="a.error"></span>
+                <span style="padding:1px 6px;border-radius:3px;font-size:12px;background:var(--border-subtle);color:var(--text-muted)" x-text="a.type === 'cf' ? 'CF' : 'Profile'"></span>
+                <span style="color:var(--text-body)" x-text="a.name"></span>
+                <span x-show="a.error" style="color:var(--accent-red);font-size:13px;margin-left:auto" x-text="a.error"></span>
               </div>
             </template>
           </div>
-          <div style="font-size:13px;color:#aaa;margin-top:8px">
-            <span style="color:#3fb950" x-text="restoreResult.actions.filter(a => !a.error).length + ' successful'"></span>
+          <div style="font-size:13px;color:var(--text-muted);margin-top:8px">
+            <span style="color:var(--accent-green)" x-text="restoreResult.actions.filter(a => !a.error).length + ' successful'"></span>
             <template x-if="restoreResult.actions.filter(a => a.error).length > 0">
-              <span style="color:#f85149" x-text="', ' + restoreResult.actions.filter(a => a.error).length + ' failed'"></span>
+              <span style="color:var(--accent-red)" x-text="', ' + restoreResult.actions.filter(a => a.error).length + ' failed'"></span>
             </template>
           </div>
           <div class="modal-actions">

--- a/ui/static/partials/modals/sandbox-cf-browser.html
+++ b/ui/static/partials/modals/sandbox-cf-browser.html
@@ -1,9 +1,9 @@
 {{define "modals/sandbox-cf-browser"}}
   <!-- ==================== SANDBOX CF BROWSER MODAL ==================== -->
   <div class="modal-overlay" x-show="sandboxCFBrowser.open" @click.self="closeSandboxCFBrowser()" x-cloak>
-    <div style="background:#161b22;border:1px solid #30363d;border-radius:12px;width:700px;max-width:90vw;max-height:80vh;display:flex;flex-direction:column">
+    <div style="background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:12px;width:700px;max-width:90vw;max-height:80vh;display:flex;flex-direction:column">
       <!-- Header -->
-      <div style="padding:16px 20px;border-bottom:1px solid #30363d;display:flex;align-items:center;gap:12px">
+      <div style="padding:16px 20px;border-bottom:1px solid var(--border-subtle);display:flex;align-items:center;gap:12px">
         <div style="font-size:15px;font-weight:600">Add Custom Formats</div>
         <input type="text" class="pb-input" placeholder="Filter..." style="width:200px;font-size:13px;margin-left:auto"
                x-model="sandboxCFBrowser.filter">
@@ -30,7 +30,7 @@
                   <template x-for="cf in group.cfs" :key="cf.trashId">
                     <div x-show="!sandboxCFBrowser.filter || cf.name.toLowerCase().includes(sandboxCFBrowser.filter.toLowerCase())"
                          style="display:flex;align-items:center;gap:8px;padding:2px 14px;font-size:13px"
-                         @mouseenter="$el.style.background='#1c2129'" @mouseleave="$el.style.background=''">
+                         @mouseenter="$el.style.background='var(--bg-elevated-hover)'" @mouseleave="$el.style.background=''">
                       <label class="toggle toggle-sm">
                         <input type="checkbox"
                                :checked="sandboxCFBrowser.selected[cf.trashId]"
@@ -39,7 +39,7 @@
                         <span class="slider"></span>
                       </label>
                       <span style="flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0"
-                            :style="sandboxCFBrowser.inProfile[cf.trashId] ? 'color:#aaa' : 'color:#c9d1d9'" x-text="cf.name"></span>
+                            :style="sandboxCFBrowser.inProfile[cf.trashId] ? 'color:var(--text-muted)' : 'color:var(--text-body)'" x-text="cf.name"></span>
                       <input x-show="sandboxCFBrowser.selected[cf.trashId]" type="number" class="pb-input"
                              style="width:75px;flex-shrink:0;font-size:12px;text-align:right;font-family:monospace"
                              :value="sandboxCFBrowser.scores[cf.trashId] ?? 0"
@@ -55,25 +55,25 @@
         <!-- Custom CFs section -->
         <template x-if="(sandboxCFBrowser.customCFs || []).length > 0">
           <div style="margin:4px 8px 0">
-            <div class="pb-cat-header" style="border-left:3px solid #d29922" @click="sandboxCFBrowser.expanded['Custom'] = !sandboxCFBrowser.expanded['Custom']">
+            <div class="pb-cat-header" style="border-left:3px solid var(--accent-orange)" @click="sandboxCFBrowser.expanded['Custom'] = !sandboxCFBrowser.expanded['Custom']">
               <span class="profile-group-chevron" :class="{ open: sandboxCFBrowser.expanded['Custom'] }">&#9654;</span>
-              <span style="font-size:13px;font-weight:500;color:#d29922">Custom CFs</span>
+              <span style="font-size:13px;font-weight:500;color:var(--accent-orange)">Custom CFs</span>
               <span class="pb-cat-count" x-text="(sandboxCFBrowser.customCFs || []).length"></span>
             </div>
             <div x-show="sandboxCFBrowser.expanded['Custom']">
               <template x-for="cf in sandboxCFBrowser.customCFs || []" :key="cf.id">
                 <div x-show="!sandboxCFBrowser.filter || cf.name.toLowerCase().includes(sandboxCFBrowser.filter.toLowerCase())"
                      style="display:flex;align-items:center;gap:8px;padding:2px 14px;font-size:13px"
-                     @mouseenter="$el.style.background='#1c2129'" @mouseleave="$el.style.background=''">
+                     @mouseenter="$el.style.background='var(--bg-elevated-hover)'" @mouseleave="$el.style.background=''">
                   <label class="toggle toggle-sm">
                     <input type="checkbox"
                            :checked="sandboxCFBrowser.selected[cf.id]"
                            @change="sandboxCFBrowser.selected[cf.id] = $event.target.checked; if($event.target.checked) { sandboxCFBrowser.scores[cf.id] = sandboxCFBrowser.scores[cf.id] ?? 0; }">
                     <span class="slider"></span>
                   </label>
-                  <span style="flex:1;color:#d29922;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0" x-text="cf.name"></span>
+                  <span style="flex:1;color:var(--accent-orange);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0" x-text="cf.name"></span>
                   <input x-show="sandboxCFBrowser.selected[cf.id]" type="number" class="pb-input"
-                         style="width:75px;flex-shrink:0;font-size:12px;text-align:right;font-family:monospace;border-color:#d29922"
+                         style="width:75px;flex-shrink:0;font-size:12px;text-align:right;font-family:monospace;border-color:var(--accent-orange)"
                          :value="sandboxCFBrowser.scores[cf.id] ?? 0"
                          @input="sandboxCFBrowser.scores[cf.id] = parseInt($event.target.value) || 0">
                 </div>

--- a/ui/static/partials/modals/sandbox-copy.html
+++ b/ui/static/partials/modals/sandbox-copy.html
@@ -5,9 +5,9 @@
     <div class="modal" style="max-width:720px;width:90vw">
       <div class="modal-title" style="display:flex;align-items:center;gap:8px">
         <span>Release Details</span>
-        <span style="font-size:11px;color:#8b949e;font-weight:400">(selectable · copy for sharing)</span>
+        <span style="font-size:11px;color:var(--text-secondary);font-weight:400">(selectable · copy for sharing)</span>
       </div>
-      <pre style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px 14px;margin:0;max-height:60vh;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.55;color:#c9d1d9;white-space:pre-wrap;user-select:text" x-text="sandboxCopyModal.text"></pre>
+      <pre style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px 14px;margin:0;max-height:60vh;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.55;color:var(--text-body);white-space:pre-wrap;user-select:text" x-text="sandboxCopyModal.text"></pre>
       <div class="modal-actions">
         <button class="btn" @click="sandboxCopyModal.show = false">Close</button>
         <button class="btn btn-primary" @click="copySandboxModalText()">

--- a/ui/static/partials/modals/sync-profile.html
+++ b/ui/static/partials/modals/sync-profile.html
@@ -8,8 +8,8 @@
       <!-- Scrollable content region so many diffs don't push Cancel/Dry Run/Apply off-screen -->
       <div style="flex:1 1 auto;overflow-y:auto;min-height:0;padding:24px">
       <div class="modal-title">Sync Profile</div>
-      <div style="font-size:13px;color:#aaa;margin-bottom:12px">
-        Deploy <strong x-text="syncForm.profileName" style="color:#e1e4e8"></strong> to an instance
+      <div style="font-size:13px;color:var(--text-muted);margin-bottom:12px">
+        Deploy <strong x-text="syncForm.profileName" style="color:var(--text-primary)"></strong> to an instance
       </div>
 
       <!-- Instance selector -->
@@ -24,12 +24,12 @@
 
       <!-- Mode selector -->
       <div style="display:flex;gap:16px;margin-bottom:16px">
-        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
-          <input type="radio" value="create" x-model="syncMode" @change="autoSyncRuleForSync = null; syncForm.arrProfileId = '0'" style="accent-color:#58a6ff">
+        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:var(--text-primary)">
+          <input type="radio" value="create" x-model="syncMode" @change="autoSyncRuleForSync = null; syncForm.arrProfileId = '0'" style="accent-color:var(--accent-blue)">
           Create new profile
         </label>
-        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#e1e4e8">
-          <input type="radio" value="update" x-model="syncMode" @change="updateAutoSyncRuleForSync()" style="accent-color:#58a6ff">
+        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:var(--text-primary)">
+          <input type="radio" value="update" x-model="syncMode" @change="updateAutoSyncRuleForSync()" style="accent-color:var(--accent-blue)">
           Update existing profile
         </label>
       </div>
@@ -38,9 +38,9 @@
       <div class="form-group" x-show="syncMode === 'create'">
         <label>Profile name</label>
         <input type="text" class="input" x-model="syncForm.newProfileName" placeholder="Profile name in Radarr/Sonarr">
-        <div style="font-size:13px;color:#aaa;margin-top:4px">A new quality profile will be created with CFs, scores, quality items, and cutoff</div>
+        <div style="font-size:13px;color:var(--text-muted);margin-top:4px">A new quality profile will be created with CFs, scores, quality items, and cutoff</div>
         <div x-show="syncForm.newProfileName && arrProfiles.some(p => p.name.toLowerCase() === syncForm.newProfileName.trim().toLowerCase())"
-             style="margin-top:8px;padding:8px 12px;background:#3d1f00;border:1px solid #d29922;border-radius:4px;font-size:12px;color:#d29922">
+             style="margin-top:8px;padding:8px 12px;background:var(--fill-orange-soft);border:1px solid var(--accent-orange);border-radius:4px;font-size:12px;color:var(--accent-orange)">
           &#9888; Profile "<span x-text="syncForm.newProfileName.trim()"></span>" already exists in <span x-text="syncForm.instanceName"></span>. Choose a different name to create a separate profile, or use <strong>Update existing profile</strong> to sync changes to it.
         </div>
       </div>
@@ -54,51 +54,51 @@
             <option :value="String(p.id)" x-text="p.name"></option>
           </template>
         </select>
-        <div style="font-size:13px;color:#aaa;margin-top:4px">CFs and scores will be synced according to the Custom Formats rules below. Use overrides on the profile page for score adjustments.</div>
+        <div style="font-size:13px;color:var(--text-muted);margin-top:4px">CFs and scores will be synced according to the Custom Formats rules below. Use overrides on the profile page for score adjustments.</div>
       </div>
 
       <!-- Create mode: static summary -->
       <div style="font-size:12px;margin-bottom:8px;line-height:1.6" x-show="syncMode === 'create' && profileDetail?.detail">
-        <div style="color:#e1e4e8"><span x-text="profileDetail?.detail?.totalCoreCFs || 0"></span> required CFs</div>
+        <div style="color:var(--text-primary)"><span x-text="profileDetail?.detail?.totalCoreCFs || 0"></span> required CFs</div>
         <template x-for="item in getSyncOptionalBreakdown()" :key="item.category">
-          <div style="color:#58a6ff">+ <span x-text="item.count"></span> <span x-text="item.category"></span></div>
+          <div style="color:var(--accent-blue)">+ <span x-text="item.count"></span> <span x-text="item.category"></span></div>
         </template>
       </div>
 
       <!-- Update mode: live preview from dry-run -->
       <div x-show="syncMode === 'update' && syncForm.arrProfileId && syncForm.arrProfileId !== '0'" style="font-size:12px;margin-bottom:8px">
-        <div x-show="syncPreviewLoading" style="color:#aaa">Loading preview...</div>
+        <div x-show="syncPreviewLoading" style="color:var(--text-muted)">Loading preview...</div>
         <div x-show="syncPreview && !syncPreviewLoading" style="line-height:1.6">
-          <div x-show="syncPreview?.summary?.cfsToCreate > 0" style="color:#3fb950">
+          <div x-show="syncPreview?.summary?.cfsToCreate > 0" style="color:var(--accent-green)">
             <span x-text="syncPreview?.summary?.cfsToCreate"></span> CFs to create
           </div>
-          <div x-show="syncPreview?.summary?.cfsToUpdate > 0" style="color:#58a6ff">
+          <div x-show="syncPreview?.summary?.cfsToUpdate > 0" style="color:var(--accent-blue)">
             <span x-text="syncPreview?.summary?.cfsToUpdate"></span> CFs to update
           </div>
-          <div x-show="syncPreview?.summary?.scoresToSet > 0" style="color:#d29922">
+          <div x-show="syncPreview?.summary?.scoresToSet > 0" style="color:var(--accent-orange)">
             <span x-text="syncPreview?.summary?.scoresToSet"></span> scores to set/update
           </div>
-          <div x-show="syncPreview?.summary?.scoresToZero > 0" style="color:#f47067">
+          <div x-show="syncPreview?.summary?.scoresToZero > 0" style="color:var(--accent-red-soft)">
             <span x-text="syncPreview?.summary?.scoresToZero"></span> extra scores will be zeroed
           </div>
-          <div x-show="syncPreview?.summary?.cfsUnchanged > 0" style="color:#aaa">
+          <div x-show="syncPreview?.summary?.cfsUnchanged > 0" style="color:var(--text-muted)">
             <span x-text="syncPreview?.summary?.cfsUnchanged"></span> CFs unchanged
           </div>
-          <div x-show="syncPreview?.summary?.scoresUnchanged > 0" style="color:#aaa">
+          <div x-show="syncPreview?.summary?.scoresUnchanged > 0" style="color:var(--text-muted)">
             <span x-text="syncPreview?.summary?.scoresUnchanged"></span> scores already correct
           </div>
           <template x-for="s in (syncPreview?.settingsPreview || [])" :key="s">
-            <div style="color:#58a6ff"><span x-text="s"></span></div>
+            <div style="color:var(--accent-blue)"><span x-text="s"></span></div>
           </template>
           <template x-for="q in (syncPreview?.qualityPreview || [])" :key="q">
-            <div style="color:#d29922"><span x-text="q"></span></div>
+            <div style="color:var(--accent-orange)"><span x-text="q"></span></div>
           </template>
-          <div x-show="syncPreview?.error" style="color:#f47067" x-text="syncPreview?.error"></div>
+          <div x-show="syncPreview?.error" style="color:var(--accent-red-soft)" x-text="syncPreview?.error"></div>
         </div>
       </div>
       <!-- Sync behavior rules -->
-      <div style="margin-bottom:12px;padding:10px 12px;background:#161b22;border:1px solid #30363d;border-radius:6px">
-        <div style="font-size:12px;font-weight:600;color:#e1e4e8;margin-bottom:8px">Custom Formats</div>
+      <div style="margin-bottom:12px;padding:10px 12px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:6px">
+        <div style="font-size:12px;font-weight:600;color:var(--text-primary);margin-bottom:8px">Custom Formats</div>
         <div style="display:flex;flex-direction:column;gap:10px">
           <!-- Behavior dropdowns are driven by the backend manifest:
                manifest.syncBehaviorAddModes / RemoveModes / ResetModes.
@@ -106,33 +106,33 @@
                internal/core/enums.go so backend validators and UI render
                from one source. -->
           <div>
-            <label style="font-size:13px;color:#aaa;display:block;margin-bottom:3px">Add</label>
+            <label style="font-size:13px;color:var(--text-muted);display:block;margin-bottom:3px">Add</label>
             <select class="input" x-model="syncForm.behavior.addMode" style="font-size:12px;width:100%" @change="fetchSyncPreview()">
               <template x-for="opt in (manifest.syncBehaviorAddModes || [])" :key="opt.value">
                 <option :value="opt.value" x-text="opt.label"></option>
               </template>
             </select>
-            <div style="font-size:12px;color:#aaa;margin-top:3px;line-height:1.5"
+            <div style="font-size:12px;color:var(--text-muted);margin-top:3px;line-height:1.5"
               x-text="manifestEnumDescription('syncBehaviorAddModes', syncForm.behavior.addMode)"></div>
           </div>
           <div>
-            <label style="font-size:13px;color:#aaa;display:block;margin-bottom:3px">Scores</label>
+            <label style="font-size:13px;color:var(--text-muted);display:block;margin-bottom:3px">Scores</label>
             <select class="input" x-model="syncForm.behavior.removeMode" style="font-size:12px;width:100%" @change="fetchSyncPreview()">
               <template x-for="opt in (manifest.syncBehaviorRemoveModes || [])" :key="opt.value">
                 <option :value="opt.value" x-text="opt.label"></option>
               </template>
             </select>
-            <div style="font-size:12px;color:#aaa;margin-top:3px;line-height:1.5"
+            <div style="font-size:12px;color:var(--text-muted);margin-top:3px;line-height:1.5"
               x-text="manifestEnumDescription('syncBehaviorRemoveModes', syncForm.behavior.removeMode)"></div>
           </div>
           <div x-show="syncMode === 'update'">
-            <label style="font-size:13px;color:#aaa;display:block;margin-bottom:3px">Reset</label>
+            <label style="font-size:13px;color:var(--text-muted);display:block;margin-bottom:3px">Reset</label>
             <select class="input" x-model="syncForm.behavior.resetMode" style="font-size:12px;width:100%" @change="fetchSyncPreview()">
               <template x-for="opt in (manifest.syncBehaviorResetModes || [])" :key="opt.value">
                 <option :value="opt.value" x-text="opt.label"></option>
               </template>
             </select>
-            <div style="font-size:12px;color:#aaa;margin-top:3px;line-height:1.5"
+            <div style="font-size:12px;color:var(--text-muted);margin-top:3px;line-height:1.5"
               x-text="manifestEnumDescription('syncBehaviorResetModes', syncForm.behavior.resetMode)"></div>
           </div>
         </div>
@@ -140,16 +140,16 @@
 
       <!-- Auto-sync toggle (hidden for builder profiles and Compare sync) -->
       <template x-if="!syncForm.importedProfileId && !syncForm._fromCompare">
-        <div style="margin-bottom:12px;padding:8px 12px;background:#161b22;border:1px solid #30363d;border-radius:6px">
-          <label style="display:flex;align-items:center;gap:8px;cursor:pointer;font-size:13px;color:#e1e4e8">
-            <input type="checkbox" :checked="autoSyncRuleForSync?.enabled" @change="toggleAutoSyncForProfile($event.target.checked)" style="accent-color:#58a6ff">
+        <div style="margin-bottom:12px;padding:8px 12px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:6px">
+          <label style="display:flex;align-items:center;gap:8px;cursor:pointer;font-size:13px;color:var(--text-primary)">
+            <input type="checkbox" :checked="autoSyncRuleForSync?.enabled" @change="toggleAutoSyncForProfile($event.target.checked)" style="accent-color:var(--accent-blue)">
             Auto-sync this profile
           </label>
-          <div style="font-size:13px;color:#aaa;margin-top:4px;margin-left:22px">When TRaSH Guides updates, automatically sync changes to this instance</div>
+          <div style="font-size:13px;color:var(--text-muted);margin-top:4px;margin-left:22px">When TRaSH Guides updates, automatically sync changes to this instance</div>
         </div>
       </template>
       </div><!-- /scroll region -->
-      <div class="modal-actions" style="flex-shrink:0;padding:16px 24px;border-top:1px solid #21262d;background:#161b22">
+      <div class="modal-actions" style="flex-shrink:0;padding:16px 24px;border-top:1px solid var(--bg-muted);background:var(--bg-card)">
         <button class="btn" @click="showSyncModal = false">Cancel</button>
         <button class="btn btn-blue" @click="startDryRun()" :disabled="syncing || (syncMode === 'create' && !syncForm.newProfileName.trim()) || (syncMode === 'update' && (!syncForm.arrProfileId || syncForm.arrProfileId === '0'))">Dry Run</button>
         <button class="btn btn-primary" @click="startApply()" :disabled="syncing || (syncMode === 'create' && !syncForm.newProfileName.trim()) || (syncMode === 'update' && (!syncForm.arrProfileId || syncForm.arrProfileId === '0'))">

--- a/ui/static/partials/modals/toasts.html
+++ b/ui/static/partials/modals/toasts.html
@@ -2,7 +2,7 @@
   <!-- Toast notifications -->
   <div style="position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:10000;display:flex;flex-direction:column;gap:8px;max-width:450px;width:100%;max-height:80vh;overflow-y:auto">
     <template x-for="toast in toasts" :key="toast.id">
-      <div :style="'position:relative;padding:10px 14px;border-radius:8px;font-size:12px;line-height:1.5;box-shadow:0 4px 12px rgba(0,0,0,0.4);cursor:pointer;animation:fadeIn 0.2s;overflow:hidden;' + (toast.type === 'warning' ? 'background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--cat-hq-release-groups)' : toast.type === 'error' ? 'background:var(--accent-red-bg);border:1px solid var(--accent-red);color:var(--accent-red)' : 'background:var(--fill-blue-soft);border:1px solid var(--accent-green-strong);color:var(--accent-green)')"
+      <div :style="'position:relative;padding:10px 14px;border-radius:8px;font-size:12px;line-height:1.5;box-shadow:0 4px 12px var(--alpha-shadow);cursor:pointer;animation:fadeIn 0.2s;overflow:hidden;' + (toast.type === 'warning' ? 'background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--accent-orange)' : toast.type === 'error' ? 'background:var(--accent-red-bg);border:1px solid var(--accent-red);color:var(--accent-red)' : 'background:var(--accent-green-bg);border:1px solid var(--accent-green-strong);color:var(--accent-green)')"
            @click="toasts = toasts.filter(t => t.id !== toast.id)">
         <span style="white-space:pre-line" x-text="toast.message"></span>
         <div :style="'position:absolute;bottom:0;left:0;height:3px;border-radius:0 0 8px 8px;opacity:0.6;background:currentColor;animation:toastProgress ' + (toast.duration || 8000) + 'ms linear forwards'"></div>

--- a/ui/static/partials/modals/toasts.html
+++ b/ui/static/partials/modals/toasts.html
@@ -2,7 +2,7 @@
   <!-- Toast notifications -->
   <div style="position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:10000;display:flex;flex-direction:column;gap:8px;max-width:450px;width:100%;max-height:80vh;overflow-y:auto">
     <template x-for="toast in toasts" :key="toast.id">
-      <div :style="'position:relative;padding:10px 14px;border-radius:8px;font-size:12px;line-height:1.5;box-shadow:0 4px 12px rgba(0,0,0,0.4);cursor:pointer;animation:fadeIn 0.2s;overflow:hidden;' + (toast.type === 'warning' ? 'background:#2d1b00;border:1px solid #d29922;color:#e3b341' : toast.type === 'error' ? 'background:#3d1f1f;border:1px solid #f85149;color:#f85149' : 'background:#0d2818;border:1px solid #238636;color:#3fb950')"
+      <div :style="'position:relative;padding:10px 14px;border-radius:8px;font-size:12px;line-height:1.5;box-shadow:0 4px 12px rgba(0,0,0,0.4);cursor:pointer;animation:fadeIn 0.2s;overflow:hidden;' + (toast.type === 'warning' ? 'background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--cat-hq-release-groups)' : toast.type === 'error' ? 'background:var(--accent-red-bg);border:1px solid var(--accent-red);color:var(--accent-red)' : 'background:var(--fill-blue-soft);border:1px solid var(--accent-green-strong);color:var(--accent-green)')"
            @click="toasts = toasts.filter(t => t.id !== toast.id)">
         <span style="white-space:pre-line" x-text="toast.message"></span>
         <div :style="'position:absolute;bottom:0;left:0;height:3px;border-radius:0 0 8px 8px;opacity:0.6;background:currentColor;animation:toastProgress ' + (toast.duration || 8000) + 'ms linear forwards'"></div>

--- a/ui/static/partials/overlays/profile-builder.html
+++ b/ui/static/partials/overlays/profile-builder.html
@@ -14,15 +14,15 @@
         </template>
         <template x-if="pb.editId">
           <div style="display:flex;gap:6px">
-            <button class="btn" style="border-color:#238636;color:#3fb950" @click="saveAndSyncBuilder()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save changes and sync to existing Arr profile'">Save & Sync</button>
-            <button class="btn" style="border-color:#58a6ff;color:#58a6ff" @click="saveAndSyncBuilderAsNew()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save and create as new Arr profile'">Create New</button>
+            <button class="btn" style="border-color:var(--accent-green-strong);color:var(--accent-green)" @click="saveAndSyncBuilder()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save changes and sync to existing Arr profile'">Save & Sync</button>
+            <button class="btn" style="border-color:var(--accent-blue);color:var(--accent-blue)" @click="saveAndSyncBuilderAsNew()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save and create as new Arr profile'">Create New</button>
           </div>
         </template>
       </div>
 
       <!-- Info banner when editing from Sync Rules -->
       <template x-if="_resyncReturnSubTab && pb.editId">
-        <div style="margin-top:8px;padding:8px 14px;background:#1a1500;border:1px solid #d29922;border-radius:6px;font-size:13px;color:#d29922;line-height:1.5">
+        <div style="margin-top:8px;padding:8px 14px;background:var(--accent-orange-bg);border:1px solid var(--accent-orange);border-radius:6px;font-size:13px;color:var(--accent-orange);line-height:1.5">
           <strong>Editing synced profile</strong> — Changes here modify the profile itself, which affects all sync rules using it. Use <strong>Save & Sync</strong> to apply changes to Arr, or <strong>Cancel</strong> to discard.
         </div>
       </template>
@@ -32,24 +32,24 @@
         <div class="profile-group-header" @click="pbSettingsOpen = !pbSettingsOpen">
           <span class="profile-group-chevron" :class="{ open: pbSettingsOpen }">&#9654;</span>
           <span>Profile Settings</span>
-          <span style="font-size:12px;color:#aaa;margin-left:auto" x-text="pbSelectedCount() + ' CFs selected'"></span>
+          <span style="font-size:12px;color:var(--text-muted);margin-left:auto" x-text="pbSelectedCount() + ' CFs selected'"></span>
         </div>
         <div x-show="pbSettingsOpen">
           <div style="padding:14px 20px;display:flex;flex-direction:column;gap:14px">
             <!-- Profile Name -->
             <div class="pb-header" style="margin-bottom:0">
-              <input type="text" x-model="pb.name" placeholder="Profile name..." :style="pb.name ? '' : 'border-bottom-color:#f85149'">
+              <input type="text" x-model="pb.name" placeholder="Profile name..." :style="pb.name ? '' : 'border-bottom-color:var(--accent-red)'">
             </div>
             <!-- Initialize from — pick a starting point for scores and settings. Tabs separate
                  the two import sources; user picks one, clicks Apply. Advanced users can also
                  skip this entirely (Builder opens blank). -->
-            <div class="pd-card" style="border-left:3px solid #f0883e">
-              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid #21262d">
-                <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Initialize from</span>
-                <span style="font-size:11px;color:#8b949e" x-text="pb.appType === 'radarr' ? 'Scores, cutoff, quality items and language get applied' : 'Scores, cutoff and quality items get applied'"></span>
+            <div class="pd-card" style="border-left:3px solid var(--accent-orange-bright)">
+              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid var(--bg-muted)">
+                <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Initialize from</span>
+                <span style="font-size:11px;color:var(--text-secondary)" x-text="pb.appType === 'radarr' ? 'Scores, cutoff, quality items and language get applied' : 'Scores, cutoff and quality items get applied'"></span>
               </div>
               <!-- Tab bar -->
-              <div style="display:inline-flex;background:#0d1117;border:1px solid #30363d;border-radius:6px;overflow:hidden;margin-bottom:12px">
+              <div style="display:inline-flex;background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;overflow:hidden;margin-bottom:12px">
                 <button type="button" class="pb-init-tab" :class="pbInitTab === 'trash' ? 'active' : ''" @click="pbInitTab = 'trash'">TRaSH template</button>
                 <button type="button" class="pb-init-tab" :class="pbInitTab === 'instance' ? 'active' : ''" @click="pbInitTab = 'instance'">Instance profile</button>
               </div>
@@ -103,8 +103,8 @@
             <div style="display:grid;grid-template-columns:1fr 1fr;gap:14px">
               <!-- General card -->
               <div class="pd-card pd-card-general">
-                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid #21262d">
-                  <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">General</span>
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid var(--bg-muted)">
+                  <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">General</span>
                 </div>
                 <div style="display:flex;flex-direction:column;gap:4px">
                   <div class="pd-row" x-show="pb.appType === 'radarr'">
@@ -149,8 +149,8 @@
               <!-- Quality card. Spans full grid width when the items editor is open so
                    drag-drop has room (avoids column-count overflow in the narrow half-width). -->
               <div class="pd-card pd-card-quality" :style="pb.qualityEditorOpen ? 'grid-column:1/-1' : ''">
-                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid #21262d">
-                  <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality</span>
+                <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;padding-bottom:8px;border-bottom:1px solid var(--bg-muted)">
+                  <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality</span>
                 </div>
                 <div style="display:flex;flex-direction:column;gap:4px">
                   <div class="pd-row">
@@ -180,28 +180,28 @@
                     </select>
                   </div>
                 </div>
-                <div style="margin-top:14px;padding-top:10px;border-top:1px solid #21262d;display:flex;align-items:center;justify-content:space-between;gap:10px">
+                <div style="margin-top:14px;padding-top:10px;border-top:1px solid var(--bg-muted);display:flex;align-items:center;justify-content:space-between;gap:10px">
                   <div style="display:flex;align-items:center;gap:8px;min-width:0">
-                    <span style="font-size:13px;color:#aaa">Quality Items</span>
+                    <span style="font-size:13px;color:var(--text-muted)">Quality Items</span>
                     <template x-if="(pb.qualityItems || []).length > 0">
-                      <span style="font-size:11px;color:#8b949e;background:#21262d;padding:1px 6px;border-radius:8px" x-text="pb.qualityItems.filter(q => q.allowed).length + '/' + pb.qualityItems.length + ' allowed'"></span>
+                      <span style="font-size:11px;color:var(--text-secondary);background:var(--bg-muted);padding:1px 6px;border-radius:8px" x-text="pb.qualityItems.filter(q => q.allowed).length + '/' + pb.qualityItems.length + ' allowed'"></span>
                     </template>
                   </div>
-                  <button class="btn" style="font-size:12px;padding:2px 10px;border-color:#a371f7;color:#a371f7"
+                  <button class="btn" style="font-size:12px;padding:2px 10px;border-color:var(--accent-purple);color:var(--accent-purple)"
                           @click="pb.qualityEditorOpen = !pb.qualityEditorOpen; if(pb.qualityEditorOpen) { if(pb.qualityItems.length === 0) pbInitQualityEditor(); pbEnsureQualityIds(); } else { qsCloseSharedState(); }"
                           x-text="pb.qualityEditorOpen ? '✓ Done' : 'Edit Quality Items'"></button>
                 </div>
-                <div x-show="pb.qualityAllowedNames && !pb.qualityEditorOpen" style="margin-top:8px;font-size:12px;color:#aaa">
-                  <span style="color:#58a6ff" x-text="pb.cutoff"></span>
+                <div x-show="pb.qualityAllowedNames && !pb.qualityEditorOpen" style="margin-top:8px;font-size:12px;color:var(--text-muted)">
+                  <span style="color:var(--accent-blue)" x-text="pb.cutoff"></span>
                   <span style="margin:0 3px">—</span>
-                  <span style="color:#aaa" x-text="pb.qualityAllowedNames"></span>
+                  <span style="color:var(--text-muted)" x-text="pb.qualityAllowedNames"></span>
                 </div>
 
                 <!-- CF Group Variants sub-section — only shown when the current template/profile
                      exposes variant-configurable groups (Golden Rule, Miscellaneous). -->
                 <template x-if="pbHasGroupVariants()">
-                  <div style="margin-top:14px;padding-top:10px;border-top:1px solid #21262d">
-                    <div style="font-size:11px;color:#8b949e;text-transform:uppercase;letter-spacing:0.5px;font-weight:600;margin-bottom:8px">CF Group Variants</div>
+                  <div style="margin-top:14px;padding-top:10px;border-top:1px solid var(--bg-muted)">
+                    <div style="font-size:11px;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;font-weight:600;margin-bottom:8px">CF Group Variants</div>
                     <div style="display:flex;flex-direction:column;gap:4px">
                       <div class="pd-row" x-show="pbGroupVariant('Golden Rule')">
                         <span class="pd-label">Golden Rule</span>
@@ -229,18 +229,18 @@
                      Uses qs-* helpers with target='builder' so all drag-drop/rename/group operations
                      mutate pb.qualityItems instead of qualityStructure. Edit Groups toggle + expanded +
                      rename + drag state are shared (only one editor open at a time). -->
-                <div x-show="pb.qualityEditorOpen" x-cloak style="margin-top:12px;border-top:1px solid #21262d;padding-top:12px"
+                <div x-show="pb.qualityEditorOpen" x-cloak style="margin-top:12px;border-top:1px solid var(--bg-muted);padding-top:12px"
                      :class="qualityStructureEditMode ? 'qs-edit-on' : ''">
                   <div style="display:flex;align-items:center;gap:8px;margin-bottom:10px;flex-wrap:wrap">
-                    <div style="font-size:12px;color:#aaa" x-show="!qualityStructureEditMode">Toggle resolutions on/off. Qualities higher in the list are more preferred.</div>
-                    <div style="font-size:12px;color:#aaa" x-show="qualityStructureEditMode">Drag rows to reorder · drop on a row to merge · click group name to rename</div>
+                    <div style="font-size:12px;color:var(--text-muted)" x-show="!qualityStructureEditMode">Toggle resolutions on/off. Qualities higher in the list are more preferred.</div>
+                    <div style="font-size:12px;color:var(--text-muted)" x-show="qualityStructureEditMode">Drag rows to reorder · drop on a row to merge · click group name to rename</div>
                     <div style="flex:1"></div>
                     <button class="btn" style="font-size:12px;padding:2px 10px"
-                            :style="qualityStructureEditMode ? 'background:#238636;border-color:#238636;color:#fff' : ''"
+                            :style="qualityStructureEditMode ? 'background:var(--accent-green-strong);border-color:var(--accent-green-strong);color:var(--text-on-accent)' : ''"
                             @click="qualityStructureEditMode = !qualityStructureEditMode; if (!qualityStructureEditMode) { qualityStructureExpanded = {}; qualityStructureRenaming = null; }">
                       <span x-text="qualityStructureEditMode ? '✓ Done Editing Groups' : 'Edit Groups'"></span>
                     </button>
-                    <button class="btn" style="font-size:12px;padding:2px 10px;border-color:#d29922;color:#d29922"
+                    <button class="btn" style="font-size:12px;padding:2px 10px;border-color:var(--accent-orange);color:var(--accent-orange)"
                             x-tt="'Clear quality items — re-apply a preset to repopulate'"
                             @click="qsResetAll('builder')">Reset</button>
                   </div>
@@ -292,7 +292,7 @@
                           <template x-if="qualityStructureRenaming !== item._id">
                             <span class="qs-name"
                                   :class="(qualityStructureEditMode && item.items) ? 'editable' : ''"
-                                  :style="item.allowed ? 'color:#e1e4e8' : 'color:#aaa'"
+                                  :style="item.allowed ? 'color:var(--text-primary)' : 'color:var(--text-muted)'"
                                   @click="if (qualityStructureEditMode && item.items) qsStartRename(item)"
                                   x-text="item.name"></span>
                           </template>
@@ -346,22 +346,22 @@
 
             <!-- TRaSH schema fields — collapsible, grey stripe. Gated by CLONARR_DEV_FEATURES env + trashSchemaFields toggle. -->
             <template x-if="config.devFeatures && config.trashSchemaFields">
-              <div class="pd-card" style="border-left:3px solid #6e7681;padding:10px 18px">
+              <div class="pd-card" style="border-left:3px solid var(--text-muted-secondary);padding:10px 18px">
                 <div @click="pbAdvancedOpen = !pbAdvancedOpen" style="cursor:pointer;display:flex;align-items:center;gap:8px">
-                  <span style="color:#8b949e" x-text="pbAdvancedOpen ? '▾' : '▸'"></span>
-                  <span style="font-size:12px;color:#8b949e;text-transform:uppercase;letter-spacing:0.5px;font-weight:700">Advanced Mode</span>
-                  <span style="font-size:11px;color:#8b949e">TRaSH ID, Group number, HTML description</span>
+                  <span style="color:var(--text-secondary)" x-text="pbAdvancedOpen ? '▾' : '▸'"></span>
+                  <span style="font-size:12px;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;font-weight:700">Advanced Mode</span>
+                  <span style="font-size:11px;color:var(--text-secondary)">TRaSH ID, Group number, HTML description</span>
                 </div>
                 <div x-show="pbAdvancedOpen" style="margin-top:12px">
                 <div class="pb-dev-fields">
-                  <div style="font-size:12px;color:#d29922;margin-bottom:6px">Advanced fields</div>
+                  <div style="font-size:12px;color:var(--accent-orange);margin-bottom:6px">Advanced fields</div>
                 <div class="pb-wide-row" style="margin-bottom:6px">
                   <span class="pb-lbl">Trash ID</span>
                   <input type="text" class="pb-input" x-model="pb.trashProfileId" placeholder="UUID" style="width:240px;font-family:monospace">
                   <button class="btn btn-sm" @click="pb.trashProfileId = genUUID(true)" style="padding:2px 8px;font-size:12px">Generate</button>
-                  <span style="font-size:13px;color:#aaa;margin-left:8px">Score Set</span>
+                  <span style="font-size:13px;color:var(--text-muted);margin-left:8px">Score Set</span>
                   <input type="text" class="pb-input" x-model="pb.trashScoreSet" @change="_pbSaveDefaults()" placeholder="e.g. sqp-3" style="width:100px">
-                  <span style="font-size:13px;color:#aaa;margin-left:8px">Group</span>
+                  <span style="font-size:13px;color:var(--text-muted);margin-left:8px">Group</span>
                   <input type="number" class="pb-input" x-model.number="pb.groupNum" style="width:50px">
                 </div>
                 <div class="pb-wide-row" style="align-items:flex-start">
@@ -396,19 +396,19 @@
               <span class="pb-cat-count" x-text="pbFormatItemCount() + ' in formatItems'"></span>
             </div>
             <div x-show="pbExpandedCats['__formatItems__'] ?? true">
-              <div style="padding:8px 16px;font-size:12px;color:#aaa;border-bottom:1px solid #161b22;line-height:1.5">
-                These CFs are added to the profile's <code style="background:#21262d;padding:1px 4px;border-radius:2px;color:#c9d1d9;font-size:13px">formatItems</code> — they are mandatory and always synced. End users cannot disable them.
+              <div style="padding:8px 16px;font-size:12px;color:var(--text-muted);border-bottom:1px solid var(--bg-card);line-height:1.5">
+                These CFs are added to the profile's <code style="background:var(--bg-muted);padding:1px 4px;border-radius:2px;color:var(--text-body);font-size:13px">formatItems</code> — they are mandatory and always synced. End users cannot disable them.
               </div>
               <!-- Clear All button (above CFs) -->
               <div x-show="pbFormatItemCFList().length > 0" style="padding:6px 16px 0;display:flex;justify-content:flex-end">
-                <button class="btn" style="font-size:12px;padding:2px 10px;color:#f85149;border-color:#f85149"
+                <button class="btn" style="font-size:12px;padding:2px 10px;color:var(--accent-red);border-color:var(--accent-red)"
                         @click="const fis = Object.keys(pb.formatItemCFs || {}); fis.forEach(tid => { delete pb.formatItemCFs[tid]; delete pb.selectedCFs[tid]; }); pb.formatItemCFs = {...pb.formatItemCFs}; pb.selectedCFs = {...pb.selectedCFs}">
                   Clear All
                 </button>
               </div>
               <!-- Selected formatItem CFs (multi-column compact view) -->
               <div x-show="pbFormatItemCFList().length > 0"
-                   :style="'padding:10px 28px 14px;border-bottom:1px solid #161b22;column-count:' + (pbFormatItemCFList().length > 20 ? 3 : pbFormatItemCFList().length > 10 ? 2 : 1) + ';column-gap:32px'">
+                   :style="'padding:10px 28px 14px;border-bottom:1px solid var(--bg-card);column-count:' + (pbFormatItemCFList().length > 20 ? 3 : pbFormatItemCFList().length > 10 ? 2 : 1) + ';column-gap:32px'">
                 <template x-for="cf in pbFormatItemCFList()" :key="'fis-'+cf.trashId">
                   <div style="break-inside:avoid;display:flex;align-items:center;gap:6px;padding:3px 0">
                     <label class="toggle toggle-sm" style="flex-shrink:0">
@@ -429,8 +429,8 @@
                 </template>
               </div>
               <!-- Add more CFs (collapsed, with search) -->
-              <div style="padding:6px 16px;border-top:1px solid #161b22;display:flex;align-items:center;gap:12px">
-                <span style="font-size:13px;color:#58a6ff;cursor:pointer;flex-shrink:0"
+              <div style="padding:6px 16px;border-top:1px solid var(--bg-card);display:flex;align-items:center;gap:12px">
+                <span style="font-size:13px;color:var(--accent-blue);cursor:pointer;flex-shrink:0"
                       @click="pbAddMoreOpen = !pbAddMoreOpen; pbFormatItemSearch = ''"
                       x-text="pbAddMoreOpen ? '▾ Hide available CFs' : '▸ Add more CFs...'"></span>
                 <template x-if="pbAddMoreOpen">
@@ -454,7 +454,7 @@
                             @mouseleave="hideCFTooltip()">ⓘ</span>
                     </div>
                   </template>
-                  <div x-show="pbFilteredAvailableCFs().length === 0" style="font-size:12px;color:#aaa;padding:4px 0">
+                  <div x-show="pbFilteredAvailableCFs().length === 0" style="font-size:12px;color:var(--text-muted);padding:4px 0">
                     No matching CFs found
                   </div>
                 </div>
@@ -463,8 +463,8 @@
           </div>
 
           <!-- ===== SECTION 2: CF Groups ===== -->
-          <div style="font-size:13px;font-weight:500;color:#e1e4e8;margin:16px 0 8px">CF Groups</div>
-          <div style="font-size:12px;color:#aaa;margin-bottom:12px;line-height:1.5">
+          <div style="font-size:13px;font-weight:500;color:var(--text-primary);margin:16px 0 8px">CF Groups</div>
+          <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px;line-height:1.5">
             Each group is an independent set of CFs. Use the toggle to include a group for this profile.
             Use <span class="pb-state-pill active-req" style="cursor:default;font-size:11px">Req</span>
             <span class="pb-state-pill active-opt" style="cursor:default;font-size:11px">Opt</span>
@@ -501,11 +501,11 @@
               </div>
               <!-- Group description -->
               <div x-show="pbExpandedGroups[group.groupTrashId] && group.trashDescription"
-                   style="padding:8px 16px;font-size:12px;color:#aaa;border-bottom:1px solid #161b22;line-height:1.6"
+                   style="padding:8px 16px;font-size:12px;color:var(--text-muted);border-bottom:1px solid var(--bg-card);line-height:1.6"
                    x-html="sanitizeHTML(group.trashDescription)"></div>
               <!-- Exclusive warning -->
               <div x-show="pbExpandedGroups[group.groupTrashId] && group.exclusive"
-                   style="padding:8px 16px;font-size:12px;color:#d29922;line-height:1.5">
+                   style="padding:8px 16px;font-size:12px;color:var(--accent-orange);line-height:1.5">
                 Please ensure you only score or enable one of them in your Quality Profile!
               </div>
               <!-- CFs in this group -->
@@ -530,7 +530,7 @@
                             @mouseenter="showCFTooltip($event, cf.description)"
                             @mouseleave="hideCFTooltip()">ⓘ</span>
                       <template x-if="config.devFeatures && config.trashSchemaFields">
-                        <span style="font-size:12px;color:#aaa;font-family:monospace" x-text="cf.trashId.substring(0,8)"></span>
+                        <span style="font-size:12px;color:var(--text-muted);font-family:monospace" x-text="cf.trashId.substring(0,8)"></span>
                       </template>
                     </div>
                     <!-- Three-state pills: Req / Opt / Fmt -->
@@ -583,8 +583,8 @@
         </template>
         <template x-if="pb.editId">
           <div style="display:flex;gap:6px">
-            <button class="btn" style="border-color:#238636;color:#3fb950" @click="saveAndSyncBuilder()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save changes and sync to existing Arr profile'">Save & Sync</button>
-            <button class="btn" style="border-color:#58a6ff;color:#58a6ff" @click="saveAndSyncBuilderAsNew()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save and create as new Arr profile'">Create New</button>
+            <button class="btn" style="border-color:var(--accent-green-strong);color:var(--accent-green)" @click="saveAndSyncBuilder()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save changes and sync to existing Arr profile'">Save & Sync</button>
+            <button class="btn" style="border-color:var(--accent-blue);color:var(--accent-blue)" @click="saveAndSyncBuilderAsNew()" :disabled="!pb.name.trim() || pbSelectedCount() === 0 || pbSaving" x-tt="'Save and create as new Arr profile'">Create New</button>
           </div>
         </template>
       </div>

--- a/ui/static/partials/overlays/profile-builder.html
+++ b/ui/static/partials/overlays/profile-builder.html
@@ -261,7 +261,7 @@
                                'dnd-merge-hover': qualityStructureDrag.dropMerge === idx
                              }"
                              :draggable="qualityStructureEditMode"
-                             @dragstart="if (qualityStructureEditMode) { qualityStructureDrag.kind = 'top'; qualityStructureDrag.src = idx; }"
+                             @dragstart="if (qualityStructureEditMode) { event.dataTransfer.setData('text/plain', ''); qualityStructureDrag.kind = 'top'; qualityStructureDrag.src = idx; }"
                              @dragover.prevent="if (qualityStructureEditMode && qualityStructureDrag.kind && !(qualityStructureDrag.kind === 'top' && qualityStructureDrag.src === idx)) qualityStructureDrag.dropMerge = idx"
                              @dragleave="if (qualityStructureDrag.dropMerge === idx) qualityStructureDrag.dropMerge = null"
                              @drop.prevent="qsHandleDropOnRow(idx, 'builder')"
@@ -321,7 +321,7 @@
                                  :class="{ 'is-dragging': qualityStructureDrag.kind === 'member' && qualityStructureDrag.srcGroup === idx && qualityStructureDrag.srcMember === mIdx }">
                               <span class="qs-pill"
                                     draggable="true"
-                                    @dragstart.stop="qualityStructureDrag.kind = 'member'; qualityStructureDrag.srcGroup = idx; qualityStructureDrag.srcMember = mIdx"
+                                    @dragstart.stop="event.dataTransfer.setData('text/plain', ''); qualityStructureDrag.kind = 'member'; qualityStructureDrag.srcGroup = idx; qualityStructureDrag.srcMember = mIdx"
                                     @dragend="qsResetDrag()"
                                     x-text="m"></span>
                               <div style="flex:1"></div>

--- a/ui/static/partials/overlays/profile-detail.html
+++ b/ui/static/partials/overlays/profile-detail.html
@@ -501,8 +501,8 @@
                                  'is-dragging': qualityStructureDrag.kind === 'top' && qualityStructureDrag.src === idx,
                                  'dnd-merge-hover': qualityStructureDrag.dropMerge === idx
                                }"
-                               :draggable="true"
-                               @dragstart="qualityStructureDrag.kind = 'top'; qualityStructureDrag.src = idx;"
+                               :draggable="qualityStructureEditMode"
+                               @dragstart="if (qualityStructureEditMode) { event.dataTransfer.setData('text/plain', ''); qualityStructureDrag.kind = 'top'; qualityStructureDrag.src = idx; }"
                                @dragover.prevent="if (qualityStructureEditMode && qualityStructureDrag.kind && !(qualityStructureDrag.kind === 'top' && qualityStructureDrag.src === idx)) qualityStructureDrag.dropMerge = idx"
                                @dragleave="if (qualityStructureDrag.dropMerge === idx) qualityStructureDrag.dropMerge = null"
                                @drop.prevent="if (qualityStructureEditMode) qsHandleDropOnRow(idx)"
@@ -563,7 +563,7 @@
                                    :class="{ 'is-dragging': qualityStructureDrag.kind === 'member' && qualityStructureDrag.srcGroup === idx && qualityStructureDrag.srcMember === mIdx }">
                                 <span class="qs-pill"
                                       draggable="true"
-                                      @dragstart.stop="qualityStructureDrag.kind = 'member'; qualityStructureDrag.srcGroup = idx; qualityStructureDrag.srcMember = mIdx"
+                                      @dragstart.stop="event.dataTransfer.setData('text/plain', ''); qualityStructureDrag.kind = 'member'; qualityStructureDrag.srcGroup = idx; qualityStructureDrag.srcMember = mIdx"
                                       @dragend="qsResetDrag()"
                                       x-text="m"></span>
                                 <div style="flex:1"></div>

--- a/ui/static/partials/overlays/profile-detail.html
+++ b/ui/static/partials/overlays/profile-detail.html
@@ -24,9 +24,9 @@
           <!-- Change details (quality, settings, CF, score) -->
           <template x-if="[...(syncResult.cfDetails || []), ...(syncResult.scoreDetails || []), ...(syncResult.qualityDetails || []), ...(syncResult.settingsDetails || [])].length > 0">
             <div style="margin-top:6px">
-              <a style="font-size:12px;color:#58a6ff;cursor:pointer;user-select:none" @click="syncResultDetailsOpen = !syncResultDetailsOpen"
+              <a style="font-size:12px;color:var(--accent-blue);cursor:pointer;user-select:none" @click="syncResultDetailsOpen = !syncResultDetailsOpen"
                  x-text="syncResultDetailsOpen ? '▾ Hide details' : '▸ Show details (' + [...(syncResult.cfDetails || []), ...(syncResult.scoreDetails || []), ...(syncResult.qualityDetails || []), ...(syncResult.settingsDetails || [])].length + ' changes)'"></a>
-              <div x-show="syncResultDetailsOpen" style="margin-top:4px;font-size:13px;color:#aaa">
+              <div x-show="syncResultDetailsOpen" style="margin-top:4px;font-size:13px;color:var(--text-muted)">
                 <template x-for="(d, i) in [...(syncResult.cfDetails || []), ...(syncResult.scoreDetails || []), ...(syncResult.qualityDetails || []), ...(syncResult.settingsDetails || [])]" :key="i">
                   <div style="padding:1px 0" x-text="d"></div>
                 </template>
@@ -36,7 +36,7 @@
           <template x-if="syncResult.errors?.length">
             <div style="margin-top:8px;font-size:13px">
               <template x-for="(err, i) in syncResult.errors" :key="i">
-                <div style="color:#f0883e;padding:2px 0" x-text="err"></div>
+                <div style="color:var(--accent-orange-bright);padding:2px 0" x-text="err"></div>
               </template>
             </div>
           </template>
@@ -58,27 +58,27 @@
               <span> — <span x-text="syncPlan.summary.scoresToSet"></span> scores to set</span>
             </template>
             <template x-if="syncPlan.summary.scoresToZero > 0">
-              <span style="color:#d29922"> — <span x-text="syncPlan.summary.scoresToZero"></span> extra scores zeroed</span>
+              <span style="color:var(--accent-orange)"> — <span x-text="syncPlan.summary.scoresToZero"></span> extra scores zeroed</span>
             </template>
             <template x-if="(syncPlan.settingsPreview || []).length > 0 || (syncPlan.qualityPreview || []).length > 0 || (syncPlan.cfActions || []).some(a => a.action !== 'unchanged') || (syncPlan.scoreActions || []).some(a => a.action !== 'unchanged')">
               <div style="margin-top:6px">
-                <a style="font-size:12px;color:#58a6ff;cursor:pointer;user-select:none" @click="dryrunDetailsOpen = !dryrunDetailsOpen"
+                <a style="font-size:12px;color:var(--accent-blue);cursor:pointer;user-select:none" @click="dryrunDetailsOpen = !dryrunDetailsOpen"
                    x-text="dryrunDetailsOpen ? '▾ Hide details' : '▸ Show details'"></a>
-                <div x-show="dryrunDetailsOpen" style="margin-top:4px;font-size:12px;color:#c9d1d9;line-height:1.6">
+                <div x-show="dryrunDetailsOpen" style="margin-top:4px;font-size:12px;color:var(--text-body);line-height:1.6">
                   <template x-for="s in (syncPlan.settingsPreview || [])" :key="s">
-                    <div><span style="color:#58a6ff">Settings:</span> <span x-text="s"></span></div>
+                    <div><span style="color:var(--accent-blue)">Settings:</span> <span x-text="s"></span></div>
                   </template>
                   <template x-for="q in (syncPlan.qualityPreview || [])" :key="q">
-                    <div><span style="color:#d29922">Quality:</span> <span x-text="q"></span></div>
+                    <div><span style="color:var(--accent-orange)">Quality:</span> <span x-text="q"></span></div>
                   </template>
                   <template x-for="a in (syncPlan.cfActions || []).filter(a => a.action === 'create')" :key="'cf-'+a.name">
-                    <div><span style="color:#3fb950">Create CF:</span> <span x-text="a.name"></span></div>
+                    <div><span style="color:var(--accent-green)">Create CF:</span> <span x-text="a.name"></span></div>
                   </template>
                   <template x-for="a in (syncPlan.cfActions || []).filter(a => a.action === 'update')" :key="'cfu-'+a.name">
-                    <div><span style="color:#58a6ff">Update CF:</span> <span x-text="a.name"></span></div>
+                    <div><span style="color:var(--accent-blue)">Update CF:</span> <span x-text="a.name"></span></div>
                   </template>
                   <template x-for="a in (syncPlan.scoreActions || []).filter(a => a.action !== 'unchanged')" :key="'sc-'+a.cfName">
-                    <div><span style="color:#d29922">Score:</span> <span x-text="a.cfName + ': ' + a.oldScore + ' → ' + a.newScore"></span></div>
+                    <div><span style="color:var(--accent-orange)">Score:</span> <span x-text="a.cfName + ': ' + a.oldScore + ' → ' + a.newScore"></span></div>
                   </template>
                 </div>
               </div>
@@ -91,18 +91,18 @@
         </div>
       </template>
 
-      <div class="card" :style="profileDetail?.detail?.imported ? 'background:#0d1117' : ''">
+      <div class="card" :style="profileDetail?.detail?.imported ? 'background:var(--bg-page)' : ''">
         <!-- Header -->
-        <div style="padding:16px 20px;border-bottom:1px solid #30363d">
+        <div style="padding:16px 20px;border-bottom:1px solid var(--border-subtle)">
           <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:16px">
             <div style="flex:1;min-width:0">
               <div style="font-size:16px;font-weight:600">
                 <span x-text="profileDetail?.profile?.name"></span>
                 <span class="sqp-badge" x-show="profileDetail?.detail?.scoreCtx && profileDetail?.detail?.scoreCtx !== 'default'" x-text="profileDetail?.detail?.scoreCtx" style="font-size:13px"></span>
               </div>
-              <div style="font-size:12px;color:#aaa;margin-top:4px">
+              <div style="font-size:12px;color:var(--text-muted);margin-top:4px">
                 <template x-if="profileDetail?.instance?.name">
-                  <span><span x-text="profileDetail.instance.name"></span><template x-if="profileDetail._arrProfileName"><span> → <span style="color:#e1e4e8" x-text="profileDetail._arrProfileName"></span></span></template> — </span>
+                  <span><span x-text="profileDetail.instance.name"></span><template x-if="profileDetail._arrProfileName"><span> → <span style="color:var(--text-primary)" x-text="profileDetail._arrProfileName"></span></span></template> — </span>
                 </template>
                 <span x-text="profileDetail?.detail?.totalCoreCFs || 0"></span> <span x-text="profileDetail?.detail?.imported ? 'Custom Formats' : 'Required CFs'"></span>
                 <template x-if="countAllCategoryCFs() > 0">
@@ -110,7 +110,7 @@
                 </template>
               </div>
               <template x-if="profileDetail?.detail?.profile?.trash_description">
-                <div @click="showProfileInfo = !showProfileInfo" style="margin-top:8px;cursor:pointer;font-size:12px;color:#58a6ff;user-select:none;display:inline-block">
+                <div @click="showProfileInfo = !showProfileInfo" style="margin-top:8px;cursor:pointer;font-size:12px;color:var(--accent-blue);user-select:none;display:inline-block">
                   <span x-text="showProfileInfo ? '▾' : '▸'"></span> Profile info
                 </div>
               </template>
@@ -119,26 +119,26 @@
               <button x-show="profileDetail?.detail?.importedRaw && (profileDetail.detail.importedRaw.source === 'custom' || profileDetail.detail.importedRaw.source === 'import' || !profileDetail.detail.importedRaw.source)" class="btn btn-sm" @click="editCustomProfile(profileDetail.detail.importedRaw.appType || profileDetail.instance?.type, profileDetail.detail.importedRaw)">Edit</button>
               <button class="btn btn-sm btn-blue" @click="openExportModal()">Export</button>
               <button class="btn btn-sm btn-primary" @click="openImportedSyncModal()" x-tt="'Save settings and sync to existing Arr profile'">Save & Sync</button>
-              <button class="btn btn-sm" style="border-color:#58a6ff;color:#58a6ff" @click="openImportedSyncModalAsNew()" x-tt="'Create a new Arr profile with these settings'">Create New</button>
+              <button class="btn btn-sm" style="border-color:var(--accent-blue);color:var(--accent-blue)" @click="openImportedSyncModalAsNew()" x-tt="'Create a new Arr profile with these settings'">Create New</button>
             </div>
             <div style="display:flex;gap:8px;flex-shrink:0" x-show="!profileDetail?.detail?.imported">
               <button class="btn btn-sm btn-primary" @click="openSyncModal(profileDetail.instance, profileDetail.profile)" x-tt="'Save settings and sync to existing Arr profile'">Save & Sync</button>
-              <button class="btn btn-sm" style="border-color:#58a6ff;color:#58a6ff" @click="openSyncModalAsNew(profileDetail.instance, profileDetail.profile)" x-tt="'Create a new Arr profile with these settings'">Create New</button>
+              <button class="btn btn-sm" style="border-color:var(--accent-blue);color:var(--accent-blue)" @click="openSyncModalAsNew(profileDetail.instance, profileDetail.profile)" x-tt="'Create a new Arr profile with these settings'">Create New</button>
             </div>
           </div>
           <!-- Profile info panel (full-width below flex row, so expanding it doesn't push buttons) -->
           <template x-if="profileDetail?.detail?.profile?.trash_description">
-            <div x-show="showProfileInfo" x-cloak style="margin-top:10px;padding:12px;background:#0d1117;border:1px solid #21262d;border-radius:6px;font-size:12px;color:#aaa;line-height:1.5">
+            <div x-show="showProfileInfo" x-cloak style="margin-top:10px;padding:12px;background:var(--bg-page);border:1px solid var(--bg-muted);border-radius:6px;font-size:12px;color:var(--text-muted);line-height:1.5">
               <span x-html="sanitizeHTML(profileDetail.detail.profile.trash_description)"></span>
               <template x-if="profileDetail.detail.profile.trash_url">
-                <a :href="profileDetail.detail.profile.trash_url" target="_blank" rel="noopener" style="display:block;margin-top:6px;color:#58a6ff;font-size:13px;text-decoration:none">View on TRaSH Guides &rarr;</a>
+                <a :href="profileDetail.detail.profile.trash_url" target="_blank" rel="noopener" style="display:block;margin-top:6px;color:var(--accent-blue);font-size:13px;text-decoration:none">View on TRaSH Guides &rarr;</a>
               </template>
             </div>
           </template>
         </div>
 
         <!-- Profile settings — unified General + Quality card with per-section overrides -->
-        <div x-show="profileDetail?.detail?.profile" style="padding:16px 12px 20px 12px;border-bottom:1px solid #30363d;background:#0d1117">
+        <div x-show="profileDetail?.detail?.profile" style="padding:16px 12px 20px 12px;border-bottom:1px solid var(--border-subtle);background:var(--bg-page)">
 
           <!-- Profile-detail overrides toggle. Single source of truth for whether the
                override editor is visible. OFF (default for new sync, or for existing
@@ -155,9 +155,9 @@
                  with its inline display:grid intact each time the toggle flips. -->
             <template x-if="!pdOverridesEnabled">
               <div style="display:grid;grid-template-columns:1fr auto;align-items:center;gap:10px;font-size:13px">
-                <span style="color:#3fb950;font-weight:500;min-width:0">&#10003; All values follow profile defaults</span>
+                <span style="color:var(--accent-green);font-weight:500;min-width:0">&#10003; All values follow profile defaults</span>
                 <button class="btn"
-                        style="font-size:11px;padding:2px 10px;border-color:#d29922;color:#d29922"
+                        style="font-size:11px;padding:2px 10px;border-color:var(--accent-orange);color:var(--accent-orange)"
                         x-tt="'Override profile defaults for language, scores, quality, and custom formats'"
                         @click="pdOverridesEnabled = true">Customize this profile</button>
               </div>
@@ -168,25 +168,25 @@
             <template x-if="pdOverridesEnabled">
               <div style="display:grid;grid-template-columns:1fr auto;align-items:center;gap:10px;font-size:13px">
               <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;min-width:0">
-                <span style="color:#d29922;font-weight:600"
+                <span style="color:var(--accent-orange);font-weight:600"
                       x-text="pdOverrideSummary().total === 0
                                 ? 'Override mode — no changes yet'
                                 : 'Override mode &middot; ' + pdOverrideSummary().total + ' change' + (pdOverrideSummary().total === 1 ? '' : 's')"></span>
                 <template x-if="pdOverrideSummary().general > 0">
-                  <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px" x-text="'General: ' + pdOverrideSummary().general"></span>
+                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="'General: ' + pdOverrideSummary().general"></span>
                 </template>
                 <template x-if="pdOverrideSummary().quality > 0">
-                  <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px" x-text="'Quality: ' + pdOverrideSummary().quality"></span>
+                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="'Quality: ' + pdOverrideSummary().quality"></span>
                 </template>
                 <template x-if="pdOverrideSummary().cfScores > 0">
-                  <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px" x-text="'Overridden Scores: ' + pdOverrideSummary().cfScores"></span>
+                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="'Overridden Scores: ' + pdOverrideSummary().cfScores"></span>
                 </template>
                 <template x-if="pdOverrideSummary().extraCFs > 0">
-                  <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px" x-text="'Extras: ' + pdOverrideSummary().extraCFs"></span>
+                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="'Extras: ' + pdOverrideSummary().extraCFs"></span>
                 </template>
               </div>
               <button class="btn"
-                      style="font-size:11px;padding:2px 10px;border-color:#f85149;color:#f85149"
+                      style="font-size:11px;padding:2px 10px;border-color:var(--accent-red);color:var(--accent-red)"
                       x-tt="'Clear all overrides and revert this profile to defaults'"
                       @click="pdConfirmDisable()">Reset to profile defaults</button>
               </div>
@@ -204,18 +204,18 @@
                  same X-coordinate across rows regardless of override state. -->
             <div class="pd-card pd-card-general">
               <div @click="pdGeneralCollapsed = !pdGeneralCollapsed"
-                   style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid #21262d;margin-bottom:10px">
-                <span class="detail-section-chevron" :class="{ open: !pdGeneralCollapsed }" style="color:#aaa;font-size:11px">&#9654;</span>
-                <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">General</span>
+                   style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px">
+                <span class="detail-section-chevron" :class="{ open: !pdGeneralCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+                <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">General</span>
                 <template x-if="pdGeneralChangeCount() > 0">
-                  <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px" x-text="pdGeneralChangeCount() + (pdGeneralChangeCount() === 1 ? ' override' : ' overrides')"></span>
+                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="pdGeneralChangeCount() + (pdGeneralChangeCount() === 1 ? ' override' : ' overrides')"></span>
                 </template>
                 <template x-if="pdGeneralChangeCount() === 0">
-                  <span style="font-size:11px;color:#6e7681;background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
+                  <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
                 </template>
                 <span style="margin-left:auto" @click.stop>
                   <button class="btn" x-show="pdGeneralChangeCount() > 0"
-                          style="font-size:11px;padding:1px 8px;border-color:#d29922;color:#d29922"
+                          style="font-size:11px;padding:1px 8px;border-color:var(--accent-orange);color:var(--accent-orange)"
                           x-tt="'Reset all General values to Profile defaults'"
                           @click="pdResetGeneral()">&#8634; Reset all</button>
                 </span>
@@ -233,14 +233,14 @@
                   <template x-if="pdOverridesEnabled">
                     <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-shrink:0">
                       <template x-if="pdOverrides.language.value !== (profileDetail?.detail?.profile?.language || 'Original')">
-                        <span style="font-size:11px;color:#8b949e;font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.language || 'Original'"></span></span>
+                        <span style="font-size:11px;color:var(--text-secondary);font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.language || 'Original'"></span></span>
                       </template>
                       <button x-show="pdOverrides.language.value !== (profileDetail?.detail?.profile?.language || 'Original')"
                               @click="pdOverrides.language.value = profileDetail?.detail?.profile?.language || 'Original'"
                               x-tt="'Revert Language to Profile default'"
-                              style="background:none;border:none;color:#d29922;cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
+                              style="background:none;border:none;color:var(--accent-orange);cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
                       <select class="pb-input pd-input"
-                              :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.language.value !== (profileDetail?.detail?.profile?.language || 'Original') ? 'border-color:#d29922' : '')"
+                              :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.language.value !== (profileDetail?.detail?.profile?.language || 'Original') ? 'border-color:var(--accent-orange)' : '')"
                               x-effect="populateSelectField($el, (instanceLanguages[profileDetail?.instance?.id] || [{name:'Original'},{name:'Any'}]).map(l => ({value: l.name, name: l.name})), pdOverrides.language.value)"
                               @change="pdOverrides.language.value = $el.value">
                       </select>
@@ -256,15 +256,15 @@
                   <template x-if="pdOverridesEnabled">
                     <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-shrink:0">
                       <template x-if="pdOverrides.minFormatScore.value !== (profileDetail?.detail?.profile?.minFormatScore ?? 0)">
-                        <span style="font-size:11px;color:#8b949e;font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.minFormatScore ?? 0"></span></span>
+                        <span style="font-size:11px;color:var(--text-secondary);font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.minFormatScore ?? 0"></span></span>
                       </template>
                       <button x-show="pdOverrides.minFormatScore.value !== (profileDetail?.detail?.profile?.minFormatScore ?? 0)"
                               @click="pdOverrides.minFormatScore.value = (profileDetail?.detail?.profile?.minFormatScore ?? 0)"
                               x-tt="'Revert Min Score to Profile default'"
-                              style="background:none;border:none;color:#d29922;cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
+                              style="background:none;border:none;color:var(--accent-orange);cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
                       <input type="number" class="pb-input pd-input" x-model.number="pdOverrides.minFormatScore.value"
                              x-tt="pdMaxPossibleScore !== null ? (pdMinScoreInvalid ? 'Above max (' + pdMaxPossibleScore + ') — Arr will reject this value' : 'Max for this profile after sync: ' + pdMaxPossibleScore + ' (sum of positive Custom Format scores)') : ''"
-                             :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdMinScoreInvalid ? 'border-color:#f85149' : (pdOverrides.minFormatScore.value !== (profileDetail?.detail?.profile?.minFormatScore ?? 0) ? 'border-color:#d29922' : ''))">
+                             :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdMinScoreInvalid ? 'border-color:var(--accent-red)' : (pdOverrides.minFormatScore.value !== (profileDetail?.detail?.profile?.minFormatScore ?? 0) ? 'border-color:var(--accent-orange)' : ''))">
                     </div>
                   </template>
                   <template x-if="!pdOverridesEnabled">
@@ -277,16 +277,16 @@
                   <template x-if="pdOverridesEnabled">
                     <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-shrink:0">
                       <template x-if="pdOverrides.minUpgradeFormatScore.value !== (profileDetail?.detail?.profile?.minUpgradeFormatScore ?? 1)">
-                        <span style="font-size:11px;color:#8b949e;font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.minUpgradeFormatScore ?? 1"></span></span>
+                        <span style="font-size:11px;color:var(--text-secondary);font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.minUpgradeFormatScore ?? 1"></span></span>
                       </template>
                       <button x-show="pdOverrides.minUpgradeFormatScore.value !== (profileDetail?.detail?.profile?.minUpgradeFormatScore ?? 1)"
                               @click="pdOverrides.minUpgradeFormatScore.value = (profileDetail?.detail?.profile?.minUpgradeFormatScore ?? 1)"
                               x-tt="'Revert Min Upgrade Score to Profile default'"
-                              style="background:none;border:none;color:#d29922;cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
+                              style="background:none;border:none;color:var(--accent-orange);cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
                       <input type="number" min="1" class="pb-input pd-input" x-model.number="pdOverrides.minUpgradeFormatScore.value"
                              @blur="if ((pdOverrides.minUpgradeFormatScore.value ?? 1) < 1) pdOverrides.minUpgradeFormatScore.value = 1"
                              x-tt="'Must be 1 or higher — Sonarr/Radarr rule. Values below 1 are auto-corrected to 1 on Save.'"
-                             :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.minUpgradeFormatScore.value !== (profileDetail?.detail?.profile?.minUpgradeFormatScore ?? 1) ? 'border-color:#d29922' : '')">
+                             :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.minUpgradeFormatScore.value !== (profileDetail?.detail?.profile?.minUpgradeFormatScore ?? 1) ? 'border-color:var(--accent-orange)' : '')">
                     </div>
                   </template>
                   <template x-if="!pdOverridesEnabled">
@@ -299,14 +299,14 @@
                   <template x-if="pdOverridesEnabled">
                     <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-shrink:0">
                       <template x-if="pdOverrides.cutoffFormatScore.value !== (profileDetail?.detail?.profile?.cutoffFormatScore || profileDetail?.detail?.profile?.cutoffScore || 10000)">
-                        <span style="font-size:11px;color:#8b949e;font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.cutoffFormatScore || profileDetail?.detail?.profile?.cutoffScore || 10000"></span></span>
+                        <span style="font-size:11px;color:var(--text-secondary);font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.cutoffFormatScore || profileDetail?.detail?.profile?.cutoffScore || 10000"></span></span>
                       </template>
                       <button x-show="pdOverrides.cutoffFormatScore.value !== (profileDetail?.detail?.profile?.cutoffFormatScore || profileDetail?.detail?.profile?.cutoffScore || 10000)"
                               @click="pdOverrides.cutoffFormatScore.value = (profileDetail?.detail?.profile?.cutoffFormatScore || profileDetail?.detail?.profile?.cutoffScore || 10000)"
                               x-tt="'Revert Cutoff Score to Profile default'"
-                              style="background:none;border:none;color:#d29922;cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
+                              style="background:none;border:none;color:var(--accent-orange);cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
                       <input type="number" class="pb-input pd-input" x-model.number="pdOverrides.cutoffFormatScore.value"
-                             :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.cutoffFormatScore.value !== (profileDetail?.detail?.profile?.cutoffFormatScore || profileDetail?.detail?.profile?.cutoffScore || 10000) ? 'border-color:#d29922' : '')">
+                             :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.cutoffFormatScore.value !== (profileDetail?.detail?.profile?.cutoffFormatScore || profileDetail?.detail?.profile?.cutoffScore || 10000) ? 'border-color:var(--accent-orange)' : '')">
                     </div>
                   </template>
                   <template x-if="!pdOverridesEnabled">
@@ -320,12 +320,12 @@
                   <template x-if="pdOverridesEnabled">
                     <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-shrink:0">
                       <template x-if="(pdOverrides.upgradeAllowed.value === true || pdOverrides.upgradeAllowed.value === 'true') !== (profileDetail?.detail?.profile?.upgradeAllowed ?? true)">
-                        <span style="font-size:11px;color:#8b949e;font-family:monospace;white-space:nowrap">Default: <span x-text="(profileDetail?.detail?.profile?.upgradeAllowed ?? true) ? 'Yes' : 'No'"></span></span>
+                        <span style="font-size:11px;color:var(--text-secondary);font-family:monospace;white-space:nowrap">Default: <span x-text="(profileDetail?.detail?.profile?.upgradeAllowed ?? true) ? 'Yes' : 'No'"></span></span>
                       </template>
                       <button x-show="(pdOverrides.upgradeAllowed.value === true || pdOverrides.upgradeAllowed.value === 'true') !== (profileDetail?.detail?.profile?.upgradeAllowed ?? true)"
                               @click="pdOverrides.upgradeAllowed.value = (profileDetail?.detail?.profile?.upgradeAllowed ?? true)"
                               x-tt="'Revert Upgrades Allowed to Profile default'"
-                              style="background:none;border:none;color:#d29922;cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
+                              style="background:none;border:none;color:var(--accent-orange);cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
                       <label class="toggle toggle-sm" @click.stop style="flex-shrink:0">
                         <input type="checkbox" :checked="pdOverrides.upgradeAllowed.value === true || pdOverrides.upgradeAllowed.value === 'true'"
                                @change="pdOverrides.upgradeAllowed.value = $event.target.checked">
@@ -340,7 +340,7 @@
                 <!-- Score Set (always read-only) -->
                 <div class="pd-row">
                   <span class="pd-label">Score Set</span>
-                  <span class="pd-value" style="color:#8b949e" x-text="profileDetail?.detail?.profile?.scoreSet || profileDetail?.detail?.scoreCtx || 'default'"></span>
+                  <span class="pd-value" style="color:var(--text-secondary)" x-text="profileDetail?.detail?.profile?.scoreSet || profileDetail?.detail?.scoreCtx || 'default'"></span>
                 </div>
               </div>
             </div>
@@ -352,18 +352,18 @@
                  width when the editor is open — that part goes away in Step 2. -->
             <div class="pd-card pd-card-quality">
               <div @click="pdQualityCollapsed = !pdQualityCollapsed"
-                   style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid #21262d;margin-bottom:10px">
-                <span class="detail-section-chevron" :class="{ open: !pdQualityCollapsed }" style="color:#aaa;font-size:11px">&#9654;</span>
-                <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality</span>
+                   style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px">
+                <span class="detail-section-chevron" :class="{ open: !pdQualityCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+                <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality</span>
                 <template x-if="pdQualityChangeCount() + pdQualityItemsChangeCount() > 0">
-                  <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px" x-text="(pdQualityChangeCount() + pdQualityItemsChangeCount()) + ' change' + (pdQualityChangeCount() + pdQualityItemsChangeCount() === 1 ? '' : 's')"></span>
+                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="(pdQualityChangeCount() + pdQualityItemsChangeCount()) + ' change' + (pdQualityChangeCount() + pdQualityItemsChangeCount() === 1 ? '' : 's')"></span>
                 </template>
                 <template x-if="pdQualityChangeCount() + pdQualityItemsChangeCount() === 0">
-                  <span style="font-size:11px;color:#6e7681;background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
+                  <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
                 </template>
                 <span style="margin-left:auto" @click.stop>
                   <button class="btn" x-show="pdQualityChangeCount() + pdQualityItemsChangeCount() > 0"
-                          style="font-size:11px;padding:1px 8px;border-color:#d29922;color:#d29922"
+                          style="font-size:11px;padding:1px 8px;border-color:var(--accent-orange);color:var(--accent-orange)"
                           x-tt="'Reset Quality cutoff and items to Profile defaults'"
                           @click="pdResetQuality(); qsResetAll()">&#8634; Reset all</button>
                 </span>
@@ -376,14 +376,14 @@
                     <template x-if="pdOverridesEnabled">
                       <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-shrink:0">
                         <template x-if="pdOverrides.cutoffQuality && pdOverrides.cutoffQuality !== (profileDetail?.detail?.profile?.cutoff || '')">
-                          <span style="font-size:11px;color:#8b949e;font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.cutoff || '—'"></span></span>
+                          <span style="font-size:11px;color:var(--text-secondary);font-family:monospace;white-space:nowrap">Default: <span x-text="profileDetail?.detail?.profile?.cutoff || '—'"></span></span>
                         </template>
                         <button x-show="pdOverrides.cutoffQuality && pdOverrides.cutoffQuality !== (profileDetail?.detail?.profile?.cutoff || '')"
                                 @click="pdOverrides.cutoffQuality = profileDetail?.detail?.profile?.cutoff || ''"
                                 x-tt="'Revert Cutoff to Profile default'"
-                                style="background:none;border:none;color:#d29922;cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
+                                style="background:none;border:none;color:var(--accent-orange);cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
                         <select class="pb-input pd-input"
-                                :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.cutoffQuality && pdOverrides.cutoffQuality !== (profileDetail?.detail?.profile?.cutoff || '') ? 'border-color:#d29922' : '')"
+                                :style="'width:150px;max-width:150px;flex-shrink:0;' + (pdOverrides.cutoffQuality && pdOverrides.cutoffQuality !== (profileDetail?.detail?.profile?.cutoff || '') ? 'border-color:var(--accent-orange)' : '')"
                                 x-effect="populateCutoffSelect($el, qualityStructure, profileDetail?.detail?.profile, pdOverrides.cutoffQuality, qualityOverrides)"
                                 @change="pdOverrides.cutoffQuality = $el.value">
                         </select>
@@ -398,18 +398,18 @@
                     <span class="pd-label" style="width:170px;flex-shrink:0">Quality Items</span>
                     <div style="margin-left:auto;display:flex;align-items:center;gap:6px;flex-shrink:0">
                       <template x-if="pdQualityItemsChangeCount() > 0">
-                        <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px;white-space:nowrap" x-text="pdQualityItemsChangeCount() + ' change' + (pdQualityItemsChangeCount() === 1 ? '' : 's')"></span>
+                        <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px;white-space:nowrap" x-text="pdQualityItemsChangeCount() + ' change' + (pdQualityItemsChangeCount() === 1 ? '' : 's')"></span>
                       </template>
                       <template x-if="pdQualityItemsChangeCount() === 0">
-                        <span style="font-size:11px;color:#6e7681;background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px;white-space:nowrap">Profile default</span>
+                        <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px;white-space:nowrap">Profile default</span>
                       </template>
                       <button x-show="pdOverridesEnabled && (qualityStructure.length > 0 || Object.keys(qualityOverrides).length > 0)"
                               @click="qsResetAll()"
                               x-tt="'Reset quality items to Profile defaults'"
-                              style="background:none;border:none;color:#d29922;cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
+                              style="background:none;border:none;color:var(--accent-orange);cursor:pointer;font-size:14px;padding:0 4px;flex-shrink:0">&#8634;</button>
                       <button class="btn"
                               x-show="pdOverridesEnabled"
-                              style="font-size:12px;padding:2px 10px;border-color:#d29922;color:#d29922;flex-shrink:0"
+                              style="font-size:12px;padding:2px 10px;border-color:var(--accent-orange);color:var(--accent-orange);flex-shrink:0"
                               x-tt="'Edit resolution toggles, grouping, and ordering'"
                               @click="if (qualityOverrideActive) { qualityOverrideActive = false; qsCloseSharedState(); } else { if (qualityStructure.length === 0) qsInitFromProfile(); qualityOverrideActive = true; }">
                         <span x-text="qualityOverrideActive ? '✓ Done' : 'Edit →'"></span>
@@ -428,15 +428,15 @@
                      @click.self="qualityOverrideActive = false; qsCloseSharedState();"
                      style="position:fixed;top:0;left:0;width:100%;height:100%;z-index:1000;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;padding:20px">
                   <div :class="qualityStructureEditMode ? 'qs-edit-on' : ''"
-                       style="background:#161b22;border:1px solid #30363d;border-radius:8px;width:100%;max-width:900px;max-height:90vh;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,0.6)">
+                       style="background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:8px;width:100%;max-width:900px;max-height:90vh;display:flex;flex-direction:column;overflow:hidden;box-shadow:0 8px 32px rgba(0,0,0,0.6)">
                     <!-- Modal header: title + close -->
-                    <div style="padding:14px 18px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:10px">
-                      <div style="font-size:15px;font-weight:600;color:#e1e4e8">Edit Quality Items</div>
-                      <div style="font-size:12px;color:#8b949e" x-show="!qualityStructureEditMode">— toggle resolutions on/off · drag rows to reorder priority</div>
-                      <div style="font-size:12px;color:#8b949e" x-show="qualityStructureEditMode">— drag to reorder · drop on a row to merge · click group name to rename</div>
+                    <div style="padding:14px 18px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:10px">
+                      <div style="font-size:15px;font-weight:600;color:var(--text-primary)">Edit Quality Items</div>
+                      <div style="font-size:12px;color:var(--text-secondary)" x-show="!qualityStructureEditMode">— toggle resolutions on/off · drag rows to reorder priority</div>
+                      <div style="font-size:12px;color:var(--text-secondary)" x-show="qualityStructureEditMode">— drag to reorder · drop on a row to merge · click group name to rename</div>
                       <button @click="qualityOverrideActive = false; qsCloseSharedState();"
                               x-tt="'Close (changes stay in profile state until Save & Sync)'"
-                              style="margin-left:auto;background:none;border:none;color:#aaa;font-size:22px;cursor:pointer;padding:0 6px;line-height:1">&times;</button>
+                              style="margin-left:auto;background:none;border:none;color:var(--text-muted);font-size:22px;cursor:pointer;padding:0 6px;line-height:1">&times;</button>
                     </div>
                     <!-- Modal body (scrollable) — contains the existing editor -->
                     <div style="padding:16px 18px;overflow-y:auto;flex:1">
@@ -444,13 +444,13 @@
                       <div style="display:flex;align-items:center;gap:8px;margin-bottom:14px;flex-wrap:wrap">
                         <button class="btn"
                                 style="font-size:12px;padding:2px 10px"
-                                :style="qualityStructureEditMode ? 'background:#238636;border-color:#238636;color:#fff' : ''"
+                                :style="qualityStructureEditMode ? 'background:var(--accent-green-strong);border-color:var(--accent-green-strong);color:var(--text-on-accent)' : ''"
                                 @click="qsToggleEditMode()">
                           <span x-text="qualityStructureEditMode ? '✓ Done Editing Groups' : 'Edit Groups'"></span>
                         </button>
                         <div style="flex:1"></div>
                         <button class="btn"
-                                style="font-size:12px;padding:2px 10px;border-color:#d29922;color:#d29922"
+                                style="font-size:12px;padding:2px 10px;border-color:var(--accent-orange);color:var(--accent-orange)"
                                 x-tt="'Reset all quality overrides to profile defaults. Discards toggles, groups, ordering, and renames.'"
                                 @click="qsResetAll()">&#8634; Reset to profile defaults</button>
                       </div>
@@ -467,9 +467,9 @@
                             <span class="slider"></span>
                           </label>
                           <span style="font-size:13px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis"
-                                :style="(qualityOverrides[item.name] !== undefined ? qualityOverrides[item.name] : item.allowed) ? 'color:#e1e4e8' : 'color:#aaa'"
+                                :style="(qualityOverrides[item.name] !== undefined ? qualityOverrides[item.name] : item.allowed) ? 'color:var(--text-primary)' : 'color:var(--text-muted)'"
                                 x-text="item.name"></span>
-                          <span x-show="qualityOverrides[item.name] !== undefined" style="font-size:10px;color:#d29922;flex-shrink:0">●</span>
+                          <span x-show="qualityOverrides[item.name] !== undefined" style="font-size:10px;color:var(--accent-orange);flex-shrink:0">●</span>
                         </div>
                       </template>
                     </div>
@@ -533,7 +533,7 @@
                             <template x-if="qualityStructureRenaming !== item._id">
                               <span class="qs-name"
                                     :class="(qualityStructureEditMode && item.items) ? 'editable' : ''"
-                                    :style="item.allowed ? 'color:#e1e4e8' : 'color:#aaa'"
+                                    :style="item.allowed ? 'color:var(--text-primary)' : 'color:var(--text-muted)'"
                                     @click="if (qualityStructureEditMode && item.items) qsStartRename(item)"
                                     x-text="item.name"></span>
                             </template>
@@ -546,7 +546,7 @@
                                      x-init="$nextTick(() => $el.focus())">
                             </template>
                             <span x-show="item.items" class="qs-badge" x-text="item.items?.length"></span>
-                            <span x-show="qsIsOverridden(item)" style="font-size:10px;color:#d29922;flex-shrink:0" x-tt="'Differs from Profile default'">●</span>
+                            <span x-show="qsIsOverridden(item)" style="font-size:10px;color:var(--accent-orange);flex-shrink:0" x-tt="'Differs from Profile default'">●</span>
                             <button x-show="qualityStructureEditMode && item.items" class="qs-tiny-x"
                                     style="font-size:11px;padding:0 6px"
                                     @click="qsDeleteGroup(idx)" x-tt="'Delete group (members become individual singles)'">× delete</button>
@@ -601,19 +601,19 @@
                score inputs (gated on pdOverridesEnabled) populate this list. -->
           <div class="pd-card pd-card-cfscores" style="margin-top:18px;padding:10px 14px">
             <div @click="pdCFScoresCollapsed = !pdCFScoresCollapsed"
-                 :style="pdCFScoresCollapsed ? 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none' : 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid #21262d;margin-bottom:10px'">
-              <span class="detail-section-chevron" :class="{ open: !pdCFScoresCollapsed }" style="color:#aaa;font-size:11px">&#9654;</span>
-              <span style="font-size:13px;color:#e1e4e8;font-weight:600">Overridden Scores</span>
+                 :style="pdCFScoresCollapsed ? 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none' : 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px'">
+              <span class="detail-section-chevron" :class="{ open: !pdCFScoresCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+              <span style="font-size:13px;color:var(--text-primary);font-weight:600">Overridden Scores</span>
               <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 0">
-                <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px"
+                <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px"
                       x-text="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length + ' override' + (Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length === 1 ? '' : 's')"></span>
               </template>
               <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length === 0">
-                <span style="font-size:11px;color:#6e7681;background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
+                <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
               </template>
               <span style="margin-left:auto" @click.stop>
                 <button class="btn" x-show="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 0"
-                        style="font-size:11px;padding:1px 8px;border-color:#d29922;color:#d29922"
+                        style="font-size:11px;padding:1px 8px;border-color:var(--accent-orange);color:var(--accent-orange)"
                         x-tt="'Reset all CF score overrides to Profile defaults'"
                         @click="cfScoreOverrides = {}">&#8634; Reset all</button>
               </span>
@@ -623,20 +623,20 @@
                 <div :style="'column-count:' + (Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 8 ? 2 : 1) + ';column-gap:24px'">
                   <template x-for="tid in Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).sort((a,b) => (resolveCFName(a)).localeCompare(resolveCFName(b)))" :key="'so-'+tid">
                     <div style="break-inside:avoid;display:flex;align-items:center;padding:3px 0;font-size:12px;gap:4px">
-                      <span style="color:#e1e4e8;width:180px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="resolveCFName(tid)"></span>
-                      <span style="color:#aaa;width:55px;flex-shrink:0;text-align:right;font-family:monospace" x-text="resolveCFDefaultScore(tid)"></span>
-                      <span style="color:#aaa;flex-shrink:0;margin:0 2px">→</span>
+                      <span style="color:var(--text-primary);width:180px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="resolveCFName(tid)"></span>
+                      <span style="color:var(--text-muted);width:55px;flex-shrink:0;text-align:right;font-family:monospace" x-text="resolveCFDefaultScore(tid)"></span>
+                      <span style="color:var(--text-muted);flex-shrink:0;margin:0 2px">→</span>
                       <input type="number" class="pb-score-input overridden" style="width:65px;flex-shrink:0"
                              :value="cfScoreOverrides[tid]"
                              @change="const v = parseInt($event.target.value) || 0; const def = resolveCFDefaultScore(tid); if (v === def) { const {[tid]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [tid]: v}; }">
                       <span @click="const {[tid]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                            style="color:#d29922;font-size:12px;cursor:pointer;flex-shrink:0;margin-left:2px" x-tt="'Reset to Profile default'">&#8634;</span>
+                            style="color:var(--accent-orange);font-size:12px;cursor:pointer;flex-shrink:0;margin-left:2px" x-tt="'Reset to Profile default'">&#8634;</span>
                     </div>
                   </template>
                 </div>
               </template>
               <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length === 0">
-                <div style="font-size:12px;color:#6e7681;font-style:italic;padding:4px 0">No score overrides yet. Edit any score in the Required CFs or Group CFs sections below to override its profile default.</div>
+                <div style="font-size:12px;color:var(--text-muted-secondary);font-style:italic;padding:4px 0">No score overrides yet. Edit any score in the Required CFs or Group CFs sections below to override its profile default.</div>
               </template>
             </div>
           </div>
@@ -647,32 +647,32 @@
           <div class="pd-card pd-card-extracfs" style="margin-top:18px;padding:10px 14px"
                x-effect="if (!pdExtraCFsCollapsed && extraCFAllCFs.length === 0 && profileDetail?.instance?.type) loadExtraCFList()">
           <div @click="pdExtraCFsCollapsed = !pdExtraCFsCollapsed"
-               :style="pdExtraCFsCollapsed ? 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none' : 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid #21262d;margin-bottom:10px'">
-            <span class="detail-section-chevron" :class="{ open: !pdExtraCFsCollapsed }" style="color:#aaa;font-size:11px">&#9654;</span>
-            <span style="font-size:13px;color:#e1e4e8;font-weight:600">Extra Custom Formats</span>
+               :style="pdExtraCFsCollapsed ? 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none' : 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px'">
+            <span class="detail-section-chevron" :class="{ open: !pdExtraCFsCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+            <span style="font-size:13px;color:var(--text-primary);font-weight:600">Extra Custom Formats</span>
             <template x-if="Object.keys(extraCFs).length > 0">
-              <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 7px;border-radius:10px" x-text="Object.keys(extraCFs).length + ' added'"></span>
+              <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="Object.keys(extraCFs).length + ' added'"></span>
             </template>
             <template x-if="Object.keys(extraCFs).length === 0">
-              <span style="font-size:11px;color:#6e7681;background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">None</span>
+              <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">None</span>
             </template>
             <span style="margin-left:auto" @click.stop>
               <input x-show="!pdExtraCFsCollapsed" type="text" class="input" x-model="extraCFSearch" placeholder="Search..." style="font-size:12px;width:140px;padding:2px 8px;margin-right:6px">
               <button class="btn" x-show="Object.keys(extraCFs).length > 0"
-                      style="font-size:11px;padding:1px 8px;border-color:#d29922;color:#d29922"
+                      style="font-size:11px;padding:1px 8px;border-color:var(--accent-orange);color:var(--accent-orange)"
                       x-tt="'Remove all extra CFs'"
                       @click="extraCFs = {}">&#8634; Reset all</button>
             </span>
           </div>
           <div x-show="!pdExtraCFsCollapsed">
-            <div style="font-size:13px;color:#f85149;font-weight:600;margin-bottom:10px">&#9888; Non-standard for this profile — use at your own risk</div>
+            <div style="font-size:13px;color:var(--accent-red);font-weight:600;margin-bottom:10px">&#9888; Non-standard for this profile — use at your own risk</div>
             <template x-if="extraCFAllCFs.length === 0">
-              <div style="font-size:12px;color:#8b949e;font-style:italic;padding:4px 0">Loading custom formats...</div>
+              <div style="font-size:12px;color:var(--text-secondary);font-style:italic;padding:4px 0">Loading custom formats...</div>
             </template>
             <!-- Selected extras -->
             <template x-if="Object.keys(extraCFs).length > 0">
-              <div style="margin-bottom:8px;padding:6px 8px;background:#0d1117;border-radius:4px">
-                <div style="font-size:12px;color:#d29922;margin-bottom:4px;font-weight:600">Added (<span x-text="Object.keys(extraCFs).length"></span>)</div>
+              <div style="margin-bottom:8px;padding:6px 8px;background:var(--bg-page);border-radius:4px">
+                <div style="font-size:12px;color:var(--accent-orange);margin-bottom:4px;font-weight:600">Added (<span x-text="Object.keys(extraCFs).length"></span>)</div>
                 <div :style="'column-count:' + (Object.keys(extraCFs).length > 8 ? 2 : 1) + ';column-gap:24px'">
                 <template x-for="tid in Object.keys(extraCFs).sort((a,b) => ((extraCFAllCFs.find(c => c.trashId === a)?.name || a).localeCompare(extraCFAllCFs.find(c => c.trashId === b)?.name || b)))" :key="'xs-'+tid">
                   <div style="break-inside:avoid;display:flex;align-items:center;padding:3px 0;gap:4px">
@@ -680,7 +680,7 @@
                       <input type="checkbox" :checked="extraCFs[tid] !== undefined" @change="const {[tid]: _, ...rest} = extraCFs; extraCFs = rest">
                       <span class="slider"></span>
                     </label>
-                    <span style="font-size:13px;color:#d29922;width:180px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="extraCFAllCFs.find(c => c.trashId === tid)?.name || resolveExtraCFName(tid)"></span>
+                    <span style="font-size:13px;color:var(--accent-orange);width:180px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="extraCFAllCFs.find(c => c.trashId === tid)?.name || resolveExtraCFName(tid)"></span>
                     <input type="number" class="pb-score-input overridden" :value="extraCFs[tid]" @change="extraCFs = {...extraCFs, [tid]: parseInt($event.target.value)||0}" style="width:65px;flex-shrink:0">
                   </div>
                 </template>
@@ -692,8 +692,8 @@
               <div x-show="group.cfs.some(cf => !_extraInProfile(cf.trashId) && extraCFs[cf.trashId] === undefined && (!extraCFSearch || cf.name.toLowerCase().includes(extraCFSearch.toLowerCase())))" style="margin-bottom:4px">
                 <div style="padding:4px 0;cursor:pointer;display:flex;align-items:center;gap:4px" @click="detailSections['extra_'+group.name] = !detailSections['extra_'+group.name]">
                   <span class="detail-section-chevron" :class="{ open: detailSections['extra_'+group.name] }">&#9654;</span>
-                  <span style="font-size:13px;font-weight:500;color:#aaa" x-text="group.name"></span>
-                  <span style="font-size:12px;color:#aaa" x-text="group.cfs.filter(cf => !_extraInProfile(cf.trashId) && extraCFs[cf.trashId] === undefined && (!extraCFSearch || cf.name.toLowerCase().includes(extraCFSearch.toLowerCase()))).length"></span>
+                  <span style="font-size:13px;font-weight:500;color:var(--text-muted)" x-text="group.name"></span>
+                  <span style="font-size:12px;color:var(--text-muted)" x-text="group.cfs.filter(cf => !_extraInProfile(cf.trashId) && extraCFs[cf.trashId] === undefined && (!extraCFSearch || cf.name.toLowerCase().includes(extraCFSearch.toLowerCase()))).length"></span>
                 </div>
                 <div x-show="detailSections['extra_'+group.name]"
                      :style="{ columnCount: (group.cfs.length > 30 ? 3 : group.cfs.length > 12 ? 2 : 1), columnGap: '24px', paddingLeft: '8px' }">
@@ -709,7 +709,7 @@
                 </div>
               </div>
             </template>
-            <div x-show="extraCFAvailable().length === 0 && extraCFAllCFs.length > 0" style="font-size:13px;color:#aaa;padding:4px 0">No matching CFs</div>
+            <div x-show="extraCFAvailable().length === 0 && extraCFAllCFs.length > 0" style="font-size:13px;color:var(--text-muted);padding:4px 0">No matching CFs</div>
           </div><!-- /x-show pdExtraCFsCollapsed -->
           </div><!-- /Extra CFs card -->
 
@@ -723,7 +723,7 @@
               <div class="detail-section-header" @click="toggleDetailSection('importedReq')">
                 <span class="detail-section-chevron" :class="{ open: detailSections.importedReq }">&#9654;</span>
                 <div style="font-size:13px;font-weight:600">Required Custom Formats</div>
-                <div style="font-size:13px;color:#aaa;margin-right:auto" x-text="profileDetail.detail.importedRequiredCategories.reduce((n,c) => n + c.cfs.length, 0) + ' CFs'"></div>
+                <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="profileDetail.detail.importedRequiredCategories.reduce((n,c) => n + c.cfs.length, 0) + ' CFs'"></div>
               </div>
               <div class="section-desc" x-show="detailSections.importedReq">
                 Required for this profile. Always included when syncing.
@@ -734,7 +734,7 @@
                     <div class="detail-section-header" @click="toggleGroupExpanded('req', cat.category)">
                       <span class="detail-section-chevron" :class="{ open: groupExpanded['req/' + cat.category] }">&#9654;</span>
                       <div style="font-size:13px;font-weight:600" x-text="cat.category"></div>
-                      <div style="font-size:13px;color:#aaa;margin-right:auto" x-text="cat.cfs.length + '/' + cat.cfs.length"></div>
+                      <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="cat.cfs.length + '/' + cat.cfs.length"></div>
                     </div>
                     <div x-show="groupExpanded['req/' + cat.category]">
                       <template x-for="cf in cat.cfs" :key="cf.trashId">
@@ -747,12 +747,12 @@
                                      @change="const v = parseInt($event.target.value) || 0; if (v === (cf.score ?? 0)) { const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [cf.trashId]: v}; }"
                                      style="width:65px">
                               <span x-show="cfScoreOverrides[cf.trashId] !== undefined" @click="const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                                    style="color:#d29922;font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
+                                    style="color:var(--accent-orange);font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
                             </div>
                           </template>
                           <template x-if="!pdOverridesEnabled">
                             <div class="cf-score" :class="(() => { const s = cfScoreOverrides[cf.trashId] ?? cf.score; return s > 0 ? 'positive' : s < 0 ? 'negative' : 'zero'; })()"
-                                 :style="cfScoreOverrides[cf.trashId] !== undefined ? 'color:#d29922' : ''">
+                                 :style="cfScoreOverrides[cf.trashId] !== undefined ? 'color:var(--accent-orange)' : ''">
                               <span x-text="(() => { const s = cfScoreOverrides[cf.trashId] ?? cf.score; return (s > 0 ? '+' : '') + s; })()"></span>
                             </div>
                           </template>
@@ -772,10 +772,10 @@
             <div class="detail-section-header" @click="toggleDetailSection('goldenRule')">
               <span class="detail-section-chevron" :class="{ open: detailSections.goldenRule }">&#9654;</span>
               <div style="font-size:13px;font-weight:600">Golden Rule</div>
-              <div style="font-size:13px;color:#aaa;margin-right:auto">pick one</div>
+              <div style="font-size:13px;color:var(--text-muted);margin-right:auto">pick one</div>
             </div>
             <div x-show="detailSections.goldenRule">
-              <div style="padding:6px 16px;font-size:13px;color:#d29922">Please ensure you only score or enable one of them in your Quality Profile!</div>
+              <div style="padding:6px 16px;font-size:13px;color:var(--accent-orange)">Please ensure you only score or enable one of them in your Quality Profile!</div>
               <template x-for="cf in profileDetail.detail.importedGoldenRule" :key="cf.trashId">
                 <div class="cf-row">
                   <label class="toggle toggle-sm">
@@ -801,7 +801,7 @@
                 <div class="detail-section-header" @click="toggleDetailSection(cat.category)">
                   <span class="detail-section-chevron" :class="{ open: detailSections[cat.category] }">&#9654;</span>
                   <div style="font-size:13px;font-weight:600" x-text="cat.category"></div>
-                  <div style="font-size:13px;color:#aaa;margin-right:auto" x-text="cat.cfs.filter(cf => selectedOptionalCFs[cf.trashId]).length + '/' + cat.cfs.length"></div>
+                  <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="cat.cfs.filter(cf => selectedOptionalCFs[cf.trashId]).length + '/' + cat.cfs.length"></div>
                   <label class="toggle toggle-sm" @click.stop>
                     <input type="checkbox"
                            :checked="cat.cfs.every(cf => selectedOptionalCFs[cf.trashId])"
@@ -834,12 +834,12 @@
                   <div class="detail-section-label">Quality Settings</div>
                   <span class="detail-section-chevron" :class="{ open: groupExpanded['imported/qualities'] }">&#9654;</span>
                 </div>
-                <div x-show="groupExpanded['imported/qualities']" style="padding:12px 16px;font-size:12px;color:#c9d1d9">
+                <div x-show="groupExpanded['imported/qualities']" style="padding:12px 16px;font-size:12px;color:var(--text-body)">
                   <template x-for="q in profileDetail.detail.profile.items" :key="q.name">
                     <div style="padding:4px 0;display:flex;gap:8px;align-items:center">
                       <span style="font-weight:500" x-text="q.name"></span>
                       <template x-if="q.items?.length > 0">
-                        <span style="color:#aaa;font-size:13px" x-text="'(' + q.items.join(', ') + ')'"></span>
+                        <span style="color:var(--text-muted);font-size:13px" x-text="'(' + q.items.join(', ') + ')'"></span>
                       </template>
                     </div>
                   </template>
@@ -853,14 +853,14 @@
 
         <!-- TRaSH group-based sync view -->
         <template x-if="profileDetail?.detail?.trashGroups">
-          <div style="background:#0d1117;padding:8px 12px">
+          <div style="background:var(--bg-page);padding:8px 12px">
             <!-- Profile section: formatItems not in any group -->
             <template x-if="(profileDetail.detail.formatItemNames || []).length > 0">
               <div class="detail-section cat-required-core">
                 <div class="detail-section-header" @click="toggleDetailSection('core')">
                   <span class="detail-section-chevron" :class="{ open: detailSections.core }">&#9654;</span>
                   <div style="font-size:13px;font-weight:600">Required CFs</div>
-                  <div style="font-size:13px;color:#aaa;margin-right:auto" x-text="profileDetail.detail.formatItemNames.length + ' custom formats'"></div>
+                  <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="profileDetail.detail.formatItemNames.length + ' custom formats'"></div>
                 </div>
                 <div class="section-desc" x-show="detailSections.core">
                   Required for this profile. Always included when syncing.
@@ -869,7 +869,7 @@
                      :style="'column-count:' + (profileDetail.detail.formatItemNames.length > 20 ? 3 : profileDetail.detail.formatItemNames.length > 10 ? 2 : 1) + ';column-gap:24px'">
                   <template x-for="fi in profileDetail.detail.formatItemNames" :key="fi.trashId">
                     <div class="cf-row" style="padding:2px 0;break-inside:avoid">
-                      <div class="cf-name" style="font-size:12px;color:#aaa" x-text="fi.name"></div>
+                      <div class="cf-name" style="font-size:12px;color:var(--text-muted)" x-text="fi.name"></div>
                       <template x-if="pdOverridesEnabled">
                         <div style="flex-shrink:0">
                           <input type="number" class="pb-score-input" :class="cfScoreOverrides[fi.trashId] !== undefined ? 'overridden' : ''"
@@ -877,12 +877,12 @@
                                  @change="const v = parseInt($event.target.value) || 0; if (v === (fi.score ?? 0)) { const {[fi.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [fi.trashId]: v}; }"
                                  style="width:65px">
                           <span x-show="cfScoreOverrides[fi.trashId] !== undefined" @click="const {[fi.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                                style="color:#d29922;font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
+                                style="color:var(--accent-orange);font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
                         </div>
                       </template>
                       <template x-if="!pdOverridesEnabled">
                         <div class="cf-score" :class="(() => { const s = cfScoreOverrides[fi.trashId] ?? fi.score ?? 0; return s > 0 ? 'positive' : s < 0 ? 'negative' : 'zero'; })()"
-                             :style="cfScoreOverrides[fi.trashId] !== undefined ? 'color:#d29922' : ''"
+                             :style="cfScoreOverrides[fi.trashId] !== undefined ? 'color:var(--accent-orange)' : ''"
                              x-text="(() => { const s = cfScoreOverrides[fi.trashId] ?? fi.score; return s != null ? ((s > 0 ? '+' : '') + s) : ''; })()"></div>
                       </template>
                     </div>
@@ -892,7 +892,7 @@
             </template>
 
             <!-- Groups section header -->
-            <div style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;padding:12px 0 6px;font-weight:600">
+            <div style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;padding:12px 0 6px;font-weight:600">
               Groups
               <span style="text-transform:none;letter-spacing:0;font-weight:400"> — toggle to include/exclude from sync</span>
             </div>
@@ -903,12 +903,12 @@
                 <div class="detail-section-header" @click="toggleGroupExpanded('tg', group.name)">
                   <span class="detail-section-chevron" :class="{ open: groupExpanded['tg/' + group.name] }">&#9654;</span>
                   <div style="font-size:13px;font-weight:500" x-text="group.name"></div>
-                  <span x-show="group.exclusive" style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 5px;border-radius:3px">pick one</span>
-                  <span x-show="group.defaultEnabled" style="font-size:11px;color:#3fb950;background:#0d2f1a;padding:1px 5px;border-radius:3px">default</span>
-                  <div style="font-size:13px;color:#aaa;margin-left:8px"
+                  <span x-show="group.exclusive" style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 5px;border-radius:3px">pick one</span>
+                  <span x-show="group.defaultEnabled" style="font-size:11px;color:var(--accent-green);background:var(--fill-green-soft);padding:1px 5px;border-radius:3px">default</span>
+                  <div style="font-size:13px;color:var(--text-muted);margin-left:8px"
                        x-text="(() => { const on = selectedOptionalCFs['__grp_' + group.name] !== undefined ? selectedOptionalCFs['__grp_' + group.name] : group.defaultEnabled; if (!on) return '0/' + group.cfs.length; return group.cfs.filter(cf => cf.required || selectedOptionalCFs[cf.trashId]).length + '/' + group.cfs.length; })()"></div>
                   <template x-if="group.cfs.some(cf => cfScoreOverrides[cf.trashId] !== undefined)">
-                    <span style="font-size:11px;color:#d29922;background:#3d2e0a;padding:1px 5px;border-radius:3px;margin-right:auto"
+                    <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 5px;border-radius:3px;margin-right:auto"
                           x-text="group.cfs.filter(cf => cfScoreOverrides[cf.trashId] !== undefined).length + ' override' + (group.cfs.filter(cf => cfScoreOverrides[cf.trashId] !== undefined).length !== 1 ? 's' : '')"></span>
                   </template>
                   <template x-if="!group.cfs.some(cf => cfScoreOverrides[cf.trashId] !== undefined)">
@@ -933,19 +933,19 @@
                 <div x-show="groupExpanded['tg/' + group.name]">
                   <!-- Description -->
                   <div x-show="group.trashDescription" class="group-desc-html"
-                       style="padding:8px 16px;font-size:13px;color:#9eaab6;font-style:italic;line-height:1.5;border-bottom:1px solid #21262d"
+                       style="padding:8px 16px;font-size:13px;color:var(--text-secondary);font-style:italic;line-height:1.5;border-bottom:1px solid var(--bg-muted)"
                        x-html="sanitizeHTML(group.trashDescription)"></div>
                   <!-- "All" toggle for optional groups with 3+ CFs (only when group is active) -->
                   <div x-show="!group.cfs.every(cf => cf.required) && !group.exclusive && group.cfs.length >= 3 && (selectedOptionalCFs['__grp_' + group.name] !== undefined ? selectedOptionalCFs['__grp_' + group.name] : group.defaultEnabled)"
-                       style="display:flex;align-items:center;padding:6px 16px;gap:8px;background:#12161d;border-bottom:1px solid #21262d">
+                       style="display:flex;align-items:center;padding:6px 16px;gap:8px;background:var(--bg-card);border-bottom:1px solid var(--bg-muted)">
                     <label class="toggle toggle-sm" @click.stop>
                       <input type="checkbox"
                              :checked="group.cfs.filter(cf => !cf.required).every(cf => selectedOptionalCFs[cf.trashId])"
                              @change="group.cfs.forEach(cf => { if (!cf.required) selectedOptionalCFs[cf.trashId] = $event.target.checked }); selectedOptionalCFs = {...selectedOptionalCFs}">
                       <span class="slider"></span>
                     </label>
-                    <span style="font-size:12px;color:#58a6ff;font-weight:500">All</span>
-                    <span style="font-size:13px;color:#aaa"
+                    <span style="font-size:12px;color:var(--accent-blue);font-weight:500">All</span>
+                    <span style="font-size:13px;color:var(--text-muted)"
                           x-text="group.cfs.filter(cf => !cf.required && selectedOptionalCFs[cf.trashId]).length + ' of ' + group.cfs.filter(cf => !cf.required).length + ' enabled'"></span>
                   </div>
                   <!-- CF list -->
@@ -953,7 +953,7 @@
                     <div class="cf-row" :style="(() => { const grpOn = selectedOptionalCFs['__grp_' + group.name] !== undefined ? selectedOptionalCFs['__grp_' + group.name] : group.defaultEnabled; if (cf.required) return grpOn ? '' : 'opacity:0.35'; return (grpOn || selectedOptionalCFs[cf.trashId]) ? '' : 'opacity:0.35'; })()">
                       <!-- Required CFs in group: no individual toggle, lock icon -->
                       <template x-if="cf.required">
-                        <span style="font-size:13px;color:#aaa;width:28px;text-align:center;flex-shrink:0" x-tt="'Included when group is active'">🔒</span>
+                        <span style="font-size:13px;color:var(--text-muted);width:28px;text-align:center;flex-shrink:0" x-tt="'Included when group is active'">🔒</span>
                       </template>
                       <!-- Optional CFs in group: individual toggle -->
                       <template x-if="!cf.required">
@@ -976,12 +976,12 @@
                                  @change="const v = parseInt($event.target.value) || 0; if (v === (cf.score ?? 0)) { const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [cf.trashId]: v}; }"
                                  style="width:65px">
                           <span x-show="cfScoreOverrides[cf.trashId] !== undefined" @click="const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                                style="color:#d29922;font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
+                                style="color:var(--accent-orange);font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
                         </div>
                       </template>
                       <template x-if="!(pdOverridesEnabled && (cf.required ? (selectedOptionalCFs['__grp_' + group.name] !== undefined ? selectedOptionalCFs['__grp_' + group.name] : group.defaultEnabled) : selectedOptionalCFs[cf.trashId]))">
                         <div class="cf-score" :class="(() => { const s = cfScoreOverrides[cf.trashId] ?? cf.score; return s > 0 ? 'positive' : s < 0 ? 'negative' : 'zero'; })()"
-                             :style="cfScoreOverrides[cf.trashId] !== undefined ? 'color:#d29922' : ''">
+                             :style="cfScoreOverrides[cf.trashId] !== undefined ? 'color:var(--accent-orange)' : ''">
                           <span x-text="(() => { const s = cfScoreOverrides[cf.trashId]; if (s !== undefined) return (s > 0 ? '+' : '') + s; return cf.hasScore ? ((cf.score > 0 ? '+' : '') + cf.score) : '—'; })()"></span>
                         </div>
                       </template>

--- a/ui/static/partials/sections/about.html
+++ b/ui/static/partials/sections/about.html
@@ -2,20 +2,20 @@
   <!-- ==================== ABOUT ==================== -->
   <div class="page" x-show="currentSection === 'about'" x-cloak>
     <div style="font-size:18px;font-weight:600;margin-bottom:4px">About</div>
-    <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">Information about Clonarr, TRaSH Guides data, and credits.</div>
+    <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">Information about Clonarr, TRaSH Guides data, and credits.</div>
 
     <div class="card" style="padding:20px;margin-bottom:16px">
-      <div style="font-weight:600;font-size:15px;color:#e1e4e8;margin-bottom:8px">TRaSH Guides</div>
-      <div style="font-size:13px;color:#aaa;line-height:1.6">
+      <div style="font-weight:600;font-size:15px;color:var(--text-primary);margin-bottom:8px">TRaSH Guides</div>
+      <div style="font-size:13px;color:var(--text-muted);line-height:1.6">
         All quality profiles, custom format definitions, naming schemes, and quality size data used in this application
         come from the TRaSH Guides project. Their comprehensive, community-maintained documentation for Radarr, Sonarr,
         and related tools is what makes projects like this possible. A huge thank you to TRaSH and all contributors
         for the incredible work they put into maintaining these guides.
       </div>
       <div style="margin-top:12px;display:flex;gap:12px;flex-wrap:wrap">
-        <a href="https://trash-guides.info" target="_blank" rel="noopener" style="font-size:12px;color:#58a6ff;text-decoration:none">Website — trash-guides.info</a>
-        <a href="https://github.com/TRaSH-Guides/Guides" target="_blank" rel="noopener" style="font-size:12px;color:#58a6ff;text-decoration:none">GitHub — TRaSH-Guides/Guides</a>
-        <a href="https://trash-guides.info/discord" target="_blank" rel="noopener" style="font-size:12px;color:#58a6ff;text-decoration:none">Discord</a>
+        <a href="https://trash-guides.info" target="_blank" rel="noopener" style="font-size:12px;color:var(--accent-blue);text-decoration:none">Website — trash-guides.info</a>
+        <a href="https://github.com/TRaSH-Guides/Guides" target="_blank" rel="noopener" style="font-size:12px;color:var(--accent-blue);text-decoration:none">GitHub — TRaSH-Guides/Guides</a>
+        <a href="https://trash-guides.info/discord" target="_blank" rel="noopener" style="font-size:12px;color:var(--accent-blue);text-decoration:none">Discord</a>
       </div>
     </div>
 

--- a/ui/static/partials/sections/advanced.html
+++ b/ui/static/partials/sections/advanced.html
@@ -5,22 +5,22 @@
     <div x-show="advancedTab === 'builder'">
       <div class="page">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Profile Builder</div>
-        <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">
-          <strong style="color:#d29922">Experimental.</strong> Build custom profiles with fixed scores, or import from Recyclarr YAML. Profiles here do <strong>not</strong> auto-sync with TRaSH Guide updates.
+        <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
+          <strong style="color:var(--accent-orange)">Experimental.</strong> Build custom profiles with fixed scores, or import from Recyclarr YAML. Profiles here do <strong>not</strong> auto-sync with TRaSH Guide updates.
         </div>
         <div style="display:flex;gap:8px;margin-bottom:16px">
-          <button class="btn btn-sm" style="background:#1f6feb;color:#fff" @click="openProfileBuilder(activeAppType)">New Profile</button>
-          <button class="btn btn-sm" style="background:#238636;color:#fff" @click="showImportModal = 'auto'">Import</button>
+          <button class="btn btn-sm" style="background:var(--accent-blue-strong);color:var(--text-on-accent)" @click="openProfileBuilder(activeAppType)">New Profile</button>
+          <button class="btn btn-sm" style="background:var(--accent-green-strong);color:var(--text-on-accent)" @click="showImportModal = 'auto'">Import</button>
         </div>
 
         <!-- Imported profiles list -->
         <div class="card">
-          <div style="padding:10px 16px;font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600;border-bottom:1px solid #21262d">
+          <div style="padding:10px 16px;font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600;border-bottom:1px solid var(--bg-muted)">
             Your Profiles
-            <span style="background:#21262d;color:#aaa;padding:0 6px;border-radius:8px;margin-left:6px;text-transform:none;letter-spacing:0" x-text="(importedProfiles[activeAppType]?.length || 0)"></span>
+            <span style="background:var(--bg-muted);color:var(--text-muted);padding:0 6px;border-radius:8px;margin-left:6px;text-transform:none;letter-spacing:0" x-text="(importedProfiles[activeAppType]?.length || 0)"></span>
           </div>
           <template x-if="!importedProfiles[activeAppType] || importedProfiles[activeAppType].length === 0">
-            <div style="padding:24px;text-align:center;color:#aaa;font-size:13px">
+            <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">
               No profiles yet. Create a new profile or import from Recyclarr YAML / TRaSH JSON.
             </div>
           </template>
@@ -28,7 +28,7 @@
             <div class="profile-row">
               <div style="flex:1;min-width:0">
                 <a class="profile-name-link" @click.stop="(p.source === 'custom' || p.source === 'import' || !p.source) ? editCustomProfile(activeAppType, p) : openImportedProfileDetail(activeAppType, p)" x-text="p.name"></a>
-                <div style="font-size:12px;color:#aaa;margin-top:2px">
+                <div style="font-size:12px;color:var(--text-muted);margin-top:2px">
                   <span x-text="Object.keys(p.formatItems || {}).length"></span> CFs
                   <span x-show="p.scoreSet"> · <span x-text="p.scoreSet"></span></span>
                 </div>
@@ -52,38 +52,38 @@
     <div x-show="advancedTab === 'group-builder'">
       <div class="page">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">CF Group Builder</div>
-        <div x-show="!config.devFeatures" style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">
+        <div x-show="!config.devFeatures" style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
           Group your custom formats so they're easy to reuse across profiles. Pick the custom formats that belong together, mark which are required, and link them to quality profiles. Save the group locally to keep iterating on it, or export it as JSON for backup.
         </div>
-        <div x-show="config.devFeatures" style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">
+        <div x-show="config.devFeatures" style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
           Build a <code>cf-groups/*.json</code> file — for TRaSH-Guides contribution, or for your own personal use. Pick custom formats, mark which are required, link to quality profiles. Save locally to iterate on later, or export as JSON. Hash (<code>trash_id</code>) auto-computed from the group name.
         </div>
 
         <!-- Load-error banner — visible when /api/trash/* calls fail -->
-        <div x-show="cfgbLoadError" x-cloak style="background:#3a1a1a;border:1px solid #5a2a2a;color:#ff9a9a;padding:10px 14px;border-radius:6px;margin-bottom:16px;font-size:13px" x-text="cfgbLoadError"></div>
+        <div x-show="cfgbLoadError" x-cloak style="background:var(--accent-red-bg);border:1px solid var(--accent-red-bg);color:var(--accent-red-soft);padding:10px 14px;border-radius:6px;margin-bottom:16px;font-size:13px" x-text="cfgbLoadError"></div>
 
         <!-- Saved cf-groups list — persistent storage, scoped to current appType. -->
         <div x-show="cfgbSavedGroups.length > 0" style="margin-bottom:20px" x-cloak>
-          <div style="font-size:12px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600;margin-bottom:8px" x-text="'Saved ' + activeAppType + ' cf-groups (' + cfgbSavedGroups.length + ')'"></div>
+          <div style="font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600;margin-bottom:8px" x-text="'Saved ' + activeAppType + ' cf-groups (' + cfgbSavedGroups.length + ')'"></div>
           <div class="card" style="padding:0">
             <template x-for="(g, idx) in cfgbSavedGroups" :key="g.id">
               <!-- Alpine object :style merges with the static style attribute;
                    the earlier string form ('border-bottom:none') replaced
                    everything including display:flex, which pushed the
                    action buttons below the row content. -->
-              <div style="padding:10px 16px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:12px"
+              <div style="padding:10px 16px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:12px"
                    :style="{ borderBottom: idx === cfgbSavedGroups.length - 1 ? 'none' : '' }">
                 <div style="flex:1;min-width:0;overflow:hidden">
                   <div style="font-size:13px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="g.name"></div>
-                  <div style="font-size:11px;color:#6a6e76;margin-top:2px">
+                  <div style="font-size:11px;color:var(--text-muted-secondary);margin-top:2px">
                     <span x-text="(g.custom_formats || []).length + ' CFs · ' + Object.keys(g.quality_profiles && g.quality_profiles.include || {}).length + ' profiles'"></span>
-                    <span x-show="g.default === 'true'" style="background:#30363d;color:#3fb950;padding:0 6px;border-radius:4px;font-size:10px;margin-left:6px;text-transform:uppercase;letter-spacing:0.5px">default</span>
+                    <span x-show="g.default === 'true'" style="background:var(--border-subtle);color:var(--accent-green);padding:0 6px;border-radius:4px;font-size:10px;margin-left:6px;text-transform:uppercase;letter-spacing:0.5px">default</span>
                     <span x-show="g.updatedAt" style="margin-left:8px" x-text="'updated ' + g.updatedAt.slice(0,10)"></span>
-                    <span x-show="cfgbEditingId === g.id" style="background:#1f6feb;color:#fff;padding:0 6px;border-radius:4px;font-size:10px;margin-left:6px;text-transform:uppercase;letter-spacing:0.5px">editing</span>
+                    <span x-show="cfgbEditingId === g.id" style="background:var(--accent-blue-strong);color:var(--text-on-accent);padding:0 6px;border-radius:4px;font-size:10px;margin-left:6px;text-transform:uppercase;letter-spacing:0.5px">editing</span>
                   </div>
                 </div>
                 <button class="btn" @click="cfgbLoadForEdit(g)" style="font-size:12px;padding:4px 10px;flex-shrink:0" x-tt="'Load into form for editing'">Edit</button>
-                <button class="btn" @click="cfgbDelete(g)" style="font-size:12px;padding:4px 10px;color:#f85149;border-color:#f85149;flex-shrink:0" x-tt="'Delete saved cf-group'">Delete</button>
+                <button class="btn" @click="cfgbDelete(g)" style="font-size:12px;padding:4px 10px;color:var(--accent-red);border-color:var(--accent-red);flex-shrink:0" x-tt="'Delete saved cf-group'">Delete</button>
               </div>
             </template>
           </div>
@@ -97,19 +97,19 @@
              scratch. -->
         <div x-show="cfgbTrashCFGroups.length > 0" style="margin-bottom:20px" x-cloak>
           <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-            <div style="font-size:12px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600" x-text="'TRaSH ' + activeAppType + ' cf-groups (' + cfgbTrashCFGroups.length + ')'"></div>
+            <div style="font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600" x-text="'TRaSH ' + activeAppType + ' cf-groups (' + cfgbTrashCFGroups.length + ')'"></div>
             <button type="button" @click="cfgbTrashListOpen = !cfgbTrashListOpen"
-                    style="background:none;border:none;color:#58a6ff;cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline"
+                    style="background:none;border:none;color:var(--accent-blue);cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline"
                     x-text="cfgbTrashListOpen ? 'Hide' : 'Show'"></button>
           </div>
           <div x-show="cfgbTrashListOpen" x-cloak class="card" style="padding:0;max-height:280px;overflow-y:auto">
             <template x-for="g in cfgbTrashCFGroups" :key="g.trash_id">
-              <div style="padding:8px 16px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:12px;flex-wrap:wrap">
+              <div style="padding:8px 16px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:12px;flex-wrap:wrap">
                 <div style="flex:1;min-width:200px">
                   <div style="font-size:13px;font-weight:600" x-text="g.name"></div>
-                  <div style="font-size:11px;color:#6a6e76;margin-top:2px">
+                  <div style="font-size:11px;color:var(--text-muted-secondary);margin-top:2px">
                     <span x-text="(g.custom_formats || []).length + ' CFs · ' + Object.keys(g.quality_profiles && g.quality_profiles.include || {}).length + ' profiles'"></span>
-                    <span x-show="g.default === 'true'" style="background:#30363d;color:#3fb950;padding:0 6px;border-radius:4px;font-size:10px;margin-left:6px;text-transform:uppercase;letter-spacing:0.5px">default</span>
+                    <span x-show="g.default === 'true'" style="background:var(--border-subtle);color:var(--accent-green);padding:0 6px;border-radius:4px;font-size:10px;margin-left:6px;text-transform:uppercase;letter-spacing:0.5px">default</span>
                   </div>
                 </div>
                 <button class="btn" @click="cfgbLoadFromTrash(g)" style="font-size:12px;padding:4px 10px" x-tt="'Load this TRaSH group into the builder for editing. Save writes a new local copy under /config/custom/json/{app}/cf-groups/ — the TRaSH repo clone is never modified.'">Edit</button>
@@ -130,7 +130,7 @@
              locked means the hash stays frozen even when the name changes
              (default for edits, so typo fixes don't invalidate downstream
              references). Unlocked means the hash tracks the name. -->
-        <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;font-size:12px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600;margin-bottom:8px">
+        <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600;margin-bottom:8px">
           <span x-show="!cfgbEditingId && !cfgbFromTrashName">New cf-group</span>
           <span x-show="!cfgbEditingId && cfgbFromTrashName" x-cloak>
             Copying from TRaSH: <span x-text="cfgbFromTrashName"></span> — will save as new local cf-group
@@ -147,8 +147,8 @@
                     ? 'ID locked: the group ID stays the same when you rename it. Click to unlock — renaming will then generate a fresh ID.'
                     : 'ID tracks name: renaming will generate a fresh ID, which can break links from existing profiles to this group. Click to lock the current ID.'"
                   :style="cfgbHashLocked
-                    ? 'background:#0f1a23;border:1px solid #1f6feb;color:#58a6ff'
-                    : 'background:#2a1a0a;border:1px solid #d29922;color:#e3b341'"
+                    ? 'background:var(--fill-blue-soft);border:1px solid var(--accent-blue-strong);color:var(--accent-blue)'
+                    : 'background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--cat-hq-release-groups)'"
                   style="padding:3px 10px;border-radius:4px;cursor:pointer;font-size:11px;text-transform:none;letter-spacing:0;font-weight:600;display:inline-flex;align-items:center;gap:6px">
             <span x-show="cfgbHashLocked">🔒 ID locked</span>
             <span x-show="!cfgbHashLocked" x-cloak>🔓 ID tracks name</span>
@@ -160,15 +160,15 @@
              full width; description keeps full width for multi-line text. -->
         <div style="display:flex;flex-wrap:wrap;gap:16px;align-items:flex-end;margin-bottom:16px">
           <div style="flex:0 1 400px;min-width:240px">
-            <label style="display:block;font-size:12px;color:#aaa;margin-bottom:4px">Group name</label>
+            <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px">Group name</label>
             <input type="text" class="input" style="width:100%" x-model="cfgbName" @input="cfgbUpdateHash()" placeholder="e.g. [Audio] Audio Channels">
           </div>
           <div x-show="config.devFeatures && config.trashSchemaFields" style="flex:0 1 360px;min-width:240px">
-            <label style="display:block;font-size:12px;color:#aaa;margin-bottom:4px">trash_id (auto-generated from name, MD5)</label>
-            <input type="text" class="input" style="width:100%;font-family:monospace;font-size:13px;color:#8b949e" readonly :value="cfgbTrashID || '(type a name above)'">
+            <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px">trash_id (auto-generated from name, MD5)</label>
+            <input type="text" class="input" style="width:100%;font-family:monospace;font-size:13px;color:var(--text-secondary)" readonly :value="cfgbTrashID || '(type a name above)'">
           </div>
           <div>
-            <label style="display:block;font-size:12px;color:#aaa;margin-bottom:4px">Default</label>
+            <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px">Default</label>
             <label class="toggle" style="margin-top:6px">
               <input type="checkbox" x-model="cfgbDefault">
               <span class="slider"></span>
@@ -176,13 +176,13 @@
           </div>
           <div style="flex:0 1 130px;min-width:120px"
                x-tt="'Sort order in the cf-group list. Lower number sorts higher up; ties break alphabetically. Leave empty for default placement (groups without a number land in the 'Other' tier between numbered groups and Custom). Common ranges per TRaSH's profile-JSON convention: 1-9 (English public), 11-19 (German), 21-29 (French), 81-89 (Anime), 91-99 (Restricted/SQP). Future ranges (e.g. 31-39 for Spanish) work too — any positive integer is accepted. NOTE: TRaSH-Guides hasn't adopted this field on cf-groups yet — when he does, our sort picks it up automatically. Until then, only your local groups use this field. Contributors PRing to TRaSH-Guides should leave this empty until TRaSH-Guides adds the field to their schema.'">
-            <label style="display:block;font-size:12px;color:#aaa;margin-bottom:4px">Group <span style="color:#7d8590">(sort order)</span></label>
+            <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px">Group <span style="color:var(--text-muted-secondary)">(sort order)</span></label>
             <input type="number" class="input" style="width:100%" x-model.number="cfgbGroup" placeholder="e.g. 1, 11, 81" min="0">
           </div>
         </div>
 
         <div style="margin-bottom:20px">
-          <label style="display:block;font-size:12px;color:#aaa;margin-bottom:4px">Description</label>
+          <label style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px">Description</label>
           <textarea class="input" style="width:100%;min-height:60px;resize:vertical;font-family:inherit" x-model="cfgbDescription" placeholder="Describe what this group is for and any guidance about when to use it."></textarea>
         </div>
 
@@ -193,24 +193,24 @@
              required/default flags, and remove. Card A below is pure
              browse+add (v2.2.0 phase 2). -->
         <div class="card" style="padding:0;display:flex;flex-direction:column;max-height:340px;margin-bottom:16px">
-          <div style="padding:10px 16px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-            <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Selected CFs</span>
-            <span style="background:#21262d;color:#aaa;padding:0 6px;border-radius:8px;font-size:12px" x-text="cfgbSelectedCFCount()"></span>
+          <div style="padding:10px 16px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+            <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Selected CFs</span>
+            <span style="background:var(--bg-muted);color:var(--text-muted);padding:0 6px;border-radius:8px;font-size:12px" x-text="cfgbSelectedCFCount()"></span>
             <!-- Sort-mode toggle. Alpha is the TRaSH-spec default; Manual is
                  user-driven order for cases where sequence matters (audio
                  tiers, release-group tiers). Applies to Copy JSON /
                  Download / Save. -->
-            <div style="display:inline-flex;border:1px solid #30363d;border-radius:4px;overflow:hidden" x-tt="'Sort order for exported JSON. Alpha is the TRaSH spec default; Manual lets you hand-order selected CFs.'">
-              <button type="button" @click="cfgbSetCFSortMode('alpha')" :style="'padding:2px 8px;font-size:11px;cursor:pointer;border:none;' + (cfgbCFSortMode === 'alpha' ? 'background:#1f6feb;color:#fff' : 'background:transparent;color:#aaa')">Alpha</button>
-              <button type="button" @click="cfgbSetCFSortMode('manual')" :style="'padding:2px 8px;font-size:11px;cursor:pointer;border:none;border-left:1px solid #30363d;' + (cfgbCFSortMode === 'manual' ? 'background:#1f6feb;color:#fff' : 'background:transparent;color:#aaa')">Manual</button>
+            <div style="display:inline-flex;border:1px solid var(--border-subtle);border-radius:4px;overflow:hidden" x-tt="'Sort order for exported JSON. Alpha is the TRaSH spec default; Manual lets you hand-order selected CFs.'">
+              <button type="button" @click="cfgbSetCFSortMode('alpha')" :style="'padding:2px 8px;font-size:11px;cursor:pointer;border:none;' + (cfgbCFSortMode === 'alpha' ? 'background:var(--accent-blue-strong);color:var(--text-on-accent)' : 'background:transparent;color:var(--text-muted)')">Alpha</button>
+              <button type="button" @click="cfgbSetCFSortMode('manual')" :style="'padding:2px 8px;font-size:11px;cursor:pointer;border:none;border-left:1px solid var(--border-subtle);' + (cfgbCFSortMode === 'manual' ? 'background:var(--accent-blue-strong);color:var(--text-on-accent)' : 'background:transparent;color:var(--text-muted)')">Manual</button>
             </div>
             <button type="button" x-show="cfgbSelectedCFCount() > 0" x-cloak @click="cfgbToggleAllRequired(!cfgbAllSelectedRequired())"
                     x-tt="cfgbAllSelectedRequired() ? 'Clear required on every selected CF' : 'Mark every selected CF as required'"
-                    style="margin-left:auto;background:none;border:none;color:#58a6ff;cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline"
+                    style="margin-left:auto;background:none;border:none;color:var(--accent-blue);cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline"
                     x-text="cfgbAllSelectedRequired() ? 'Clear required' : 'Mark all required'"></button>
             <button type="button" x-show="cfgbSelectedCFCount() > 0" x-cloak @click="cfgbClearCFs()"
                     x-tt="'Deselect every CF — profile selection and group metadata stay'"
-                    style="background:none;border:none;color:#f85149;cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline">Remove all</button>
+                    style="background:none;border:none;color:var(--accent-red);cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline">Remove all</button>
           </div>
           <div style="overflow-y:auto;flex:1">
             <!-- Fixed grid columns keep each field aligned across rows:
@@ -226,26 +226,26 @@
                    @dragover.prevent="if (cfgbCFSortMode === 'manual') cfgbCFDragOver(cf.trashId)"
                    @drop.prevent="if (cfgbCFSortMode === 'manual') cfgbCFDrop(cf.trashId)"
                    @dragend="cfgbCFDragEnd()"
-                   style="display:grid;grid-template-columns:28px 36px 1fr auto 24px;align-items:center;gap:10px;padding:6px 16px;border-bottom:1px solid #21262d"
+                   style="display:grid;grid-template-columns:28px 36px 1fr auto 24px;align-items:center;gap:10px;padding:6px 16px;border-bottom:1px solid var(--bg-muted)"
                    :style="{
                      opacity: cfgbDragSrcTid === cf.trashId ? 0.4 : 1,
-                     boxShadow: (cfgbDragOverTid === cf.trashId && cfgbDragSrcTid && cfgbDragSrcTid !== cf.trashId) ? 'inset 0 2px 0 #58a6ff' : ''
+                     boxShadow: (cfgbDragOverTid === cf.trashId && cfgbDragSrcTid && cfgbDragSrcTid !== cf.trashId) ? 'inset 0 2px 0 var(--accent-blue)' : ''
                    }">
                 <span x-show="cfgbCFSortMode === 'manual'" x-cloak
-                      style="color:#6a6e76;cursor:grab;user-select:none;text-align:center;font-size:14px;line-height:1"
+                      style="color:var(--text-muted-secondary);cursor:grab;user-select:none;text-align:center;font-size:14px;line-height:1"
                       x-tt="'Drag to reorder'">⋮⋮</span>
                 <span x-show="cfgbCFSortMode !== 'manual'" x-cloak></span>
-                <span style="text-align:right;color:#6a6e76;font-size:11px;font-family:monospace" x-text="(idx + 1) + '.'"></span>
+                <span style="text-align:right;color:var(--text-muted-secondary);font-size:11px;font-family:monospace" x-text="(idx + 1) + '.'"></span>
                 <span style="font-size:13px;display:flex;align-items:center;gap:6px;min-width:0;overflow:hidden">
                   <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="cf.name"></span>
-                  <span x-show="cf.isCustom" style="background:#30363d;color:#58a6ff;padding:0 6px;border-radius:4px;font-size:10px;text-transform:uppercase;letter-spacing:0.5px;flex-shrink:0" x-tt="'Custom format'">custom</span>
+                  <span x-show="cf.isCustom" style="background:var(--border-subtle);color:var(--accent-blue);padding:0 6px;border-radius:4px;font-size:10px;text-transform:uppercase;letter-spacing:0.5px;flex-shrink:0" x-tt="'Custom format'">custom</span>
                 </span>
                 <div style="display:flex;gap:10px;align-items:center;white-space:nowrap">
-                  <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:#aaa" x-tt="'Mark as required — exists in group whether user opts in or not'">
+                  <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:var(--text-muted)" x-tt="'Mark as required — exists in group whether user opts in or not'">
                     <input type="checkbox" x-model="cfgbRequiredCFs[cf.trashId]" @change="cfgbRequiredCFs = {...cfgbRequiredCFs}">
                     required
                   </label>
-                  <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:#aaa" x-tt="'Per-CF default override — rare; TRaSH only uses this on Golden Rule files'">
+                  <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:var(--text-muted)" x-tt="'Per-CF default override — rare; TRaSH only uses this on Golden Rule files'">
                     <input type="checkbox" x-model="cfgbDefaultCFs[cf.trashId]" @change="cfgbDefaultCFs = {...cfgbDefaultCFs}">
                     default
                   </label>
@@ -253,11 +253,11 @@
                 <button type="button"
                         @click="cfgbSelectedCFs = (() => { const { [cf.trashId]: _a, ...rest } = cfgbSelectedCFs; return rest; })(); cfgbRequiredCFs = (() => { const { [cf.trashId]: _b, ...rest } = cfgbRequiredCFs; return rest; })(); cfgbDefaultCFs = (() => { const { [cf.trashId]: _c, ...rest } = cfgbDefaultCFs; return rest; })()"
                         x-tt="'Remove from group'"
-                        style="background:none;border:none;color:#f85149;cursor:pointer;font-size:16px;line-height:1;padding:0">&times;</button>
+                        style="background:none;border:none;color:var(--accent-red);cursor:pointer;font-size:16px;line-height:1;padding:0">&times;</button>
               </div>
             </template>
             <template x-if="cfgbSelectedCFCount() === 0">
-              <div style="padding:32px 16px;text-align:center;color:#8b949e;font-size:13px">
+              <div style="padding:32px 16px;text-align:center;color:var(--text-secondary);font-size:13px">
                 No CFs in this group yet. Use the <strong>Custom Formats</strong> list below to add some, or start from an upstream TRaSH group with the <em>Edit</em> button above.
               </div>
             </template>
@@ -268,15 +268,15 @@
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:20px">
           <!-- CFs panel -->
           <div class="card" style="padding:0;display:flex;flex-direction:column;max-height:500px">
-            <div style="padding:10px 16px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-              <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Custom Formats</span>
-              <span style="background:#21262d;color:#aaa;padding:0 6px;border-radius:8px;font-size:12px" x-text="cfgbSelectedCFCount() + ' / ' + cfgbFilteredCount() + (cfgbGroupFilter === 'all' ? '' : ' in ' + cfgbGroupFilterLabel())"></span>
+            <div style="padding:10px 16px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+              <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Custom Formats</span>
+              <span style="background:var(--bg-muted);color:var(--text-muted);padding:0 6px;border-radius:8px;font-size:12px" x-text="cfgbSelectedCFCount() + ' / ' + cfgbFilteredCount() + (cfgbGroupFilter === 'all' ? '' : ' in ' + cfgbGroupFilterLabel())"></span>
               <!-- v2.2.0 phase 2: Card A is now a pure "browse + add" view —
                    sort-mode toggle, manual-order arrows, and selection bulk
                    actions (Mark-all-required / Remove all) migrated to the
                    Selected CFs card above, where the group's state actually
                    lives. Card A only needs the narrow-and-pick controls. -->
-              <select x-model="cfgbGroupFilter" style="padding:4px 6px;background:#0d1117;border:1px solid #30363d;border-radius:4px;color:#e6e6e6;font-size:12px;max-width:240px" x-tt="'Narrow to one TRaSH cf-group, your custom CFs, or ungrouped CFs'">
+              <select x-model="cfgbGroupFilter" style="padding:4px 6px;background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:4px;color:var(--text-primary);font-size:12px;max-width:240px" x-tt="'Narrow to one TRaSH cf-group, your custom CFs, or ungrouped CFs'">
                 <option value="all">All CFs (no filter)</option>
                 <option value="custom" x-show="cfgbHasCustom">— Custom CFs (yours)</option>
                 <option value="other-trash" x-show="cfgbUngroupedTrashCount > 0" x-text="'— Ungrouped per TRaSH (' + cfgbUngroupedTrashCount + ')'"></option>
@@ -287,7 +287,7 @@
                   <option :value="gr.groupTrashId" x-text="(gr.isLocal ? '[local] ' : '') + gr.name + ' (' + gr.count + ')'"></option>
                 </template>
               </select>
-              <input type="text" placeholder="Filter (multiple terms: mono stereo surround)" x-model="cfgbCFFilter" style="flex:1;min-width:100px;padding:4px 8px;background:#0d1117;border:1px solid #30363d;border-radius:4px;color:#e6e6e6;font-size:12px" x-tt="'Matches any of the space-separated terms, e.g. &quot;mono stereo surround&quot; shows all three'">
+              <input type="text" placeholder="Filter (multiple terms: mono stereo surround)" x-model="cfgbCFFilter" style="flex:1;min-width:100px;padding:4px 8px;background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:4px;color:var(--text-primary);font-size:12px" x-tt="'Matches any of the space-separated terms, e.g. &quot;mono stereo surround&quot; shows all three'">
               <!-- Select-all toggle: only visible when filters have narrowed
                    the list. For "All cf-groups" with no text filter this
                    would mean selecting every CF in TRaSH, which is almost
@@ -297,7 +297,7 @@
                       x-cloak
                       @click="cfgbToggleFilteredAll(!cfgbFilteredAllSelected())"
                       x-tt="cfgbFilteredAllSelected() ? 'Deselect every visible CF' : 'Select every CF in the current filter'"
-                      style="padding:4px 8px;background:#21262d;border:1px solid #30363d;border-radius:4px;color:#e6e6e6;font-size:11px;cursor:pointer;white-space:nowrap"
+                      style="padding:4px 8px;background:var(--bg-muted);border:1px solid var(--border-subtle);border-radius:4px;color:var(--text-primary);font-size:11px;cursor:pointer;white-space:nowrap"
                       x-text="cfgbFilteredAllSelected() ? 'Deselect all' : 'Select all (' + cfgbFilteredCount() + ')'"></button>
             </div>
             <div style="overflow-y:auto;flex:1">
@@ -317,20 +317,20 @@
                        instead of replacing it. Passing a string here
                        collapses the whole row layout (checkbox wraps
                        above the name). -->
-                  <div style="padding:6px 16px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px;min-width:0"
-                       :style="{ background: cfgbSelectedCFs[cf.trashId] ? '#0f1a23' : '' }">
+                  <div style="padding:6px 16px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px;min-width:0"
+                       :style="{ background: cfgbSelectedCFs[cf.trashId] ? 'var(--fill-blue-soft)' : '' }">
                     <input type="checkbox" :id="'cfgb-cf-' + cf.trashId" x-model="cfgbSelectedCFs[cf.trashId]" @change="cfgbSelectedCFs = {...cfgbSelectedCFs}">
                     <label :for="'cfgb-cf-' + cf.trashId" style="flex:1;cursor:pointer;font-size:13px;display:flex;align-items:center;gap:6px;min-width:0;overflow:hidden">
                       <span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="cf.name"></span>
-                      <span x-show="cf.isCustom" style="background:#30363d;color:#58a6ff;padding:0 6px;border-radius:4px;font-size:10px;text-transform:uppercase;letter-spacing:0.5px;flex-shrink:0" x-tt="'Custom format from your Custom Formats tab — won't resolve in the public TRaSH-Guides repo'">custom</span>
-                      <span x-show="cfgbSelectedCFs[cf.trashId]" style="color:#3fb950;font-size:10px;text-transform:uppercase;letter-spacing:0.3px;flex-shrink:0" x-tt="'In group — manage required/default/order in the Selected CFs card above'">in group</span>
+                      <span x-show="cf.isCustom" style="background:var(--border-subtle);color:var(--accent-blue);padding:0 6px;border-radius:4px;font-size:10px;text-transform:uppercase;letter-spacing:0.5px;flex-shrink:0" x-tt="'Custom format from your Custom Formats tab — won't resolve in the public TRaSH-Guides repo'">custom</span>
+                      <span x-show="cfgbSelectedCFs[cf.trashId]" style="color:var(--accent-green);font-size:10px;text-transform:uppercase;letter-spacing:0.3px;flex-shrink:0" x-tt="'In group — manage required/default/order in the Selected CFs card above'">in group</span>
                     </label>
-                    <span x-show="cfgbGroupFilter === 'all' && cf.groupNames && cf.groupNames.length > 0" style="font-size:10px;color:#6a6e76;flex-shrink:0;max-width:30%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="cf.groupNames.join(' · ')" x-tt="cf.groupNames.join('\n')"></span>
+                    <span x-show="cfgbGroupFilter === 'all' && cf.groupNames && cf.groupNames.length > 0" style="font-size:10px;color:var(--text-muted-secondary);flex-shrink:0;max-width:30%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="cf.groupNames.join(' · ')" x-tt="cf.groupNames.join('\n')"></span>
                   </div>
                 </template>
               </div>
               <template x-if="cfgbFilteredCFs().length === 0">
-                <div style="padding:24px;text-align:center;color:#aaa;font-size:13px" x-text="cfgbCFs.length === 0 ? 'Loading CFs...' : 'No matches.'"></div>
+                <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px" x-text="cfgbCFs.length === 0 ? 'Loading CFs...' : 'No matches.'"></div>
               </template>
             </div>
           </div>
@@ -338,11 +338,11 @@
           <!-- Profiles panel — card layout matching the Profiles tab, with
                per-card select-all + a top-level select-all. -->
           <div class="card" style="padding:0;display:flex;flex-direction:column;max-height:500px">
-            <div style="padding:10px 16px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px">
-              <span style="font-size:13px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality Profiles</span>
-              <span style="background:#21262d;color:#aaa;padding:0 6px;border-radius:8px;font-size:12px" x-text="cfgbSelectedProfileCount() + ' / ' + cfgbProfiles.length"></span>
-              <button type="button" x-show="cfgbSelectedProfileCount() > 0" x-cloak @click="cfgbClearProfiles()" x-tt="'Deselect every profile — CF selection stays'" style="background:none;border:none;color:#f85149;cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline">Clear profiles</button>
-              <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:#aaa;margin-left:auto" x-tt="'Select every profile across all groups'">
+            <div style="padding:10px 16px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px">
+              <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality Profiles</span>
+              <span style="background:var(--bg-muted);color:var(--text-muted);padding:0 6px;border-radius:8px;font-size:12px" x-text="cfgbSelectedProfileCount() + ' / ' + cfgbProfiles.length"></span>
+              <button type="button" x-show="cfgbSelectedProfileCount() > 0" x-cloak @click="cfgbClearProfiles()" x-tt="'Deselect every profile — CF selection stays'" style="background:none;border:none;color:var(--accent-red);cursor:pointer;font-size:11px;padding:2px 4px;text-decoration:underline">Clear profiles</button>
+              <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:var(--text-muted);margin-left:auto" x-tt="'Select every profile across all groups'">
                 <input type="checkbox" :checked="cfgbAllProfilesSelected()" @change="cfgbToggleAllProfiles($event.target.checked)">
                 select all
               </label>
@@ -352,21 +352,21 @@
                  accent match. Wrapped nodes sit inside the builder panel's
                  scrollable body; a small background tint separates them from
                  the panel's card background. -->
-            <div style="overflow-y:auto;flex:1;padding:8px;background:#0d1117">
+            <div style="overflow-y:auto;flex:1;padding:8px;background:var(--bg-page)">
               <template x-for="grp in cfgbGroupedProfiles()" :key="grp.name">
                 <div class="card" :class="'grp-' + grp.name.toLowerCase().replace(/[^a-z]/g, '')" style="margin-bottom:6px">
                   <div class="profile-group-header" @click="cfgbToggleProfileGroupCard(grp.name)">
                     <span class="profile-group-chevron" :class="{ open: cfgbIsProfileGroupExpanded(grp.name) }">&#9654;</span>
                     <span style="flex:1" x-text="grp.name"></span>
                     <span class="profile-group-count" x-text="cfgbGroupSelectedCount(grp) + ' / ' + grp.profiles.length"></span>
-                    <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:#aaa" @click.stop x-tt="'Select all ' + grp.name + ' profiles'">
+                    <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:var(--text-muted)" @click.stop x-tt="'Select all ' + grp.name + ' profiles'">
                       <input type="checkbox" :checked="cfgbGroupAllSelected(grp)" @change="cfgbToggleGroupAll(grp, $event.target.checked)">
                       all
                     </label>
                   </div>
                   <div x-show="cfgbIsProfileGroupExpanded(grp.name)">
                     <template x-for="p in grp.profiles" :key="p.trashId">
-                      <div style="padding:6px 16px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px">
+                      <div style="padding:6px 16px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px">
                         <input type="checkbox" :id="'cfgb-p-' + p.trashId" x-model="cfgbSelectedProfiles[p.trashId]" @change="cfgbSelectedProfiles = {...cfgbSelectedProfiles}">
                         <label :for="'cfgb-p-' + p.trashId" style="flex:1;cursor:pointer;font-size:13px" x-text="p.name"></label>
                       </div>
@@ -375,7 +375,7 @@
                 </div>
               </template>
               <template x-if="cfgbProfiles.length === 0">
-                <div style="padding:24px;text-align:center;color:#aaa;font-size:13px">Loading profiles...</div>
+                <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">Loading profiles...</div>
               </template>
             </div>
           </div>
@@ -388,15 +388,15 @@
           </button>
           <button class="btn" @click="cfgbCopyJSON()" :disabled="!cfgbCanExport()" x-tt="'Copy the JSON to clipboard'"><span x-text="cfgbCopyLabel"></span></button>
           <button class="btn" @click="cfgbDownloadJSON()" :disabled="!cfgbCanExport()" x-tt="'Download the JSON as a file'">Download .json</button>
-          <button class="btn" @click="cfgbUIReset()" style="margin-left:auto;color:#f85149;border-color:#f85149" x-text="cfgbEditingId ? 'Discard changes' : 'Reset'"></button>
+          <button class="btn" @click="cfgbUIReset()" style="margin-left:auto;color:var(--accent-red);border-color:var(--accent-red)" x-text="cfgbEditingId ? 'Discard changes' : 'Reset'"></button>
         </div>
 
         <!-- Save/delete feedback -->
-        <div x-show="cfgbSavingMsg" x-cloak :style="'background:' + (cfgbSavingOk ? '#1a3a1a' : '#3a1a1a') + ';border:1px solid ' + (cfgbSavingOk ? '#2a5a2a' : '#5a2a2a') + ';color:' + (cfgbSavingOk ? '#9aff9a' : '#ff9a9a') + ';padding:8px 12px;border-radius:6px;margin-bottom:8px;font-size:12px'" x-text="cfgbSavingMsg"></div>
+        <div x-show="cfgbSavingMsg" x-cloak :style="'background:' + (cfgbSavingOk ? 'var(--accent-green-bg)' : 'var(--accent-red-bg)') + ';border:1px solid ' + (cfgbSavingOk ? 'var(--accent-green-bg)' : 'var(--accent-red-bg)') + ';color:' + (cfgbSavingOk ? 'var(--accent-green)' : 'var(--accent-red-soft)') + ';padding:8px 12px;border-radius:6px;margin-bottom:8px;font-size:12px'" x-text="cfgbSavingMsg"></div>
 
         <!-- Custom-CF warning — surfaces when the selected set includes custom CFs
              which won't resolve in the public TRaSH-Guides repo. -->
-        <div x-show="cfgbSelectedCustomCFCount() > 0" x-cloak style="background:#2a2418;border:1px solid #4a3a18;color:#ffc88a;padding:8px 12px;border-radius:6px;margin-bottom:8px;font-size:12px">
+        <div x-show="cfgbSelectedCustomCFCount() > 0" x-cloak style="background:var(--accent-orange-bg);border:1px solid var(--accent-orange-bg);color:var(--accent-orange-bright);padding:8px 12px;border-radius:6px;margin-bottom:8px;font-size:12px">
           <span x-text="cfgbSelectedCustomCFCount()"></span>
           custom CF<span x-show="cfgbSelectedCustomCFCount() !== 1">s</span>
           selected. These have IDs starting <code>custom:</code> and won't resolve in TRaSH-Guides. Save locally for personal use, but don't include them in a Download meant for contribution.
@@ -404,11 +404,11 @@
 
         <!-- JSON preview (collapsible — Alpine pattern, matches other Clonarr collapsibles) -->
         <div style="margin-top:8px">
-          <div @click="cfgbPreviewOpen = !cfgbPreviewOpen" style="cursor:pointer;font-size:13px;color:#aaa;padding:6px 0;display:flex;align-items:center;gap:6px;user-select:none">
+          <div @click="cfgbPreviewOpen = !cfgbPreviewOpen" style="cursor:pointer;font-size:13px;color:var(--text-muted);padding:6px 0;display:flex;align-items:center;gap:6px;user-select:none">
             <span class="detail-section-chevron" :class="{ open: cfgbPreviewOpen }">▶</span>
             <span>JSON preview</span>
           </div>
-          <pre x-show="cfgbPreviewOpen" x-cloak style="background:#0d1117;border:1px solid #30363d;border-radius:6px;padding:12px;overflow-x:auto;font-size:12px;color:#c9d1d9;max-height:300px;overflow-y:auto" x-text="cfgbGenerateJSON()"></pre>
+          <pre x-show="cfgbPreviewOpen" x-cloak style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px;overflow-x:auto;font-size:12px;color:var(--text-body);max-height:300px;overflow-y:auto" x-text="cfgbGenerateJSON()"></pre>
         </div>
       </div>
     </div>

--- a/ui/static/partials/sections/advanced.html
+++ b/ui/static/partials/sections/advanced.html
@@ -222,7 +222,7 @@
                  unchanged. -->
             <template x-for="(cf, idx) in cfgbOrderedSelectedCFs()" :key="cf.trashId">
               <div :draggable="cfgbCFSortMode === 'manual'"
-                   @dragstart="if (cfgbCFSortMode === 'manual') cfgbCFDragStart(cf.trashId)"
+                   @dragstart="if (cfgbCFSortMode === 'manual') { event.dataTransfer.setData('text/plain', ''); cfgbCFDragStart(cf.trashId); }"
                    @dragover.prevent="if (cfgbCFSortMode === 'manual') cfgbCFDragOver(cf.trashId)"
                    @drop.prevent="if (cfgbCFSortMode === 'manual') cfgbCFDrop(cf.trashId)"
                    @dragend="cfgbCFDragEnd()"

--- a/ui/static/partials/sections/app-pages.html
+++ b/ui/static/partials/sections/app-pages.html
@@ -3,17 +3,17 @@
   <template x-if="true">
     <div x-show="!['settings','about'].includes(currentSection) && !profileDetail && !profileBuilder">
       <!-- App type + section sub-tabs (universal bar, matches page width) -->
-      <div class="profile-tabs" style="max-width:1100px;margin:0 auto;padding:0 24px;background:transparent;border-bottom:1px solid #21262d">
+      <div class="profile-tabs" style="max-width:1100px;margin:0 auto;padding:0 24px;background:transparent;border-bottom:1px solid var(--bg-muted)">
         <template x-for="appType in availableAppTypes" :key="'global-'+appType">
           <div class="profile-tab" :class="{ active: activeAppType === appType }"
                @click="switchAppType(appType)">
             <span x-text="appType.charAt(0).toUpperCase() + appType.slice(1)"></span>
-            <span x-show="instancesOfType(appType).length > 0" style="background:#21262d;color:#aaa;padding:0 6px;border-radius:8px;margin-left:4px;font-size:11px" x-text="instancesOfType(appType).length"></span>
+            <span x-show="instancesOfType(appType).length > 0" style="background:var(--bg-muted);color:var(--text-muted);padding:0 6px;border-radius:8px;margin-left:4px;font-size:11px" x-text="instancesOfType(appType).length"></span>
           </div>
         </template>
         <!-- Profiles sub-tabs -->
         <template x-if="currentSection === 'profiles'">
-          <div style="display:flex;gap:0;margin-left:16px;border-left:1px solid #30363d;padding-left:8px">
+          <div style="display:flex;gap:0;margin-left:16px;border-left:1px solid var(--border-subtle);padding-left:8px">
             <div class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'trash-sync' }" @click="setProfileTab(activeAppType, 'trash-sync'); pushNav()">TRaSH Sync</div>
             <div class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'history' }" @click="setProfileTab(activeAppType, 'history'); pushNav(); instancesOfType(activeAppType).forEach(i => loadSyncHistory(i.id))">History</div>
             <div class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'compare' }" @click="setProfileTab(activeAppType, 'compare'); pushNav()">Compare</div>
@@ -21,7 +21,7 @@
         </template>
         <!-- Advanced sub-tabs -->
         <template x-if="currentSection === 'advanced'">
-          <div style="display:flex;gap:0;margin-left:16px;border-left:1px solid #30363d;padding-left:8px">
+          <div style="display:flex;gap:0;margin-left:16px;border-left:1px solid var(--border-subtle);padding-left:8px">
             <div class="profile-tab" :class="{ active: advancedTab === 'builder' }" @click="advancedTab = 'builder'; pushNav()">Profile Builder</div>
             <div class="profile-tab" :class="{ active: advancedTab === 'scoring' }" @click="advancedTab = 'scoring'; loadSandbox(activeAppType); pushNav()">Scoring Sandbox</div>
             <div class="profile-tab" :class="{ active: advancedTab === 'group-builder' }" @click="advancedTab = 'group-builder'; cfgbLoad(activeAppType); pushNav()">CF Group Builder</div>

--- a/ui/static/partials/sections/custom-formats.html
+++ b/ui/static/partials/sections/custom-formats.html
@@ -2,24 +2,24 @@
       <!-- ===== Custom Formats sub-tab ===== -->
       <div class="page" x-show="currentSection === 'custom-formats'">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Custom Formats</div>
-        <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">All Custom Formats from TRaSH Guides, organized by category. Use Create to build a custom format from scratch, or Import to add existing formats from an Arr instance or JSON.</div>
+        <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">All Custom Formats from TRaSH Guides, organized by category. Use Create to build a custom format from scratch, or Import to add existing formats from an Arr instance or JSON.</div>
 
         <template x-if="getCFBrowseGroups(activeAppType).length > 0">
           <div>
             <div style="padding:0 0 12px;display:flex;align-items:center;justify-content:space-between">
-              <div style="font-size:14px;color:#aaa">
-                Showing <strong style="color:#e1e4e8" x-text="(getCFBrowseGroups(activeAppType) || []).reduce((acc, c) => acc + (c.totalCFs || 0), 0)"></strong> Custom Formats.
+              <div style="font-size:14px;color:var(--text-muted)">
+                Showing <strong style="color:var(--text-primary)" x-text="(getCFBrowseGroups(activeAppType) || []).reduce((acc, c) => acc + (c.totalCFs || 0), 0)"></strong> Custom Formats.
               </div>
               <div style="display:flex;gap:8px;margin-left:12px;flex-shrink:0">
-                <button class="btn btn-sm" style="background:#1f6feb;color:#fff;white-space:nowrap" @click="openCFEditor('create', activeAppType)">Create</button>
-                <button class="btn btn-sm" style="background:#238636;color:#fff;white-space:nowrap" @click="openImportCFModal(activeAppType)">Import</button>
+                <button class="btn btn-sm" style="background:var(--accent-blue-strong);color:var(--text-on-accent);white-space:nowrap" @click="openCFEditor('create', activeAppType)">Create</button>
+                <button class="btn btn-sm" style="background:var(--accent-green-strong);color:var(--text-on-accent);white-space:nowrap" @click="openImportCFModal(activeAppType)">Import</button>
               </div>
             </div>
             <template x-for="cat in getCFBrowseGroups(activeAppType)" :key="cat.displayName">
               <div class="detail-section" :class="getCategoryClass(cat.category)" style="margin-bottom:8px">
                 <div class="detail-section-header" @click="toggleDetailSection('cfb_' + cat.displayName)" style="cursor:pointer"
-                     :style="cat.isCustom ? 'border-left:3px solid #d29922;background:#1a1500' : ''">
-                  <div class="detail-section-label" :style="cat.isCustom ? 'color:#d29922' : ''" x-text="cat.displayName"></div>
+                     :style="cat.isCustom ? 'border-left:3px solid var(--accent-orange);background:var(--accent-orange-bg)' : ''">
+                  <div class="detail-section-label" :style="cat.isCustom ? 'color:var(--accent-orange)' : ''" x-text="cat.displayName"></div>
                   <div class="detail-section-count" x-text="cat.totalCFs + ' CFs'"></div>
                   <span class="detail-section-chevron" :class="{ open: detailSections['cfb_' + cat.displayName] }">&#9654;</span>
                 </div>
@@ -34,10 +34,10 @@
                               <div class="cf-row">
                                 <div class="cf-name" style="flex:1">
                                   <span x-text="cf.name"></span>
-                                  <span x-show="cf.isCustom" style="font-size:12px;color:#d29922;border:1px solid #d29922;border-radius:3px;padding:0 4px;margin-left:6px">Custom</span>
+                                  <span x-show="cf.isCustom" style="font-size:12px;color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:3px;padding:0 4px;margin-left:6px">Custom</span>
                                   <span class="cf-info" x-show="cf.description" @mouseenter="showCFTooltip($event, cf.description)" @mouseleave="hideCFTooltip()">ⓘ</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:#58a6ff;cursor:pointer;margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'">&#9998;</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:#f85149;cursor:pointer;margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'">&#10005;</span>
+                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-blue);cursor:pointer;margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'">&#9998;</span>
+                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-red);cursor:pointer;margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'">&#10005;</span>
                                 </div>
                                 <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'"
                                      x-text="cf.score !== undefined ? ((cf.score > 0 ? '+' : '') + cf.score) : '—'"></div>
@@ -54,10 +54,10 @@
                               <div class="cf-row">
                                 <div class="cf-name" style="flex:1">
                                   <span x-text="cf.name"></span>
-                                  <span x-show="cf.isCustom" style="font-size:12px;color:#d29922;border:1px solid #d29922;border-radius:3px;padding:0 4px;margin-left:6px">Custom</span>
+                                  <span x-show="cf.isCustom" style="font-size:12px;color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:3px;padding:0 4px;margin-left:6px">Custom</span>
                                   <span class="cf-info" x-show="cf.description" @mouseenter="showCFTooltip($event, cf.description)" @mouseleave="hideCFTooltip()">ⓘ</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:#58a6ff;cursor:pointer;margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'">&#9998;</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:#f85149;cursor:pointer;margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'">&#10005;</span>
+                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-blue);cursor:pointer;margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'">&#9998;</span>
+                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-red);cursor:pointer;margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'">&#10005;</span>
                                 </div>
                                 <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'"
                                      x-text="cf.score !== undefined ? ((cf.score > 0 ? '+' : '') + cf.score) : '—'"></div>
@@ -75,7 +75,7 @@
                               <span class="detail-section-chevron" style="font-size:12px"
                                     :class="{ open: groupExpanded['cfb_' + cat.displayName + '/' + group.shortName] }">&#9654;</span>
                               <span x-text="group.shortName"></span>
-                              <span style="font-size:13px;color:#aaa" x-text="group.cfs.length + ' CFs'"></span>
+                              <span style="font-size:13px;color:var(--text-muted)" x-text="group.cfs.length + ' CFs'"></span>
                             </div>
                           </div>
                           <div x-show="groupExpanded['cfb_' + cat.displayName + '/' + group.shortName]"

--- a/ui/static/partials/sections/maintenance.html
+++ b/ui/static/partials/sections/maintenance.html
@@ -116,7 +116,7 @@
                                      @blur="setTimeout(() => { cleanupKeepFocused = false; cleanupKeepSuggestions = [] }, 150)"
                                      style="width:100%;background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:4px;padding:6px 8px;color:var(--text-primary);font-size:12px">
                               <div x-show="cleanupKeepFocused && cleanupKeepSuggestions.length > 0" @mousedown.prevent
-                                   style="position:absolute;top:100%;left:0;right:0;z-index:50;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:0 0 6px 6px;max-height:200px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,0.4)">
+                                   style="position:absolute;top:100%;left:0;right:0;z-index:50;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:0 0 6px 6px;max-height:200px;overflow-y:auto;box-shadow:0 4px 12px var(--alpha-shadow)">
                                 <template x-for="(suggestion, si) in cleanupKeepSuggestions" :key="si">
                                   <div @click="addCleanupKeepName(suggestion)"
                                        style="padding:6px 10px;font-size:12px;color:var(--text-body);cursor:pointer;border-bottom:1px solid var(--bg-muted)"

--- a/ui/static/partials/sections/maintenance.html
+++ b/ui/static/partials/sections/maintenance.html
@@ -2,10 +2,10 @@
       <!-- ===== Maintenance sub-tab ===== -->
       <div class="page" x-show="currentSection === 'maintenance'">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Backup &amp; Maintenance</div>
-        <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">Backup and restore instance data, clean up custom formats and scores.</div>
+        <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">Backup and restore instance data, clean up custom formats and scores.</div>
 
         <template x-if="instancesOfType(activeAppType).length === 0">
-          <div class="card" style="padding:24px;text-align:center;color:#aaa">
+          <div class="card" style="padding:24px;text-align:center;color:var(--text-muted)">
             No instances configured. Add an instance in Settings first.
           </div>
         </template>
@@ -15,7 +15,7 @@
             <!-- Instance selector -->
             <div class="card" style="padding:16px;margin-bottom:16px">
               <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap">
-                <span style="font-size:13px;color:#aaa">Instance:</span>
+                <span style="font-size:13px;color:var(--text-muted)">Instance:</span>
                 <select class="input" style="width:250px"
                         x-model="maintenanceInstanceId"
                         @change="cleanupInstanceId = maintenanceInstanceId; loadCleanupKeep(); loadCleanupCFNames(); if (maintenanceInstance) { testInstance(maintenanceInstance); }">
@@ -25,13 +25,13 @@
                   </template>
                 </select>
                 <template x-if="maintenanceInstance && maintenanceInstance.type === activeAppType && instanceStatus[maintenanceInstance.id] === 'connected'">
-                  <span style="font-size:13px;color:#3fb950">Connected</span>
+                  <span style="font-size:13px;color:var(--accent-green)">Connected</span>
                 </template>
                 <template x-if="maintenanceInstance && maintenanceInstance.type === activeAppType && instanceStatus[maintenanceInstance.id] === 'failed'">
-                  <span style="font-size:13px;color:#f85149">Connection failed</span>
+                  <span style="font-size:13px;color:var(--accent-red)">Connection failed</span>
                 </template>
                 <template x-if="maintenanceInstance && maintenanceInstance.type === activeAppType && !instanceStatus[maintenanceInstance.id]">
-                  <span style="font-size:13px;color:#d29922">Not tested</span>
+                  <span style="font-size:13px;color:var(--accent-orange)">Not tested</span>
                 </template>
               </div>
             </div>
@@ -40,8 +40,8 @@
               <div>
                 <!-- ===== Backup & Restore Section ===== -->
                 <div class="card" style="padding:16px;margin-bottom:16px">
-                  <div style="font-size:14px;font-weight:600;color:#e1e4e8;margin-bottom:4px">Backup &amp; Restore</div>
-                  <div style="font-size:12px;color:#aaa;margin-bottom:12px">Download instance profiles and custom formats as JSON, or restore from a previous backup.</div>
+                  <div style="font-size:14px;font-weight:600;color:var(--text-primary);margin-bottom:4px">Backup &amp; Restore</div>
+                  <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px">Download instance profiles and custom formats as JSON, or restore from a previous backup.</div>
                   <div style="display:flex;gap:8px">
                     <button class="btn btn-sm btn-primary" @click="openBackupModal(maintenanceInstance)">Backup</button>
                     <button class="btn btn-sm" @click="openRestoreModal(maintenanceInstance)">Restore</button>
@@ -50,8 +50,8 @@
 
                 <!-- ===== Cleanup Section ===== -->
                 <div style="margin-bottom:16px">
-                  <div style="font-size:14px;font-weight:600;color:#e1e4e8;margin-bottom:4px">Cleanup</div>
-                  <div style="font-size:12px;color:#aaa;margin-bottom:12px">Scan and clean up custom formats and scores. All operations show a preview before applying.</div>
+                  <div style="font-size:14px;font-weight:600;color:var(--text-primary);margin-bottom:4px">Cleanup</div>
+                  <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px">Scan and clean up custom formats and scores. All operations show a preview before applying.</div>
 
                   <div style="display:flex;flex-direction:column;gap:12px">
 
@@ -59,21 +59,21 @@
                     <div class="card" style="padding:16px">
                       <div style="display:flex;justify-content:space-between;align-items:flex-start">
                         <div>
-                          <div style="font-size:14px;font-weight:600;color:#e1e4e8">Duplicate Custom Formats</div>
-                          <div style="font-size:12px;color:#aaa;margin-top:4px">Find CFs with identical specifications but different names. Keeps the first, flags duplicates for removal.</div>
+                          <div style="font-size:14px;font-weight:600;color:var(--text-primary)">Duplicate Custom Formats</div>
+                          <div style="font-size:12px;color:var(--text-muted);margin-top:4px">Find CFs with identical specifications but different names. Keeps the first, flags duplicates for removal.</div>
                         </div>
                         <button class="btn btn-primary" @click="cleanupScan('duplicates')" :disabled="cleanupScanning">Scan</button>
                       </div>
                     </div>
 
                     <!-- Unused by clonarr -->
-                    <div class="card" style="padding:16px;border-color:#d29922">
+                    <div class="card" style="padding:16px;border-color:var(--accent-orange)">
                       <div style="display:flex;justify-content:space-between;align-items:flex-start">
                         <div>
-                          <div style="font-size:14px;font-weight:600;color:#d29922">Unused Custom Formats (Clonarr-managed only)</div>
-                          <div style="font-size:12px;color:#aaa;margin-top:4px;line-height:1.5">Finds CFs in this Arr instance that are not referenced by any Clonarr sync rule (selectedCFs, score overrides, or required by the rule's TRaSH/imported profile) and are not used for renaming. <strong>Assumes Clonarr is the sole tool managing CFs on this instance</strong> — CFs added via the Arr UI directly, or via Recyclarr / Notifiarr / other tools, will appear here as "unused". Review the preview list carefully. Keep List protection still applies.</div>
+                          <div style="font-size:14px;font-weight:600;color:var(--accent-orange)">Unused Custom Formats (Clonarr-managed only)</div>
+                          <div style="font-size:12px;color:var(--text-muted);margin-top:4px;line-height:1.5">Finds CFs in this Arr instance that are not referenced by any Clonarr sync rule (selectedCFs, score overrides, or required by the rule's TRaSH/imported profile) and are not used for renaming. <strong>Assumes Clonarr is the sole tool managing CFs on this instance</strong> — CFs added via the Arr UI directly, or via Recyclarr / Notifiarr / other tools, will appear here as "unused". Review the preview list carefully. Keep List protection still applies.</div>
                         </div>
-                        <button class="btn" style="border-color:#d29922;color:#d29922" @click="cleanupScan('unused-by-clonarr')" :disabled="cleanupScanning">Scan</button>
+                        <button class="btn" style="border-color:var(--accent-orange);color:var(--accent-orange)" @click="cleanupScan('unused-by-clonarr')" :disabled="cleanupScanning">Scan</button>
                       </div>
                     </div>
 
@@ -81,8 +81,8 @@
                     <div class="card" style="padding:16px">
                       <div style="display:flex;justify-content:space-between;align-items:flex-start">
                         <div>
-                          <div style="font-size:14px;font-weight:600;color:#e1e4e8">Reset Non-Synced Scores</div>
-                          <div style="font-size:12px;color:#aaa;margin-top:4px">Finds CFs with non-zero scores that weren't set by Clonarr (not part of any synced profile). Resets their scores to 0. Useful for cleaning up scores set manually or by other tools like Recyclarr.</div>
+                          <div style="font-size:14px;font-weight:600;color:var(--text-primary)">Reset Non-Synced Scores</div>
+                          <div style="font-size:12px;color:var(--text-muted);margin-top:4px">Finds CFs with non-zero scores that weren't set by Clonarr (not part of any synced profile). Resets their scores to 0. Useful for cleaning up scores set manually or by other tools like Recyclarr.</div>
                         </div>
                         <button class="btn btn-primary" @click="cleanupScan('reset-unsynced-scores')" :disabled="cleanupScanning">Scan</button>
                       </div>
@@ -92,20 +92,20 @@
                     <div class="card" style="padding:16px">
                       <div style="display:flex;justify-content:space-between;align-items:flex-start">
                         <div>
-                          <div style="font-size:14px;font-weight:600;color:#e1e4e8">Orphaned Scores</div>
-                          <div style="font-size:12px;color:#aaa;margin-top:4px">Finds score entries in profiles that reference Custom Formats which have been deleted. These ghost entries are harmless but clutter the profile. Resets them to 0.</div>
+                          <div style="font-size:14px;font-weight:600;color:var(--text-primary)">Orphaned Scores</div>
+                          <div style="font-size:12px;color:var(--text-muted);margin-top:4px">Finds score entries in profiles that reference Custom Formats which have been deleted. These ghost entries are harmless but clutter the profile. Resets them to 0.</div>
                         </div>
                         <button class="btn btn-primary" @click="cleanupScan('orphaned-scores')" :disabled="cleanupScanning">Scan</button>
                       </div>
                     </div>
 
                     <!-- Keep list (shared by both delete actions) -->
-                    <div class="card" style="padding:16px;border-color:#30363d;overflow:visible">
+                    <div class="card" style="padding:16px;border-color:var(--border-subtle);overflow:visible">
                       <div style="display:flex;gap:16px">
                         <!-- Left: title, description, search -->
                         <div style="flex-shrink:0;width:380px">
-                          <div style="font-size:14px;font-weight:600;color:#e1e4e8;margin-bottom:4px">Keep List</div>
-                          <div style="font-size:12px;color:#aaa;margin-bottom:10px;line-height:1.5">Custom formats on this list will be excluded from delete operations. Case-insensitive, saved per instance.</div>
+                          <div style="font-size:14px;font-weight:600;color:var(--text-primary);margin-bottom:4px">Keep List</div>
+                          <div style="font-size:12px;color:var(--text-muted);margin-bottom:10px;line-height:1.5">Custom formats on this list will be excluded from delete operations. Case-insensitive, saved per instance.</div>
                           <div style="display:flex;gap:6px;position:relative">
                             <div style="width:250px;position:relative">
                               <input type="text" x-model="cleanupKeepInput" placeholder="Type to search CFs..."
@@ -114,19 +114,19 @@
                                      @keydown.enter.prevent="cleanupKeepSuggestions.length > 0 ? addCleanupKeepName(cleanupKeepSuggestions[0]) : addCleanupKeep()"
                                      @keydown.escape="cleanupKeepSuggestions = []; cleanupKeepFocused = false"
                                      @blur="setTimeout(() => { cleanupKeepFocused = false; cleanupKeepSuggestions = [] }, 150)"
-                                     style="width:100%;background:#0d1117;border:1px solid #30363d;border-radius:4px;padding:6px 8px;color:#e1e4e8;font-size:12px">
+                                     style="width:100%;background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:4px;padding:6px 8px;color:var(--text-primary);font-size:12px">
                               <div x-show="cleanupKeepFocused && cleanupKeepSuggestions.length > 0" @mousedown.prevent
-                                   style="position:absolute;top:100%;left:0;right:0;z-index:50;background:#161b22;border:1px solid #30363d;border-radius:0 0 6px 6px;max-height:200px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,0.4)">
+                                   style="position:absolute;top:100%;left:0;right:0;z-index:50;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:0 0 6px 6px;max-height:200px;overflow-y:auto;box-shadow:0 4px 12px rgba(0,0,0,0.4)">
                                 <template x-for="(suggestion, si) in cleanupKeepSuggestions" :key="si">
                                   <div @click="addCleanupKeepName(suggestion)"
-                                       style="padding:6px 10px;font-size:12px;color:#c9d1d9;cursor:pointer;border-bottom:1px solid #21262d"
-                                       @mouseenter="$el.style.background='#1f6feb33'" @mouseleave="$el.style.background='transparent'"
+                                       style="padding:6px 10px;font-size:12px;color:var(--text-body);cursor:pointer;border-bottom:1px solid var(--bg-muted)"
+                                       @mouseenter="$el.style.background='color-mix(in srgb, var(--accent-blue-strong) 20%, transparent)'" @mouseleave="$el.style.background='transparent'"
                                        x-text="suggestion"></div>
                                 </template>
                               </div>
                             </div>
                             <button class="btn btn-sm" @click="addCleanupKeep()" style="white-space:nowrap">Add</button>
-                            <button class="btn btn-sm" style="white-space:nowrap;border-color:#d29922;color:#d29922"
+                            <button class="btn btn-sm" style="white-space:nowrap;border-color:var(--accent-orange);color:var(--accent-orange)"
                                     x-show="cleanupKeepInput.trim()"
                                     @click="addAllMatchingKeep()"
                                     :disabled="cleanupCFNames.filter(n => n.toLowerCase().includes(cleanupKeepInput.trim().toLowerCase()) && !cleanupKeepList.some(k => k.toLowerCase() === n.toLowerCase())).length === 0"
@@ -136,15 +136,15 @@
                         <!-- Right: keep list entries as compact column -->
                         <div style="flex:1;min-width:0" x-show="cleanupKeepList.length > 0">
                           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:4px">
-                            <span style="font-size:11px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px" x-text="cleanupKeepList.length + ' kept'"></span>
-                            <button class="btn" style="font-size:11px;padding:1px 8px;border-color:#f85149;color:#f85149" @click="cleanupKeepList = []; saveCleanupKeep()" x-tt="'Remove all from Keep List'">Remove all</button>
+                            <span style="font-size:11px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px" x-text="cleanupKeepList.length + ' kept'"></span>
+                            <button class="btn" style="font-size:11px;padding:1px 8px;border-color:var(--accent-red);color:var(--accent-red)" @click="cleanupKeepList = []; saveCleanupKeep()" x-tt="'Remove all from Keep List'">Remove all</button>
                           </div>
                           <div style="max-height:160px;overflow-y:auto;overflow-x:hidden">
                             <div style="column-count:3;column-gap:8px">
                               <template x-for="(name, idx) in [...cleanupKeepList].sort((a,b) => a.localeCompare(b))" :key="'kl-'+idx">
                                 <div style="break-inside:avoid;display:flex;align-items:center;padding:1px 0;font-size:12px">
-                                  <span style="color:#58a6ff;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="name"></span>
-                                  <span style="color:#8b949e;cursor:pointer;font-size:13px;flex-shrink:0;margin-left:4px" @click="removeCleanupKeep(cleanupKeepList.indexOf(name))" x-tt="'Remove'">&times;</span>
+                                  <span style="color:var(--accent-blue);overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="name"></span>
+                                  <span style="color:var(--text-secondary);cursor:pointer;font-size:13px;flex-shrink:0;margin-left:4px" @click="removeCleanupKeep(cleanupKeepList.indexOf(name))" x-tt="'Remove'">&times;</span>
                                 </div>
                               </template>
                             </div>
@@ -154,22 +154,22 @@
                     </div>
 
                     <!-- Delete all CFs keep scores -->
-                    <div class="card" style="padding:16px;border-color:#d29922">
+                    <div class="card" style="padding:16px;border-color:var(--accent-orange)">
                       <div style="display:flex;justify-content:space-between;align-items:flex-start">
                         <div>
-                          <div style="font-size:14px;font-weight:600;color:#d29922">Delete All Custom Formats (Keep Scores)</div>
-                          <div style="font-size:12px;color:#aaa;margin-top:4px">Remove all CFs but preserve score mappings in profiles (respects Keep List). CFs can be re-added and will retain their scores.</div>
+                          <div style="font-size:14px;font-weight:600;color:var(--accent-orange)">Delete All Custom Formats (Keep Scores)</div>
+                          <div style="font-size:12px;color:var(--text-muted);margin-top:4px">Remove all CFs but preserve score mappings in profiles (respects Keep List). CFs can be re-added and will retain their scores.</div>
                         </div>
-                        <button class="btn" style="border-color:#d29922;color:#d29922" @click="cleanupScan('delete-cfs-keep-scores')" :disabled="cleanupScanning">Scan</button>
+                        <button class="btn" style="border-color:var(--accent-orange);color:var(--accent-orange)" @click="cleanupScan('delete-cfs-keep-scores')" :disabled="cleanupScanning">Scan</button>
                       </div>
                     </div>
 
                     <!-- Delete all CFs and scores (nuclear) -->
-                    <div class="card" style="padding:16px;border-color:#f85149">
+                    <div class="card" style="padding:16px;border-color:var(--accent-red)">
                       <div style="display:flex;justify-content:space-between;align-items:flex-start">
                         <div>
-                          <div style="font-size:14px;font-weight:600;color:#f85149">Delete All Custom Formats &amp; Scores</div>
-                          <div style="font-size:12px;color:#aaa;margin-top:4px">Complete fresh start — removes all CFs and resets their scores to 0 across every profile (respects Keep List). This cannot be undone.</div>
+                          <div style="font-size:14px;font-weight:600;color:var(--accent-red)">Delete All Custom Formats &amp; Scores</div>
+                          <div style="font-size:12px;color:var(--text-muted);margin-top:4px">Complete fresh start — removes all CFs and resets their scores to 0 across every profile (respects Keep List). This cannot be undone.</div>
                         </div>
                         <button class="btn btn-danger" @click="cleanupScan('delete-cfs-and-scores')" :disabled="cleanupScanning">Scan</button>
                       </div>

--- a/ui/static/partials/sections/naming.html
+++ b/ui/static/partials/sections/naming.html
@@ -2,7 +2,7 @@
       <!-- ===== File Naming sub-tab ===== -->
       <div class="page" x-show="currentSection === 'naming'">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">File Naming</div>
-        <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">TRaSH recommended naming schemes for folders and files. Select a media server tab and an instance to compare and apply.</div>
+        <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">TRaSH recommended naming schemes for folders and files. Select a media server tab and an instance to compare and apply.</div>
         <!-- Shared info cards — text sourced verbatim from TRaSH-Guides:
              includes/starr/renaming-description-faq.md
              includes/{sonarr,radarr}/{imdb-vs-tvdb,imdb-vs-tmdb}.md
@@ -10,88 +10,88 @@
         <div class="card" style="padding:0;margin:12px 0 0;overflow:hidden">
           <div style="padding:12px 16px;cursor:pointer;user-select:none;display:flex;align-items:center;gap:8px"
                @click="namingFAQExpanded = !namingFAQExpanded">
-            <span class="detail-section-chevron" :class="{ open: namingFAQExpanded }" style="color:#aaa;font-size:11px">&#9654;</span>
-            <span style="font-weight:600;color:#e1e4e8;font-size:15px">Why use a naming scheme?</span>
-            <span style="font-size:12px;color:#6e7681;margin-left:auto" x-show="!namingFAQExpanded">click to expand</span>
+            <span class="detail-section-chevron" :class="{ open: namingFAQExpanded }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+            <span style="font-weight:600;color:var(--text-primary);font-size:15px">Why use a naming scheme?</span>
+            <span style="font-size:12px;color:var(--text-secondary);margin-left:auto" x-show="!namingFAQExpanded">click to expand</span>
           </div>
-          <div x-show="namingFAQExpanded" x-collapse style="padding:0 16px 14px;border-top:1px solid #21262d">
+          <div x-show="namingFAQExpanded" x-collapse style="padding:0 16px 14px;border-top:1px solid var(--bg-muted)">
             <!-- Intro: verbatim from includes/starr/renaming-description-faq.md -->
-            <div style="font-size:12px;color:#aaa;line-height:1.6;margin-top:10px">
+            <div style="font-size:12px;color:var(--text-muted);line-height:1.6;margin-top:10px">
               While naming is a personal choice, adding non-recoverable information to your filenames is strongly recommended for several good reasons.
             </div>
 
             <!-- Q1 -->
             <div style="margin-top:14px">
-              <div style="font-weight:600;color:#c9d1d9;font-size:14px;margin-bottom:4px">Why should I include extra information in filenames?</div>
-              <ul style="font-size:12px;color:#aaa;line-height:1.6;margin:0 0 0 18px;padding:0">
-                <li><strong style="color:#c9d1d9">Easy re-imports</strong> — If you ever need to reinstall or re-import your media in Radarr/Sonarr or media servers like Plex/Emby/Jellyfin, having all the details in the filename helps everything get imported correctly. Without this info, files might get wrongly identified as HDTV or WEB-DL quality.</li>
-                <li><strong style="color:#c9d1d9">Prevents duplicate downloads</strong> — Radarr/Sonarr won't accidentally download the same file again.</li>
+              <div style="font-weight:600;color:var(--text-body);font-size:14px;margin-bottom:4px">Why should I include extra information in filenames?</div>
+              <ul style="font-size:12px;color:var(--text-muted);line-height:1.6;margin:0 0 0 18px;padding:0">
+                <li><strong style="color:var(--text-body)">Easy re-imports</strong> — If you ever need to reinstall or re-import your media in Radarr/Sonarr or media servers like Plex/Emby/Jellyfin, having all the details in the filename helps everything get imported correctly. Without this info, files might get wrongly identified as HDTV or WEB-DL quality.</li>
+                <li><strong style="color:var(--text-body)">Prevents duplicate downloads</strong> — Radarr/Sonarr won't accidentally download the same file again.</li>
               </ul>
             </div>
 
             <!-- Q2 -->
             <div style="margin-top:14px">
-              <div style="font-weight:600;color:#c9d1d9;font-size:14px;margin-bottom:4px">What's non-recoverable information and can't be recovered later?</div>
-              <ul style="font-size:12px;color:#aaa;line-height:1.6;margin:0 0 0 18px;padding:0">
-                <li><strong style="color:#c9d1d9">Quality source</strong> (HDTV, WEB-DL, Blu-ray, Remux, etc.)</li>
-                <li><strong style="color:#c9d1d9">Release group</strong> (the team that created the release)</li>
-                <li><strong style="color:#c9d1d9">Edition type</strong> (Director's Cut, Theatrical, Unrated, etc.)</li>
-                <li><strong style="color:#c9d1d9">Repack/Proper status</strong> (whether it's a fixed version)</li>
+              <div style="font-weight:600;color:var(--text-body);font-size:14px;margin-bottom:4px">What's non-recoverable information and can't be recovered later?</div>
+              <ul style="font-size:12px;color:var(--text-muted);line-height:1.6;margin:0 0 0 18px;padding:0">
+                <li><strong style="color:var(--text-body)">Quality source</strong> (HDTV, WEB-DL, Blu-ray, Remux, etc.)</li>
+                <li><strong style="color:var(--text-body)">Release group</strong> (the team that created the release)</li>
+                <li><strong style="color:var(--text-body)">Edition type</strong> (Director's Cut, Theatrical, Unrated, etc.)</li>
+                <li><strong style="color:var(--text-body)">Repack/Proper status</strong> (whether it's a fixed version)</li>
               </ul>
             </div>
 
             <!-- Q3 -->
             <div style="margin-top:14px">
-              <div style="font-weight:600;color:#c9d1d9;font-size:14px;margin-bottom:4px">Why is the non-recoverable information important/needed?</div>
-              <ul style="font-size:12px;color:#aaa;line-height:1.6;margin:0 0 0 18px;padding:0">
-                <li><strong style="color:#c9d1d9">Stops download loops</strong> — With proper naming, Radarr/Sonarr knows what you already have.</li>
-                <li><strong style="color:#c9d1d9">Quality source</strong> — Can you tell what quality <code style="background:#0d1117;padding:1px 4px;border-radius:3px">Movie (2023).mkv</code> is just by looking at it? Probably not. Without this info, you can't easily upgrade or downgrade your files, and you might download the same movie or TV show again.</li>
-                <li><strong style="color:#c9d1d9">Release group</strong> — Knowing the release group helps you identify if there are known issues with that specific release. It also helps you find extra information about hybrid releases or source materials.</li>
-                <li><strong style="color:#c9d1d9">Edition type</strong> — Tells you if you have the Director's Cut, Theatrical version, Unrated version, etc.</li>
-                <li><strong style="color:#c9d1d9">Repack/Proper</strong> — Shows whether you have the fixed version or the original (possibly broken) release.</li>
+              <div style="font-weight:600;color:var(--text-body);font-size:14px;margin-bottom:4px">Why is the non-recoverable information important/needed?</div>
+              <ul style="font-size:12px;color:var(--text-muted);line-height:1.6;margin:0 0 0 18px;padding:0">
+                <li><strong style="color:var(--text-body)">Stops download loops</strong> — With proper naming, Radarr/Sonarr knows what you already have.</li>
+                <li><strong style="color:var(--text-body)">Quality source</strong> — Can you tell what quality <code style="background:var(--bg-page);padding:1px 4px;border-radius:3px;color:var(--code-string)">Movie (2023).mkv</code> is just by looking at it? Probably not. Without this info, you can't easily upgrade or downgrade your files, and you might download the same movie or TV show again.</li>
+                <li><strong style="color:var(--text-body)">Release group</strong> — Knowing the release group helps you identify if there are known issues with that specific release. It also helps you find extra information about hybrid releases or source materials.</li>
+                <li><strong style="color:var(--text-body)">Edition type</strong> — Tells you if you have the Director's Cut, Theatrical version, Unrated version, etc.</li>
+                <li><strong style="color:var(--text-body)">Repack/Proper</strong> — Shows whether you have the fixed version or the original (possibly broken) release.</li>
               </ul>
             </div>
 
             <!-- Q4 -->
             <div style="margin-top:14px">
-              <div style="font-weight:600;color:#c9d1d9;font-size:14px;margin-bottom:4px">Don't Plex, Emby, and Jellyfin work fine with simple names like <code style="background:#0d1117;padding:1px 4px;border-radius:3px">movie (year).ext</code> / <code style="background:#0d1117;padding:1px 4px;border-radius:3px">tv showname SxxExx.ext</code>?</div>
-              <ul style="font-size:12px;color:#aaa;line-height:1.6;margin:0 0 0 18px;padding:0">
+              <div style="font-weight:600;color:var(--text-body);font-size:14px;margin-bottom:4px">Don't Plex, Emby, and Jellyfin work fine with simple names like <code style="background:var(--bg-page);padding:1px 4px;border-radius:3px;color:var(--code-string)">movie (year).ext</code> / <code style="background:var(--bg-page);padding:1px 4px;border-radius:3px;color:var(--code-string)">tv showname SxxExx.ext</code>?</div>
+              <ul style="font-size:12px;color:var(--text-muted);line-height:1.6;margin:0 0 0 18px;padding:0">
                 <li>Yes, they do work with simple names. However, these media servers only care about organizing and playing your files — they don't track quality or help prevent duplicate downloads. That's what Radarr/Sonarr handles.</li>
               </ul>
             </div>
 
             <!-- Q5 -->
             <div style="margin-top:14px">
-              <div style="font-weight:600;color:#c9d1d9;font-size:14px;margin-bottom:4px">Why are the recommended filenames so long?</div>
-              <ul style="font-size:12px;color:#aaa;line-height:1.6;margin:0 0 0 18px;padding:0">
-                <li><strong style="color:#c9d1d9">Complete information</strong> — To ensure your files have all the details needed to prevent download loops after import.</li>
-                <li><strong style="color:#c9d1d9">Only used parts show up</strong> — If your file doesn't have certain attributes (like being a repack), those parts won't appear in the filename.</li>
-                <li><strong style="color:#c9d1d9">Media servers hide filenames anyway</strong> — Plex, Emby, and Jellyfin display movie titles and show information, not the actual filename, so the length doesn't matter for viewing.</li>
+              <div style="font-weight:600;color:var(--text-body);font-size:14px;margin-bottom:4px">Why are the recommended filenames so long?</div>
+              <ul style="font-size:12px;color:var(--text-muted);line-height:1.6;margin:0 0 0 18px;padding:0">
+                <li><strong style="color:var(--text-body)">Complete information</strong> — To ensure your files have all the details needed to prevent download loops after import.</li>
+                <li><strong style="color:var(--text-body)">Only used parts show up</strong> — If your file doesn't have certain attributes (like being a repack), those parts won't appear in the filename.</li>
+                <li><strong style="color:var(--text-body)">Media servers hide filenames anyway</strong> — Plex, Emby, and Jellyfin display movie titles and show information, not the actual filename, so the length doesn't matter for viewing.</li>
               </ul>
             </div>
 
-            <div style="font-size:11px;color:#8b949e;margin-top:14px;font-style:italic">Source: TRaSH-Guides — <code style="background:#0d1117;padding:1px 4px;border-radius:3px">includes/starr/renaming-description-faq.md</code></div>
+            <div style="font-size:11px;color:var(--text-secondary);margin-top:14px;font-style:italic">Source: TRaSH-Guides — <code style="background:var(--bg-page);padding:1px 4px;border-radius:3px;color:var(--code-string)">includes/starr/renaming-description-faq.md</code></div>
           </div>
         </div>
 
         <div class="card" style="padding:14px 16px;margin:12px 0 0">
-          <div style="font-weight:600;margin-bottom:8px;color:#e1e4e8;font-size:13px" x-text="activeAppType === 'radarr' ? 'IMDb vs TMDb' : 'IMDb vs TVDb'"></div>
+          <div style="font-weight:600;margin-bottom:8px;color:var(--text-primary);font-size:13px" x-text="activeAppType === 'radarr' ? 'IMDb vs TMDb' : 'IMDb vs TVDb'"></div>
           <!-- Info banner — leads the card so the most actionable line is the first thing the user sees.
                Verbatim from includes/{radarr,sonarr}/{tmdb,tvdb}-imdb-info.md (TRaSH renders these as
                !!! info admonitions; we use a blue info box with an ⓘ icon to match the visual semantics
                while keeping the wording byte-for-byte identical to the source). -->
-          <div style="font-size:12px;line-height:1.6;padding:8px 10px;background:#0d2847;border-left:3px solid #58a6ff;border-radius:3px;color:#c9d1d9;display:flex;align-items:flex-start;gap:8px">
-            <span style="color:#58a6ff;font-size:14px;line-height:1.4;flex-shrink:0">&#9432;</span>
-            <strong style="color:#c9d1d9;font-weight:600" x-text="activeAppType === 'radarr'
+          <div style="font-size:12px;line-height:1.6;padding:8px 10px;background:var(--fill-blue-soft);border-left:3px solid var(--accent-blue);border-radius:3px;color:var(--text-body);display:flex;align-items:flex-start;gap:8px">
+            <span style="color:var(--accent-blue);font-size:14px;line-height:1.4;flex-shrink:0">&#9432;</span>
+            <strong style="color:var(--text-body);font-weight:600" x-text="activeAppType === 'radarr'
               ? 'TMDb is usually better as it guarantees a match, IMDb only gets matched if the TMDb entry has the correct IMDb ID association.'
               : 'TVDb is usually better as it guarantees a match, IMDb only gets matched if the TVDb entry has the correct IMDb ID association.'"></strong>
           </div>
           <!-- Trade-off context — verbatim from includes/{radarr,sonarr}/imdb-vs-{tmdb,tvdb}.md -->
-          <div style="font-size:12px;color:#aaa;line-height:1.6;margin-top:10px"
+          <div style="font-size:12px;color:var(--text-muted);line-height:1.6;margin-top:10px"
                x-text="activeAppType === 'radarr'
             ? 'While both IMDb and TMDb IDs are unique, TMDb can occasionally remove IDs entirely, sometimes only to be re-added with a new ID later. However, due to using TMDb as its metadata source, they can be seen as \'more aligned\' with Radarr. IMDb IDs on the other hand, once present, are very accurate and rarely ever change.'
             : 'While both IMDb and TVDb IDs are unique, TVDb can occasionally remove IDs entirely, sometimes only to be re-added with a new ID later. However, due to using TVDb as its metadata source, they can be seen as \'more aligned\' with Sonarr. IMDb IDs on the other hand, once present, are very accurate and rarely ever change.'"></div>
-          <div style="font-size:11px;color:#8b949e;margin-top:8px;font-style:italic" x-text="activeAppType === 'radarr'
+          <div style="font-size:11px;color:var(--text-secondary);margin-top:8px;font-style:italic" x-text="activeAppType === 'radarr'
             ? 'Source: TRaSH-Guides — includes/radarr/{tmdb-imdb-info,imdb-vs-tmdb}.md'
             : 'Source: TRaSH-Guides — includes/sonarr/{tvdb-imdb-info,imdb-vs-tvdb}.md'"></div>
         </div>
@@ -100,8 +100,8 @@
             <!-- Naming card: instance + tabs + content -->
             <div class="card" style="margin:16px 0 0;overflow:visible">
               <!-- Instance selector -->
-              <div style="display:flex;align-items:center;gap:12px;padding:10px 16px;border-bottom:1px solid #21262d">
-                <span style="font-size:13px;color:#aaa">Instance:</span>
+              <div style="display:flex;align-items:center;gap:12px;padding:10px 16px;border-bottom:1px solid var(--bg-muted)">
+                <span style="font-size:13px;color:var(--text-muted)">Instance:</span>
                 <select class="input" style="width:200px;font-size:12px;padding:4px 8px"
                   @change="namingSelectedInstance = { ...namingSelectedInstance, [activeAppType]: $event.target.value }; if ($event.target.value) { const _inst = instances.find(i => i.id === $event.target.value); if (_inst) testInstance(_inst); } loadInstanceNaming(activeAppType)">
                   <option value="" :selected="!namingSelectedInstance[activeAppType]">Select instance...</option>
@@ -110,20 +110,20 @@
                   </template>
                 </select>
                 <template x-if="namingSelectedInstance[activeAppType] && instanceStatus[namingSelectedInstance[activeAppType]] === 'connected'">
-                  <span style="font-size:13px;color:#3fb950">Connected</span>
+                  <span style="font-size:13px;color:var(--accent-green)">Connected</span>
                 </template>
                 <template x-if="namingSelectedInstance[activeAppType] && instanceStatus[namingSelectedInstance[activeAppType]] === 'failed'">
-                  <span style="font-size:13px;color:#f85149">Connection failed</span>
+                  <span style="font-size:13px;color:var(--accent-red)">Connection failed</span>
                 </template>
                 <template x-if="namingSelectedInstance[activeAppType] && !instanceStatus[namingSelectedInstance[activeAppType]]">
-                  <span style="font-size:13px;color:#d29922">Not tested</span>
+                  <span style="font-size:13px;color:var(--accent-orange)">Not tested</span>
                 </template>
                 <template x-if="!namingSelectedInstance[activeAppType]">
-                  <span style="font-size:13px;color:#aaa">Select an instance to enable sync</span>
+                  <span style="font-size:13px;color:var(--text-muted)">Select an instance to enable sync</span>
                 </template>
               </div>
               <!-- Media server tabs -->
-              <div style="display:flex;align-items:center;border-bottom:1px solid #21262d;padding:0 16px">
+              <div style="display:flex;align-items:center;border-bottom:1px solid var(--bg-muted);padding:0 16px">
                 <div class="subtab" :class="{ active: (namingMediaServer[activeAppType] || 'standard') === 'standard' }" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'standard'}">Standard</div>
                 <div class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'plex' }" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'plex'}">Plex</div>
                 <div class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'emby' }" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'emby'}">Emby</div>
@@ -136,23 +136,23 @@
                      and visual hierarchy. Yellow border-left signals "your current setting" (matches
                      the override-language used elsewhere). -->
                 <template x-if="namingInstanceData[activeAppType]">
-                  <div style="border:1px solid #21262d;border-left:3px solid #d29922;border-radius:6px;padding:10px 14px;margin-bottom:12px;background:#0d1117">
+                  <div style="border:1px solid var(--bg-muted);border-left:3px solid var(--accent-orange);border-radius:6px;padding:10px 14px;margin-bottom:12px;background:var(--bg-page)">
                     <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;flex-wrap:wrap">
-                      <span style="font-size:11px;color:#d29922;font-weight:600;text-transform:uppercase;letter-spacing:0.5px">Current on instance</span>
-                      <span style="font-size:11px;color:#8b949e">— compare with TRaSH-recommended schemes below</span>
+                      <span style="font-size:11px;color:var(--accent-orange);font-weight:600;text-transform:uppercase;letter-spacing:0.5px">Current on instance</span>
+                      <span style="font-size:11px;color:var(--text-secondary)">— compare with TRaSH-recommended schemes below</span>
                     </div>
                     <template x-if="activeAppType === 'radarr'">
                       <div style="display:flex;gap:16px;flex-wrap:wrap;font-size:13px">
-                        <div><span style="color:#aaa">File:</span> <span style="font-family:monospace;color:#aaa" x-text="namingInstanceData[activeAppType].standardMovieFormat || '(not set)'"></span></div>
-                        <div><span style="color:#aaa">Folder:</span> <span style="font-family:monospace;color:#aaa" x-text="namingInstanceData[activeAppType].movieFolderFormat || '(not set)'"></span></div>
-                        <div><span style="color:#aaa">Rename:</span> <span :style="namingInstanceData[activeAppType].renameMovies ? 'color:#3fb950' : 'color:#f85149'" x-text="namingInstanceData[activeAppType].renameMovies ? 'On' : 'Off'"></span></div>
+                        <div><span style="color:var(--text-muted)">File:</span> <span style="font-family:monospace;color:var(--text-muted)" x-text="namingInstanceData[activeAppType].standardMovieFormat || '(not set)'"></span></div>
+                        <div><span style="color:var(--text-muted)">Folder:</span> <span style="font-family:monospace;color:var(--text-muted)" x-text="namingInstanceData[activeAppType].movieFolderFormat || '(not set)'"></span></div>
+                        <div><span style="color:var(--text-muted)">Rename:</span> <span :style="namingInstanceData[activeAppType].renameMovies ? 'color:var(--accent-green)' : 'color:var(--accent-red)'" x-text="namingInstanceData[activeAppType].renameMovies ? 'On' : 'Off'"></span></div>
                       </div>
                     </template>
                     <template x-if="activeAppType === 'sonarr'">
                       <div style="display:flex;gap:16px;flex-wrap:wrap;font-size:13px">
-                        <div><span style="color:#aaa">Episode:</span> <span style="font-family:monospace;color:#aaa" x-text="namingInstanceData[activeAppType].standardEpisodeFormat || '(not set)'"></span></div>
-                        <div><span style="color:#aaa">Series:</span> <span style="font-family:monospace;color:#aaa" x-text="namingInstanceData[activeAppType].seriesFolderFormat || '(not set)'"></span></div>
-                        <div><span style="color:#aaa">Rename:</span> <span :style="namingInstanceData[activeAppType].renameEpisodes ? 'color:#3fb950' : 'color:#f85149'" x-text="namingInstanceData[activeAppType].renameEpisodes ? 'On' : 'Off'"></span></div>
+                        <div><span style="color:var(--text-muted)">Episode:</span> <span style="font-family:monospace;color:var(--text-muted)" x-text="namingInstanceData[activeAppType].standardEpisodeFormat || '(not set)'"></span></div>
+                        <div><span style="color:var(--text-muted)">Series:</span> <span style="font-family:monospace;color:var(--text-muted)" x-text="namingInstanceData[activeAppType].seriesFolderFormat || '(not set)'"></span></div>
+                        <div><span style="color:var(--text-muted)">Rename:</span> <span :style="namingInstanceData[activeAppType].renameEpisodes ? 'color:var(--accent-green)' : 'color:var(--accent-red)'" x-text="namingInstanceData[activeAppType].renameEpisodes ? 'On' : 'Off'"></span></div>
                       </div>
                     </template>
                   </div>
@@ -160,8 +160,8 @@
 
                 <!-- Naming apply result -->
                 <template x-if="namingApplyResult[activeAppType]">
-                  <div style="padding:8px 12px;margin-bottom:12px;border-left:3px solid #3fb950;background:#0d1117;border-radius:4px">
-                    <div style="font-size:12px;color:#3fb950" x-text="namingApplyResult[activeAppType]"></div>
+                  <div style="padding:8px 12px;margin-bottom:12px;border-left:3px solid var(--accent-green);background:var(--bg-page);border-radius:4px">
+                    <div style="font-size:12px;color:var(--accent-green)" x-text="namingApplyResult[activeAppType]"></div>
                   </div>
                 </template>
 
@@ -172,63 +172,63 @@
                        Text sourced verbatim from TRaSH-Guides:
                        docs/Radarr/Radarr-recommended-naming-scheme.md (!!! danger admonition under the Plex section) -->
                   <template x-if="section.showEditionToggle">
-                    <div style="border:1px solid #21262d;border-left:3px solid #d29922;border-radius:6px;padding:14px 16px;margin-bottom:12px">
+                    <div style="border:1px solid var(--bg-muted);border-left:3px solid var(--accent-orange);border-radius:6px;padding:14px 16px;margin-bottom:12px">
                       <div style="display:flex;align-items:flex-start;gap:12px">
                         <div style="flex:1">
-                          <div style="font-weight:600;margin-bottom:6px;color:#e1e4e8;font-size:13px">Edition Tags</div>
-                          <div style="font-size:12px;color:#aaa;line-height:1.6">
-                            If you use the <code style="background:#21262d;padding:1px 5px;border-radius:3px;color:#d2a8ff">{edition-{Edition Tags}}</code> part of the recommended file name, Plex will recognize the movie edition and add it to the Plex interface — for example, Director's Cut.
+                          <div style="font-weight:600;margin-bottom:6px;color:var(--text-primary);font-size:13px">Edition Tags</div>
+                          <div style="font-size:12px;color:var(--text-muted);line-height:1.6">
+                            If you use the <code style="background:var(--bg-muted);padding:1px 5px;border-radius:3px;color:var(--accent-purple-soft)">{edition-{Edition Tags}}</code> part of the recommended file name, Plex will recognize the movie edition and add it to the Plex interface — for example, Director's Cut.
                           </div>
-                          <div style="font-size:12px;color:#aaa;line-height:1.6;margin-top:6px">
-                            However, this means that if you have two copies of a movie with different editions in a single <strong style="color:#c9d1d9">merged library</strong> — for example, a 1080p Director's Cut and a 2160p Theatrical Edition — these will appear as <strong style="color:#f85149">two separate items</strong> in Plex.
+                          <div style="font-size:12px;color:var(--text-muted);line-height:1.6;margin-top:6px">
+                            However, this means that if you have two copies of a movie with different editions in a single <strong style="color:var(--text-body)">merged library</strong> — for example, a 1080p Director's Cut and a 2160p Theatrical Edition — these will appear as <strong style="color:var(--accent-red)">two separate items</strong> in Plex.
                           </div>
-                          <div style="font-size:12px;color:#aaa;line-height:1.6;margin-top:6px">
-                            If you want a movie to appear only once per library when you keep more than one copy of a movie, replace <code style="background:#21262d;padding:1px 5px;border-radius:3px;color:#d2a8ff">{edition-{Edition Tags}}</code> with <code style="background:#21262d;padding:1px 5px;border-radius:3px;color:#d2a8ff">{Edition Tags}</code>.
+                          <div style="font-size:12px;color:var(--text-muted);line-height:1.6;margin-top:6px">
+                            If you want a movie to appear only once per library when you keep more than one copy of a movie, replace <code style="background:var(--bg-muted);padding:1px 5px;border-radius:3px;color:var(--accent-purple-soft)">{edition-{Edition Tags}}</code> with <code style="background:var(--bg-muted);padding:1px 5px;border-radius:3px;color:var(--accent-purple-soft)">{Edition Tags}</code>.
                           </div>
                         </div>
                         <div style="display:flex;flex-direction:column;align-items:center;gap:4px;padding-top:4px;flex-shrink:0">
                           <label class="toggle"><input type="checkbox" :checked="namingPlexSingleEntry[activeAppType]" @change="namingPlexSingleEntry = {...namingPlexSingleEntry, [activeAppType]: $event.target.checked}"><span class="slider"></span></label>
-                          <span style="font-size:12px;white-space:nowrap" :style="namingPlexSingleEntry[activeAppType] ? 'color:#3fb950' : 'color:#aaa'" x-text="namingPlexSingleEntry[activeAppType] ? 'Single entry' : 'Per edition'"></span>
+                          <span style="font-size:12px;white-space:nowrap" :style="namingPlexSingleEntry[activeAppType] ? 'color:var(--accent-green)' : 'color:var(--text-muted)'" x-text="namingPlexSingleEntry[activeAppType] ? 'Single entry' : 'Per edition'"></span>
                         </div>
                       </div>
                     </div>
                   </template>
 
-                  <div style="font-weight:600;margin-bottom:4px;color:#e1e4e8" x-text="section.label"></div>
-                  <div x-show="section.description" style="font-size:13px;color:#aaa;margin-bottom:10px;line-height:1.5" x-text="section.description"></div>
+                  <div style="font-weight:600;margin-bottom:4px;color:var(--text-primary)" x-text="section.label"></div>
+                  <div x-show="section.description" style="font-size:13px;color:var(--text-muted);margin-bottom:10px;line-height:1.5" x-text="section.description"></div>
 
                   <template x-for="scheme in section.schemes" :key="scheme.key">
-                    <div style="margin-bottom:10px;padding:8px;background:#0d1117;border-radius:4px;border:1px solid #21262d">
+                    <div style="margin-bottom:10px;padding:8px;background:var(--bg-page);border-radius:4px;border:1px solid var(--bg-muted)">
                       <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px">
-                        <span style="font-size:12px;font-weight:600;color:#c9d1d9" x-text="scheme.label"></span>
-                        <span x-show="scheme.recommended" style="font-size:12px;background:#238636;color:#fff;padding:1px 6px;border-radius:3px">Recommended</span>
+                        <span style="font-size:12px;font-weight:600;color:var(--text-body)" x-text="scheme.label"></span>
+                        <span x-show="scheme.recommended" style="font-size:12px;background:var(--accent-green-strong);color:var(--text-on-accent);padding:1px 6px;border-radius:3px">Recommended</span>
                         <span style="margin-left:auto;display:flex;gap:8px;align-items:center">
-                          <span style="font-size:12px;color:#58a6ff;cursor:pointer" @click="copyToClipboard(scheme.pattern)">Copy</span>
+                          <span style="font-size:12px;color:var(--accent-blue);cursor:pointer" @click="copyToClipboard(scheme.pattern)">Copy</span>
                           <template x-if="namingSelectedInstance[activeAppType]">
-                            <span style="font-size:12px;color:#d29922;cursor:pointer"
-                              @click="$el.textContent='Syncing...'; $el.style.color='#8b949e'; applyNamingScheme(activeAppType, section.key, scheme).then(() => { $el.textContent='✓ Synced'; $el.style.color='#3fb950'; setTimeout(() => { $el.textContent='Sync'; $el.style.color='#d29922'; }, 2000); })">Sync</span>
+                            <span style="font-size:12px;color:var(--accent-orange);cursor:pointer"
+                              @click="$el.textContent='Syncing...'; $el.style.color='var(--text-secondary)'; applyNamingScheme(activeAppType, section.key, scheme).then(() => { $el.textContent='✓ Synced'; $el.style.color='var(--accent-green)'; setTimeout(() => { $el.textContent='Sync'; $el.style.color='var(--accent-orange)'; }, 2000); })">Sync</span>
                           </template>
                         </span>
                       </div>
-                      <div x-show="scheme.description" style="font-size:13px;color:#aaa;margin-bottom:6px;line-height:1.4" x-text="scheme.description"></div>
-                      <div style="font-family:monospace;font-size:13px;color:#9ecbaa;background:#0d1117;border:1px solid #21262d;border-radius:4px;padding:6px 8px;word-break:break-all" x-text="scheme.pattern"></div>
-                      <div x-show="scheme.example" style="font-family:monospace;font-size:12px;color:#aaa;margin-top:4px;word-break:break-all">
-                        <strong style="color:#aaa;font-weight:600">Movie:</strong> <span x-text="scheme.example"></span>
+                      <div x-show="scheme.description" style="font-size:13px;color:var(--text-muted);margin-bottom:6px;line-height:1.4" x-text="scheme.description"></div>
+                      <div style="font-family:monospace;font-size:13px;color:var(--code-string);background:var(--bg-page);border:1px solid var(--bg-muted);border-radius:4px;padding:6px 8px;word-break:break-all" x-text="scheme.pattern"></div>
+                      <div x-show="scheme.example" style="font-family:monospace;font-size:12px;color:var(--text-muted);margin-top:4px;word-break:break-all">
+                        <strong style="color:var(--text-muted);font-weight:600">Movie:</strong> <span x-text="scheme.example"></span>
                       </div>
                       <!-- Extra advice for "Original Title" scheme (verbatim from TRaSH:
                            docs/{Radarr,Sonarr}/-recommended-naming-scheme.md § Original Title) -->
                       <template x-if="scheme.key === 'original'">
-                        <div style="margin-top:10px;padding:10px;background:#0d1117;border-left:3px solid #58a6ff;border-radius:3px">
-                          <div style="font-size:13px;color:#c9d1d9;line-height:1.5">
-                            <strong>If you use this alternate naming scheme</strong>, we suggest using <code style="background:#161b22;padding:1px 5px;border-radius:3px;color:#9ecbaa;font-family:monospace">{Original Title}</code> instead of <code style="background:#161b22;padding:1px 5px;border-radius:3px;color:#9ecbaa;font-family:monospace">{Original Filename}</code>.
+                        <div style="margin-top:10px;padding:10px;background:var(--bg-page);border-left:3px solid var(--accent-blue);border-radius:3px">
+                          <div style="font-size:13px;color:var(--text-body);line-height:1.5">
+                            <strong>If you use this alternate naming scheme</strong>, we suggest using <code style="background:var(--bg-muted);padding:1px 5px;border-radius:3px;color:var(--code-string);font-family:monospace">{Original Title}</code> instead of <code style="background:var(--bg-muted);padding:1px 5px;border-radius:3px;color:var(--code-string);font-family:monospace">{Original Filename}</code>.
                           </div>
-                          <div style="font-size:13px;color:#c9d1d9;margin-top:8px"><strong>Why?</strong></div>
-                          <div style="font-size:13px;color:#aaa;line-height:1.5;margin-top:4px">
+                          <div style="font-size:13px;color:var(--text-body);margin-top:8px"><strong>Why?</strong></div>
+                          <div style="font-size:13px;color:var(--text-muted);line-height:1.5;margin-top:4px">
                             The filename can be obscured or unclear, whereas the release naming is clear, especially when you use Usenet.
                           </div>
                           <div style="font-family:monospace;font-size:12px;margin-top:8px;line-height:1.7;word-break:break-all">
-                            <div><span style="color:#9ecbaa">{Original Title}</span> <span style="color:#8b949e">=&gt;</span> <span style="color:#aaa" x-text="activeAppType === 'radarr' ? 'The.Movie.Title.2010.REMASTERED.1080p.BluRay.x264-RlsGrp' : 'The.Series.Title.S01E01.Episode.Title.1080p.AMZN.WEB-DL.DDP5.1.H.264-RlsGrp'"></span></div>
-                            <div><span style="color:#9ecbaa">{Original Filename}</span> <span style="color:#8b949e">=&gt;</span> <span style="color:#aaa" x-text="activeAppType === 'radarr' ? 'rlsgrp-karatekid-1080p or lchd-tkk1080p or t1i0p3s7i8yuti' : 'show episode 1-1080p or lchd-tkk1080p or t1i0p3s7i8yuti'"></span></div>
+                            <div><span style="color:var(--code-string)">{Original Title}</span> <span style="color:var(--text-secondary)">=&gt;</span> <span style="color:var(--text-muted)" x-text="activeAppType === 'radarr' ? 'The.Movie.Title.2010.REMASTERED.1080p.BluRay.x264-RlsGrp' : 'The.Series.Title.S01E01.Episode.Title.1080p.AMZN.WEB-DL.DDP5.1.H.264-RlsGrp'"></span></div>
+                            <div><span style="color:var(--code-string)">{Original Filename}</span> <span style="color:var(--text-secondary)">=&gt;</span> <span style="color:var(--text-muted)" x-text="activeAppType === 'radarr' ? 'rlsgrp-karatekid-1080p or lchd-tkk1080p or t1i0p3s7i8yuti' : 'show episode 1-1080p or lchd-tkk1080p or t1i0p3s7i8yuti'"></span></div>
                           </div>
                         </div>
                       </template>

--- a/ui/static/partials/sections/profiles.html
+++ b/ui/static/partials/sections/profiles.html
@@ -226,13 +226,13 @@
                       </div>
                       <div style="flex:1;display:flex;gap:4px;justify-content:flex-end;padding-right:4px">
                         <template x-if="sh.changes?.cfDetails?.length > 0">
-                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(63,185,80,0.15);color:var(--accent-green)" x-text="sh.changes.cfDetails.length + ' CF'"></span>
+                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--alpha-green);color:var(--accent-green)" x-text="sh.changes.cfDetails.length + ' CF'"></span>
                         </template>
                         <template x-if="sh.changes?.scoreDetails?.length > 0">
                           <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--accent-orange-bg);color:var(--accent-orange)" x-text="sh.changes.scoreDetails.length + ' score'"></span>
                         </template>
                         <template x-if="sh.changes?.qualityDetails?.length > 0">
-                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(163,113,247,0.15);color:var(--accent-purple)" x-text="sh.changes.qualityDetails.length + ' quality'"></span>
+                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--alpha-purple);color:var(--accent-purple)" x-text="sh.changes.qualityDetails.length + ' quality'"></span>
                         </template>
                         <template x-if="sh.changes?.settingsDetails?.length > 0">
                           <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--fill-blue-soft);color:var(--accent-blue)" x-text="sh.changes.settingsDetails.length + ' setting'"></span>
@@ -586,7 +586,7 @@
                                         <!-- Summary bar — single-row: profile identity + status + Sync All Fixes.
                                              Diff counts intentionally removed; the filter chip bar below is the single source of truth for counts.
                                              NOTE: :style uses object form so it MERGES with the base style attribute. A string form would replace it entirely. -->
-                                        <div style="background:var(--bg-card);border:1px solid var(--text-muted-secondary);border-radius:8px;padding:10px 14px;margin-bottom:20px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;box-shadow:0 2px 6px rgba(0,0,0,0.4)"
+                                        <div style="background:var(--bg-card);border:1px solid var(--text-muted-secondary);border-radius:8px;padding:10px 14px;margin-bottom:20px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;box-shadow:0 2px 6px var(--alpha-shadow)"
                                              :style="{ borderColor: ((cr.summary?.wrongScore||0) + (cr.summary?.missing||0) + (cr.summary?.extra||0) + (cr.summary?.settingsDiffs||0) + (cr.summary?.qualityDiffs||0)) > 0 ? 'var(--accent-orange)' : 'var(--accent-green)' }">
                                           <strong style="color:var(--text-primary);font-size:13px" x-text="ap.name"></strong>
                                           <span style="color:var(--text-muted);font-size:12px">vs</span>

--- a/ui/static/partials/sections/profiles.html
+++ b/ui/static/partials/sections/profiles.html
@@ -7,45 +7,45 @@
         <!-- ===== TRaSH Sync tab ===== -->
         <div class="page" x-show="getProfileTab(activeAppType) === 'trash-sync'">
           <div style="font-size:18px;font-weight:600;margin-bottom:4px">Quality Profiles</div>
-          <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">
+          <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
             TRaSH Guides quality profiles — click a profile to view its contents, customize groups, and sync to your <span x-text="activeAppLabel"></span> instance. Manage sync rules, auto-sync, and overrides from the Sync Rules section below.
           </div>
           <!-- Auto-sync paused banner -->
           <template x-if="autoSyncSettings.paused">
-            <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;margin-bottom:12px;background:#3b2a05;border:1px solid #d29922;border-radius:6px;color:#e3b341;font-size:13px">
+            <div style="display:flex;align-items:center;gap:10px;padding:10px 14px;margin-bottom:12px;background:var(--accent-orange-bg);border:1px solid var(--accent-orange);border-radius:6px;color:var(--cat-hq-release-groups);font-size:13px">
               <span style="font-size:16px">⏸</span>
               <div style="flex:1">
                 <div style="font-weight:600">Auto-sync paused</div>
-                <div style="font-size:12px;color:#c9a44a;margin-top:2px">Scheduled and after-pull syncs are skipped. Manual actions ("Sync All", per-rule "Sync now", Save &amp; Sync from a profile) still work.</div>
+                <div style="font-size:12px;color:var(--accent-orange);margin-top:2px">Scheduled and after-pull syncs are skipped. Manual actions ("Sync All", per-rule "Sync now", Save &amp; Sync from a profile) still work.</div>
               </div>
-              <button class="btn btn-sm" style="border-color:#d29922;color:#e3b341;font-size:12px" @click="setAutoSyncPaused(false)">▶ Resume</button>
+              <button class="btn btn-sm" style="border-color:var(--accent-orange);color:var(--cat-hq-release-groups);font-size:12px" @click="setAutoSyncPaused(false)">▶ Resume</button>
             </div>
           </template>
 
           <!-- Collapsible Sync Rules (always visible) -->
             <div class="card" style="margin-bottom:20px">
-              <div style="display:flex;align-items:center;padding:12px 16px;cursor:pointer;gap:8px;border-left:3px solid #e1e4e8" @click="syncRulesExpanded = { ...syncRulesExpanded, [activeAppType]: !syncRulesExpanded[activeAppType] }">
+              <div style="display:flex;align-items:center;padding:12px 16px;cursor:pointer;gap:8px;border-left:3px solid var(--text-primary)" @click="syncRulesExpanded = { ...syncRulesExpanded, [activeAppType]: !syncRulesExpanded[activeAppType] }">
                 <span class="profile-group-chevron" :class="{ open: syncRulesExpanded[activeAppType] }">&#9654;</span>
                 <span style="font-size:13px;font-weight:500">Sync Rules</span>
-                <span style="font-size:13px;color:#aaa;margin-left:auto"
+                <span style="font-size:13px;color:var(--text-muted);margin-left:auto"
                       x-text="(() => { let count = 0; for (const inst of instancesOfType(activeAppType)) count += sortedSyncRules(inst.id).length; return count > 0 ? count + ' synced profile' + (count !== 1 ? 's' : '') : 'No syncs yet'; })()"></span>
                 <button class="btn btn-sm"
                         @click.stop="setAutoSyncPaused(!autoSyncSettings.paused)"
                         x-tt="autoSyncSettings.paused ? 'Resume auto-sync' : 'Pause auto-sync (scheduled + after-pull). Manual syncs unaffected.'"
                         :style="autoSyncSettings.paused
-                                ? 'font-size:12px;padding:2px 8px;border-color:#d29922;color:#e3b341;margin-left:8px'
-                                : 'font-size:12px;padding:2px 8px;border-color:#30363d;color:#8b949e;margin-left:8px'"
+                                ? 'font-size:12px;padding:2px 8px;border-color:var(--accent-orange);color:var(--cat-hq-release-groups);margin-left:8px'
+                                : 'font-size:12px;padding:2px 8px;border-color:var(--border-subtle);color:var(--text-secondary);margin-left:8px'"
                         x-text="autoSyncSettings.paused ? '▶ Resume Auto-Sync' : '⏸ Pause Auto-Sync'"></button>
               </div>
-              <div x-show="syncRulesExpanded[activeAppType]" style="border-top:1px solid #21262d">
+              <div x-show="syncRulesExpanded[activeAppType]" style="border-top:1px solid var(--bg-muted)">
                 <template x-for="inst in instancesOfType(activeAppType)" :key="'sr-'+inst.id">
                   <template x-if="sortedSyncRules(inst.id).length > 0">
                     <div>
-                      <div style="padding:8px 16px;font-size:13px;color:#aaa;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;background:#0d1117;border-bottom:1px solid #21262d;display:flex;align-items:center">
+                      <div style="padding:8px 16px;font-size:13px;color:var(--text-muted);font-weight:600;text-transform:uppercase;letter-spacing:0.5px;background:var(--bg-page);border-bottom:1px solid var(--bg-muted);display:flex;align-items:center">
                         <span x-text="inst.name"></span>
-                        <button class="btn btn-sm" style="margin-left:auto;font-size:12px;padding:2px 8px;border-color:#238636;color:#3fb950" @click.stop="syncAllForInstance(inst)" x-tt="'Re-sync all profiles with auto-sync enabled on this instance'">Sync All</button>
+                        <button class="btn btn-sm" style="margin-left:auto;font-size:12px;padding:2px 8px;border-color:var(--accent-green-strong);color:var(--accent-green)" @click.stop="syncAllForInstance(inst)" x-tt="'Re-sync all profiles with auto-sync enabled on this instance'">Sync All</button>
                       </div>
-                      <div style="display:flex;align-items:center;padding:4px 16px;gap:8px;font-size:12px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid #161b22;user-select:none">
+                      <div style="display:flex;align-items:center;padding:4px 16px;gap:8px;font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid var(--bg-card);user-select:none">
                         <span style="width:200px;flex-shrink:0;cursor:pointer;white-space:nowrap" @click="toggleSyncRulesSort('trash')">
                           TRaSH Profile <span x-show="syncRulesSort.col==='trash'" x-text="syncRulesSort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span>
                         </span>
@@ -58,21 +58,21 @@
                         <span style="width:180px;flex-shrink:0;text-align:center">Actions</span>
                       </div>
                       <template x-for="sh in sortedSyncRules(inst.id)" :key="sh.arrProfileId">
-                        <div :style="'display:flex;align-items:center;padding:8px 16px;border-bottom:1px solid #161b22;gap:8px;font-size:12px;' + (sh.orphanedAt ? 'background:#1f1305' : '')">
-                          <span :style="'color:' + (sh.orphanedAt ? '#aaa' : '#58a6ff') + ';font-weight:500;width:200px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap'" x-text="sh.profileName"></span>
-                          <span style="color:#aaa;flex-shrink:0;font-size:15px;width:20px;text-align:center">&rarr;</span>
+                        <div :style="'display:flex;align-items:center;padding:8px 16px;border-bottom:1px solid var(--bg-card);gap:8px;font-size:12px;' + (sh.orphanedAt ? 'background:var(--accent-orange-bg)' : '')">
+                          <span :style="'color:' + (sh.orphanedAt ? 'var(--text-muted)' : 'var(--accent-blue)') + ';font-weight:500;width:200px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap'" x-text="sh.profileName"></span>
+                          <span style="color:var(--text-muted);flex-shrink:0;font-size:15px;width:20px;text-align:center">&rarr;</span>
                           <span style="width:200px;flex-shrink:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"
                                 x-data="{ editing: false, newName: '' }">
                             <template x-if="sh.orphanedAt">
                               <span>
-                                <span style="color:#aaa;text-decoration:line-through" x-text="sh.arrProfileName"></span>
-                                <span style="background:#3d2410;border:1px solid #d29922;color:#e3b341;padding:1px 6px;border-radius:3px;font-size:10px;font-weight:500;margin-left:6px" x-tt="'Profile deleted in Arr — ' + (sh.orphanedAt || '')">orphaned</span>
+                                <span style="color:var(--text-muted);text-decoration:line-through" x-text="sh.arrProfileName"></span>
+                                <span style="background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--cat-hq-release-groups);padding:1px 6px;border-radius:3px;font-size:10px;font-weight:500;margin-left:6px" x-tt="'Profile deleted in Arr — ' + (sh.orphanedAt || '')">orphaned</span>
                               </span>
                             </template>
                             <template x-if="!sh.orphanedAt && !editing">
                               <span>
-                                <span style="color:#e1e4e8;cursor:pointer;border-bottom:1px dashed #30363d" @click.stop="newName = sh.arrProfileName; editing = true" x-tt="'Click to rename in Arr'" x-text="sh.arrProfileName"></span>
-                                <span style="color:#aaa;font-size:12px" x-text="'ID ' + sh.arrProfileId"></span>
+                                <span style="color:var(--text-primary);cursor:pointer;border-bottom:1px dashed var(--border-subtle)" @click.stop="newName = sh.arrProfileName; editing = true" x-tt="'Click to rename in Arr'" x-text="sh.arrProfileName"></span>
+                                <span style="color:var(--text-muted);font-size:12px" x-text="'ID ' + sh.arrProfileId"></span>
                               </span>
                             </template>
                             <template x-if="editing">
@@ -93,44 +93,44 @@
                                 <span class="slider"></span>
                               </label>
                               <span style="font-size:11px"
-                                    :style="sh.orphanedAt ? 'color:#666' : (autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId)?.enabled ? 'color:#3fb950' : 'color:#f8514980')"
+                                    :style="sh.orphanedAt ? 'color:var(--text-muted-secondary)' : (autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId)?.enabled ? 'color:var(--accent-green)' : 'color:color-mix(in srgb, var(--accent-red) 50%, transparent)')"
                                     x-text="sh.orphanedAt ? 'orphaned' : (autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId)?.enabled ? 'auto-sync' : 'auto-sync off')"></span>
                           </div>
                           <span style="flex:1;display:flex;gap:8px;align-items:center;justify-content:flex-end">
                             <template x-if="autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId)?.lastSyncError">
-                              <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:#3d1f1f;color:#f85149;flex-shrink:0"
+                              <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--accent-red-bg);color:var(--accent-red);flex-shrink:0"
                                     x-tt="autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId)?.lastSyncError">error</span>
                             </template>
                             <span style="display:flex;gap:4px;align-items:center;flex-shrink:0"
                                   x-data="{ get _rule() { return autoSyncRules.find(r => r.instanceId === inst.id && r.arrProfileId === sh.arrProfileId) || {}; }, get _so() { return Object.keys(this._rule.scoreOverrides || {}).filter(k => !k.startsWith('custom:')).length; }, get _extra() { return Object.keys(this._rule.scoreOverrides || {}).filter(k => k.startsWith('custom:')).length; }, get _qo() { return Object.keys(this._rule.qualityOverrides || {}).length; }, get _oo() { return this._rule.overrides ? Object.keys(this._rule.overrides).filter(k => this._rule.overrides[k] !== undefined).length : 0; } }">
                               <template x-if="_extra > 0">
-                                <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:#0d2847;color:#58a6ff;flex-shrink:0"
+                                <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--fill-blue-soft);color:var(--accent-blue);flex-shrink:0"
                                       x-tt="'Custom formats created by you and added to this profile'"
                                       x-text="_extra + ' custom CF' + (_extra !== 1 ? 's' : '')"></span>
                               </template>
                               <template x-if="_so + _qo + _oo > 0">
-                                <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:#3d2e0a;color:#d29922;flex-shrink:0"
+                                <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--accent-orange-bg);color:var(--accent-orange);flex-shrink:0"
                                       x-tt="(() => { const parts = []; if (_so) parts.push(_so + ' score'); if (_qo) parts.push(_qo + ' quality'); if (_oo) parts.push(_oo + ' settings'); return 'Values that differ from TRaSH defaults: ' + parts.join(', '); })()"
                                       x-text="(_so + _qo + _oo) + ' override' + ((_so + _qo + _oo) !== 1 ? 's' : '')"></span>
                               </template>
                             </span>
-                            <span style="color:#aaa;flex-shrink:0" x-text="(sh.syncedCFs?.length || 0) + ' CFs'"></span>
-                            <span style="color:#aaa;flex-shrink:0" x-text="timeAgo(sh.lastSync)"></span>
+                            <span style="color:var(--text-muted);flex-shrink:0" x-text="(sh.syncedCFs?.length || 0) + ' CFs'"></span>
+                            <span style="color:var(--text-muted);flex-shrink:0" x-text="timeAgo(sh.lastSync)"></span>
                           </span>
                           <span style="display:flex;gap:6px;flex-shrink:0;align-items:center">
                             <template x-if="sh.orphanedAt">
-                              <button class="btn" style="padding:3px 10px;font-size:11px;background:#0d2818;border:1px solid #1f6f3d;color:#7ee787" @click.stop="restoreOrphanedRule(inst, sh)" x-tt="'Recreate this profile in Arr from the last synced state'">&#8634; Restore</button>
+                              <button class="btn" style="padding:3px 10px;font-size:11px;background:var(--fill-blue-soft);border:1px solid var(--accent-green-bg);color:var(--accent-green)" @click.stop="restoreOrphanedRule(inst, sh)" x-tt="'Recreate this profile in Arr from the last synced state'">&#8634; Restore</button>
                             </template>
                             <template x-if="!sh.orphanedAt">
                               <button class="btn-icon" @click.stop="resyncProfile(inst, sh)" x-tt="'Edit sync settings'">&#9998;</button>
                             </template>
                             <template x-if="!sh.orphanedAt">
-                              <button class="btn-icon" style="color:#3fb950" @click.stop="quickSync(inst, sh)" x-tt="'Re-sync with saved settings'">&#8635;</button>
+                              <button class="btn-icon" style="color:var(--accent-green)" @click.stop="quickSync(inst, sh)" x-tt="'Re-sync with saved settings'">&#8635;</button>
                             </template>
                             <template x-if="!sh.orphanedAt">
-                              <button class="btn-icon" style="color:#58a6ff" @click.stop="cloneProfile(inst, sh)" x-tt="'Clone to new profile'">&#10697;</button>
+                              <button class="btn-icon" style="color:var(--accent-blue)" @click.stop="cloneProfile(inst, sh)" x-tt="'Clone to new profile'">&#10697;</button>
                             </template>
-                            <button class="btn-icon" style="color:#f85149" @click.stop="removeSyncHistory(inst.id, sh.arrProfileId)" x-tt="sh.orphanedAt ? 'Permanently remove this orphaned sync rule and history' : 'Remove sync rule'">&#10005;</button>
+                            <button class="btn-icon" style="color:var(--accent-red)" @click.stop="removeSyncHistory(inst.id, sh.arrProfileId)" x-tt="sh.orphanedAt ? 'Permanently remove this orphaned sync rule and history' : 'Remove sync rule'">&#10005;</button>
                           </span>
                         </div>
                       </template>
@@ -138,7 +138,7 @@
                   </template>
                 </template>
                 <template x-if="!instancesOfType(activeAppType).some(inst => sortedSyncRules(inst.id).length > 0)">
-                  <div style="padding:16px;text-align:center;color:#aaa;font-size:12px">No sync history yet. Sync a profile from the list below to get started.</div>
+                  <div style="padding:16px;text-align:center;color:var(--text-muted);font-size:12px">No sync history yet. Sync a profile from the list below to get started.</div>
                 </template>
               </div>
             </div>
@@ -164,7 +164,7 @@
                               @mouseleave="hideCFTooltip()">&#9432;</span>
                       </div>
                       <div style="display:flex;align-items:center;gap:8px">
-                        <span style="font-size:12px;background:#21262d;color:#aaa;padding:2px 8px;border-radius:3px" x-text="p.cfCount + ' CFs'"></span>
+                        <span style="font-size:12px;background:var(--bg-muted);color:var(--text-muted);padding:2px 8px;border-radius:3px" x-text="p.cfCount + ' CFs'"></span>
                       </div>
                     </div>
                   </template>
@@ -185,7 +185,7 @@
         <!-- ===== History tab ===== -->
         <div class="page" x-show="getProfileTab(activeAppType) === 'history'">
           <div style="font-size:18px;font-weight:600;margin-bottom:4px">Sync History</div>
-          <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">
+          <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
             Track changes made to your synced profiles. Each sync that modifies scores, CFs, quality items, or settings is recorded here. Roll back to a previous state if needed.
           </div>
 
@@ -193,12 +193,12 @@
             <template x-if="sortedSyncRules(inst.id).length > 0">
               <div class="card" style="margin-bottom:16px">
                 <!-- Instance header — matches Trash Sync -->
-                <div style="padding:8px 16px;font-size:13px;color:#aaa;font-weight:600;text-transform:uppercase;letter-spacing:0.5px;background:#0d1117;border-bottom:1px solid #21262d;display:flex;align-items:center">
+                <div style="padding:8px 16px;font-size:13px;color:var(--text-muted);font-weight:600;text-transform:uppercase;letter-spacing:0.5px;background:var(--bg-page);border-bottom:1px solid var(--bg-muted);display:flex;align-items:center">
                   <span x-text="inst.name"></span>
                 </div>
                 <!-- Table layout for proper column alignment -->
                 <!-- Column headers -->
-                <div style="display:flex;align-items:center;padding:4px 16px;font-size:12px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid #161b22;user-select:none">
+                <div style="display:flex;align-items:center;padding:4px 16px;font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid var(--bg-card);user-select:none">
                   <div style="flex:none;width:240px;cursor:pointer" @click="toggleHistorySort('trash')">TRaSH Profile <span x-show="historySort.col==='trash'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></div>
                   <div style="flex:none;width:20px"></div>
                   <div style="flex:none;width:240px;cursor:pointer" @click="toggleHistorySort('arr')">Arr Profile <span x-show="historySort.col==='arr'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></div>
@@ -209,40 +209,40 @@
                 <!-- Data rows -->
                 <template x-for="sh in sortedHistoryProfiles(inst.id)" :key="'hp-'+sh.arrProfileId">
                   <div>
-                    <div style="display:flex;align-items:center;padding:8px 16px;border-bottom:1px solid #161b22;font-size:12px;cursor:pointer"
+                    <div style="display:flex;align-items:center;padding:8px 16px;border-bottom:1px solid var(--bg-card);font-size:12px;cursor:pointer"
                          @click="historyExpanded === inst.id + ':' + sh.arrProfileId ? historyExpanded = '' : (historyExpanded = inst.id + ':' + sh.arrProfileId, loadProfileHistory(inst.id, sh.arrProfileId))"
-                         @mouseenter="$el.style.background='#1c2128'" @mouseleave="if (historyExpanded !== inst.id + ':' + sh.arrProfileId) $el.style.background=''">
-                      <div style="flex:none;width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#58a6ff;font-weight:500" x-text="sh.profileName"></div>
-                      <div style="flex:none;width:20px;color:#aaa;text-align:center;font-size:15px">&rarr;</div>
-                      <div style="flex:none;width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:#e1e4e8" x-text="sh.arrProfileName"></div>
+                         @mouseenter="$el.style.background='var(--bg-elevated)'" @mouseleave="if (historyExpanded !== inst.id + ':' + sh.arrProfileId) $el.style.background=''">
+                      <div style="flex:none;width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--accent-blue);font-weight:500" x-text="sh.profileName"></div>
+                      <div style="flex:none;width:20px;color:var(--text-muted);text-align:center;font-size:15px">&rarr;</div>
+                      <div style="flex:none;width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;color:var(--text-primary)" x-text="sh.arrProfileName"></div>
                       <div style="flex:none;width:100px;white-space:nowrap">
-                        <span :style="sh.changes ? 'color:#d29922' : 'color:#aaa'" x-text="sh.changes ? timeAgo(sh.appliedAt || sh.lastSync) : '—'"></span>
+                        <span :style="sh.changes ? 'color:var(--accent-orange)' : 'color:var(--text-muted)'" x-text="sh.changes ? timeAgo(sh.appliedAt || sh.lastSync) : '—'"></span>
                       </div>
                       <div style="flex:none;width:55px;text-align:center;white-space:nowrap">
                         <span x-show="historyEventCount(inst.id, sh.arrProfileId) > 0"
-                              style="font-size:11px;padding:1px 6px;border-radius:3px;background:#21262d;color:#e1e4e8"
+                              style="font-size:11px;padding:1px 6px;border-radius:3px;background:var(--bg-muted);color:var(--text-primary)"
                               x-text="historyEventCount(inst.id, sh.arrProfileId)"></span>
-                        <span x-show="historyEventCount(inst.id, sh.arrProfileId) === 0" style="color:#30363d">—</span>
+                        <span x-show="historyEventCount(inst.id, sh.arrProfileId) === 0" style="color:var(--border-subtle)">—</span>
                       </div>
                       <div style="flex:1;display:flex;gap:4px;justify-content:flex-end;padding-right:4px">
                         <template x-if="sh.changes?.cfDetails?.length > 0">
-                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(63,185,80,0.15);color:#3fb950" x-text="sh.changes.cfDetails.length + ' CF'"></span>
+                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(63,185,80,0.15);color:var(--accent-green)" x-text="sh.changes.cfDetails.length + ' CF'"></span>
                         </template>
                         <template x-if="sh.changes?.scoreDetails?.length > 0">
-                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:#3d2e0a;color:#d29922" x-text="sh.changes.scoreDetails.length + ' score'"></span>
+                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--accent-orange-bg);color:var(--accent-orange)" x-text="sh.changes.scoreDetails.length + ' score'"></span>
                         </template>
                         <template x-if="sh.changes?.qualityDetails?.length > 0">
-                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(163,113,247,0.15);color:#a371f7" x-text="sh.changes.qualityDetails.length + ' quality'"></span>
+                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(163,113,247,0.15);color:var(--accent-purple)" x-text="sh.changes.qualityDetails.length + ' quality'"></span>
                         </template>
                         <template x-if="sh.changes?.settingsDetails?.length > 0">
-                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:#0d2847;color:#58a6ff" x-text="sh.changes.settingsDetails.length + ' setting'"></span>
+                          <span style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--fill-blue-soft);color:var(--accent-blue)" x-text="sh.changes.settingsDetails.length + ' setting'"></span>
                         </template>
-                        <span x-show="!sh.changes" style="color:#aaa">No changes recorded</span>
+                        <span x-show="!sh.changes" style="color:var(--text-muted)">No changes recorded</span>
                       </div>
                     </div>
 
                     <!-- Expanded: change history for this profile -->
-                    <div x-show="historyExpanded === inst.id + ':' + sh.arrProfileId" style="background:#0d1117;border-bottom:1px solid #21262d">
+                    <div x-show="historyExpanded === inst.id + ':' + sh.arrProfileId" style="background:var(--bg-page);border-bottom:1px solid var(--bg-muted)">
                       <template x-if="historyLoading">
                         <div style="padding:16px;text-align:center"><span class="spinner"></span></div>
                       </template>
@@ -252,7 +252,7 @@
                              only). Previously the latter fell through every
                              x-if branch, rendering an empty expanded panel
                              that looked like a click that did nothing. -->
-                        <div style="font-size:12px;color:#aaa;padding:12px 16px 12px 32px">No changes recorded yet. Changes are tracked from the next sync onwards.</div>
+                        <div style="font-size:12px;color:var(--text-muted);padding:12px 16px 12px 32px">No changes recorded yet. Changes are tracked from the next sync onwards.</div>
                       </template>
                       <template x-if="!historyLoading && historyEntries.filter(e => e.changes).length > 0">
                         <div style="padding:6px 16px 6px 32px">
@@ -260,12 +260,12 @@
                                history is marked orphaned. All entries for one ArrProfileID
                                share the same orphaned state, so we just check the first. -->
                           <template x-if="historyEntries.some(e => e.orphanedAt)">
-                            <div style="margin:4px 0 8px 0;padding:8px 12px;background:#3d2410;border:1px solid #d29922;border-radius:6px;font-size:12px;color:#e3b341;line-height:1.55">
+                            <div style="margin:4px 0 8px 0;padding:8px 12px;background:var(--accent-orange-bg);border:1px solid var(--accent-orange);border-radius:6px;font-size:12px;color:var(--cat-hq-release-groups);line-height:1.55">
                               <strong>This profile is orphaned</strong> — its target was deleted in Arr. These entries describe the pre-deletion state and Rollback is disabled. Click Restore on the sync row above to recreate the profile from this saved state. After a successful restore, these entries are cleared automatically.
                             </div>
                           </template>
                           <!-- Sub-table column headers -->
-                          <div style="display:flex;align-items:center;padding:4px 0;gap:8px;font-size:12px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid #21262d;margin-bottom:2px">
+                          <div style="display:flex;align-items:center;padding:4px 0;gap:8px;font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid var(--bg-muted);margin-bottom:2px">
                             <span style="width:150px;flex-shrink:0">Date</span>
                             <span style="width:70px;flex-shrink:0;text-align:center">CFs</span>
                             <span style="width:70px;flex-shrink:0;text-align:center">Scores</span>
@@ -276,68 +276,68 @@
                           <template x-for="(entry, ei) in historyEntries.filter(e => e.changes)" :key="'he-'+ei">
                             <div>
                               <!-- Entry row -->
-                              <div style="display:flex;align-items:center;padding:6px 0;gap:8px;cursor:pointer;font-size:12px;border-bottom:1px solid #161b22"
+                              <div style="display:flex;align-items:center;padding:6px 0;gap:8px;cursor:pointer;font-size:12px;border-bottom:1px solid var(--bg-card)"
                                    @click="historyDetailIdx = historyDetailIdx === ei ? -1 : ei"
-                                   @mouseenter="$el.style.background='#161b22'" @mouseleave="$el.style.background=''">
-                                <span style="color:#e1e4e8;font-weight:500;width:150px;flex-shrink:0;display:flex;align-items:center;gap:6px">
-                                  <span style="color:#aaa;font-size:11px;display:inline-block;width:10px;transition:transform 0.15s"
+                                   @mouseenter="$el.style.background='var(--bg-card)'" @mouseleave="$el.style.background=''">
+                                <span style="color:var(--text-primary);font-weight:500;width:150px;flex-shrink:0;display:flex;align-items:center;gap:6px">
+                                  <span style="color:var(--text-muted);font-size:11px;display:inline-block;width:10px;transition:transform 0.15s"
                                         :style="historyDetailIdx === ei ? 'transform:rotate(90deg)' : ''">&#9654;</span>
                                   <span x-text="new Date(entry.appliedAt || entry.lastSync).toLocaleString(undefined, {month:'short',day:'numeric',hour:'2-digit',minute:'2-digit',hour12:false})"></span>
                                 </span>
                                 <span style="width:70px;flex-shrink:0;text-align:center">
-                                  <span x-show="entry.changes.cfDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(63,185,80,0.15);color:#3fb950" x-text="entry.changes.cfDetails?.length"></span>
-                                  <span x-show="!entry.changes.cfDetails?.length" style="color:#30363d">—</span>
+                                  <span x-show="entry.changes.cfDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--alpha-green);color:var(--accent-green)" x-text="entry.changes.cfDetails.length"></span>
+                                  <span x-show="!entry.changes.cfDetails?.length" style="color:var(--border-subtle)">—</span>
                                 </span>
                                 <span style="width:70px;flex-shrink:0;text-align:center">
-                                  <span x-show="entry.changes.scoreDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:#3d2e0a;color:#d29922" x-text="entry.changes.scoreDetails?.length"></span>
-                                  <span x-show="!entry.changes.scoreDetails?.length" style="color:#30363d">—</span>
+                                  <span x-show="entry.changes.scoreDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--accent-orange-bg);color:var(--accent-orange)" x-text="entry.changes.scoreDetails.length"></span>
+                                  <span x-show="!entry.changes.scoreDetails?.length" style="color:var(--border-subtle)">—</span>
                                 </span>
                                 <span style="width:70px;flex-shrink:0;text-align:center">
-                                  <span x-show="entry.changes.qualityDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:rgba(163,113,247,0.15);color:#a371f7" x-text="entry.changes.qualityDetails?.length"></span>
-                                  <span x-show="!entry.changes.qualityDetails?.length" style="color:#30363d">—</span>
+                                  <span x-show="entry.changes.qualityDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--alpha-purple);color:var(--accent-purple)" x-text="entry.changes.qualityDetails.length"></span>
+                                  <span x-show="!entry.changes.qualityDetails?.length" style="color:var(--border-subtle)">—</span>
                                 </span>
                                 <span style="width:70px;flex-shrink:0;text-align:center">
-                                  <span x-show="entry.changes.settingsDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:#0d2847;color:#58a6ff" x-text="entry.changes.settingsDetails?.length"></span>
-                                  <span x-show="!entry.changes.settingsDetails?.length" style="color:#30363d">—</span>
+                                  <span x-show="entry.changes.settingsDetails?.length > 0" style="font-size:11px;padding:1px 5px;border-radius:3px;background:var(--fill-blue-soft);color:var(--accent-blue)" x-text="entry.changes.settingsDetails.length"></span>
+                                  <span x-show="!entry.changes.settingsDetails?.length" style="color:var(--border-subtle)">—</span>
                                 </span>
                                 <span style="flex:1"></span>
                                 <button class="btn" style="font-size:11px;padding:2px 8px;flex-shrink:0"
-                                        :style="entry.orphanedAt ? 'opacity:0.4;cursor:not-allowed;border-color:#30363d;color:#666' : 'border-color:#d29922;color:#d29922'"
+                                        :style="entry.orphanedAt ? 'opacity:0.4;cursor:not-allowed;border-color:var(--border-subtle);color:var(--text-muted-secondary)' : 'border-color:var(--accent-orange);color:var(--accent-orange)'"
                                         :disabled="!!entry.orphanedAt"
                                         @click.stop="if (!entry.orphanedAt) rollbackSync(inst, entry, ei)"
                                         x-tt="entry.orphanedAt ? 'Cannot rollback — the target profile is orphaned (deleted in Arr). Use Restore on the sync row first.' : 'Re-sync this profile to the state from this point in time. Auto-sync will be disabled.'">Rollback</button>
                               </div>
                               <!-- Expanded detail -->
-                              <div x-show="historyDetailIdx === ei" style="margin:4px 0 8px 16px;padding:10px 14px;background:#161b22;border-left:2px solid #58a6ff;border-radius:0 6px 6px 0;font-size:12px;line-height:1.7">
+                              <div x-show="historyDetailIdx === ei" style="margin:4px 0 8px 16px;padding:10px 14px;background:var(--bg-card);border-left:2px solid var(--accent-blue);border-radius:0 6px 6px 0;font-size:12px;line-height:1.7">
                                 <template x-if="entry.changes.cfDetails?.length > 0">
                                   <div>
-                                    <div style="color:#aaa;font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Custom Formats</div>
+                                    <div style="color:var(--text-muted);font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Custom Formats</div>
                                     <template x-for="d in entry.changes.cfDetails" :key="d">
-                                      <div :style="d.startsWith('Created') || d.startsWith('Added') ? 'color:#3fb950' : d.startsWith('Removed') || d.startsWith('Deleted') ? 'color:#f85149' : 'color:#d29922'" x-text="d"></div>
+                                      <div :style="d.startsWith('Created') || d.startsWith('Added') ? 'color:var(--accent-green)' : d.startsWith('Removed') || d.startsWith('Deleted') ? 'color:var(--accent-red)' : 'color:var(--accent-orange)'" x-text="d"></div>
                                     </template>
                                   </div>
                                 </template>
                                 <template x-if="entry.changes.scoreDetails?.length > 0">
                                   <div :style="entry.changes.cfDetails?.length > 0 ? 'margin-top:8px' : ''">
-                                    <div style="color:#aaa;font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Scores</div>
+                                    <div style="color:var(--text-muted);font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Scores</div>
                                     <template x-for="d in entry.changes.scoreDetails" :key="d">
-                                      <div style="color:#d29922" x-text="d"></div>
+                                      <div style="color:var(--accent-orange)" x-text="d"></div>
                                     </template>
                                   </div>
                                 </template>
                                 <template x-if="entry.changes.qualityDetails?.length > 0">
                                   <div :style="(entry.changes.cfDetails?.length > 0 || entry.changes.scoreDetails?.length > 0) ? 'margin-top:8px' : ''">
-                                    <div style="color:#aaa;font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Quality Items</div>
+                                    <div style="color:var(--text-muted);font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Quality Items</div>
                                     <template x-for="d in entry.changes.qualityDetails" :key="d">
-                                      <div style="color:#a371f7" x-text="d"></div>
+                                      <div style="color:var(--accent-purple)" x-text="d"></div>
                                     </template>
                                   </div>
                                 </template>
                                 <template x-if="entry.changes.settingsDetails?.length > 0">
                                   <div :style="(entry.changes.cfDetails?.length > 0 || entry.changes.scoreDetails?.length > 0 || entry.changes.qualityDetails?.length > 0) ? 'margin-top:8px' : ''">
-                                    <div style="color:#aaa;font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Settings</div>
+                                    <div style="color:var(--text-muted);font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:0.3px;margin-bottom:2px">Settings</div>
                                     <template x-for="d in entry.changes.settingsDetails" :key="d">
-                                      <div style="color:#58a6ff" x-text="d"></div>
+                                      <div style="color:var(--accent-blue)" x-text="d"></div>
                                     </template>
                                   </div>
                                 </template>
@@ -354,7 +354,7 @@
           </template>
 
           <template x-if="!instancesOfType(activeAppType).some(inst => sortedSyncRules(inst.id).length > 0)">
-            <div style="text-align:center;padding:40px;color:#aaa;font-size:13px">No synced profiles yet. Sync a profile from the TRaSH Sync tab to see history here.</div>
+            <div style="text-align:center;padding:40px;color:var(--text-muted);font-size:13px">No synced profiles yet. Sync a profile from the TRaSH Sync tab to see history here.</div>
           </template>
         </div>
         <!-- end History tab -->
@@ -362,15 +362,15 @@
         <!-- ===== Compare tab ===== -->
         <div class="page" x-show="getProfileTab(activeAppType) === 'compare'">
           <div style="font-size:18px;font-weight:600;margin-bottom:4px">Compare Profiles</div>
-          <div style="font-size:14px;color:#aaa;margin-bottom:12px;line-height:1.5">Compare your <span x-text="activeAppLabel"></span> profiles against TRaSH Guides profiles. See what's matching, what has wrong scores, and what's missing — then sync individual fixes or all at once.</div>
-          <div style="font-size:12px;color:#e1e4e8;margin-bottom:16px;line-height:1.6;padding:10px 14px;background:#1a1500;border:1px solid #9e6a03;border-radius:6px;border-left:3px solid #d29922">
-            <strong style="color:#d29922">Note:</strong> Compare works best with profiles synced via Clonarr. For profiles created with other tools, custom formats with a score of 0 cannot be reliably distinguished from unused formats — these may not appear as "in use" in the comparison.
+          <div style="font-size:14px;color:var(--text-muted);margin-bottom:12px;line-height:1.5">Compare your <span x-text="activeAppLabel"></span> profiles against TRaSH Guides profiles. See what's matching, what has wrong scores, and what's missing — then sync individual fixes or all at once.</div>
+          <div style="font-size:12px;color:var(--text-primary);margin-bottom:16px;line-height:1.6;padding:10px 14px;background:var(--accent-orange-bg);border:1px solid var(--accent-orange-strong);border-radius:6px;border-left:3px solid var(--accent-orange)">
+            <strong style="color:var(--accent-orange)">Note:</strong> Compare works best with profiles synced via Clonarr. For profiles created with other tools, custom formats with a score of 0 cannot be reliably distinguished from unused formats — these may not appear as "in use" in the comparison.
           </div>
 
           <!-- Compact selector bar: instance + Arr profile + TRaSH profile on one row -->
           <div class="card">
             <div style="display:flex;align-items:center;gap:8px;padding:10px 14px;flex-wrap:wrap">
-              <span style="font-size:12px;color:#aaa">Instance:</span>
+              <span style="font-size:12px;color:var(--text-muted)">Instance:</span>
               <select class="input" style="width:140px;font-size:12px;padding:4px 8px"
                       :value="getCompareInstanceId(activeAppType)"
                       @change="setCompareInstanceId(activeAppType, $event.target.value); $nextTick(() => { const ci = getCompareInstance(activeAppType); if (ci) { testInstance(ci); loadInstanceProfiles(ci); loadSyncHistory(ci.id); } })">
@@ -380,21 +380,21 @@
                 </template>
               </select>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType && instanceStatus[getCompareInstance(activeAppType)?.id] === 'connected'">
-                <span style="width:8px;height:8px;border-radius:50%;background:#3fb950;display:inline-block" x-tt="'Connected'"></span>
+                <span style="width:8px;height:8px;border-radius:50%;background:var(--accent-green);display:inline-block" x-tt="'Connected'"></span>
               </template>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType && instanceStatus[getCompareInstance(activeAppType)?.id] === 'failed'">
-                <span style="width:8px;height:8px;border-radius:50%;background:#f85149;display:inline-block" x-tt="'Connection failed'"></span>
+                <span style="width:8px;height:8px;border-radius:50%;background:var(--accent-red);display:inline-block" x-tt="'Connection failed'"></span>
               </template>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType && !instanceStatus[getCompareInstance(activeAppType)?.id]">
-                <span style="width:8px;height:8px;border-radius:50%;background:#d29922;display:inline-block" x-tt="'Not tested'"></span>
+                <span style="width:8px;height:8px;border-radius:50%;background:var(--accent-orange);display:inline-block" x-tt="'Not tested'"></span>
               </template>
 
               <!-- Arr profile + TRaSH profile dropdowns (only show when instance selected) -->
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType">
-                <span style="width:1px;height:20px;background:#30363d"></span>
+                <span style="width:1px;height:20px;background:var(--border-subtle)"></span>
               </template>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType">
-                <span style="font-size:12px;color:#aaa">Arr:</span>
+                <span style="font-size:12px;color:var(--text-muted)">Arr:</span>
               </template>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType">
                 <select class="input" style="width:200px;font-size:12px;padding:4px 8px"
@@ -407,10 +407,10 @@
                 </select>
               </template>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType">
-                <span style="font-size:11px;color:#d29922;font-weight:600">VS</span>
+                <span style="font-size:11px;color:var(--accent-orange);font-weight:600">VS</span>
               </template>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType">
-                <span style="font-size:12px;color:#aaa">TRaSH:</span>
+                <span style="font-size:12px;color:var(--text-muted)">TRaSH:</span>
               </template>
               <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType">
                 <select class="input" style="width:240px;font-size:12px;padding:4px 8px"
@@ -440,12 +440,12 @@
           <!-- Empty states -->
           <template x-if="!getCompareInstance(activeAppType) || getCompareInstance(activeAppType)?.type !== activeAppType">
             <div class="card">
-              <div style="padding:32px;text-align:center;color:#aaa;font-size:13px">Select an instance above to compare profiles.</div>
+              <div style="padding:32px;text-align:center;color:var(--text-muted);font-size:13px">Select an instance above to compare profiles.</div>
             </div>
           </template>
           <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType && !instProfiles[getCompareInstance(activeAppType)?.id]">
             <div class="card">
-              <div style="padding:32px;text-align:center;color:#aaa;font-size:13px">
+              <div style="padding:32px;text-align:center;color:var(--text-muted);font-size:13px">
                 <div style="margin-bottom:12px">Loading profiles from <span x-text="getCompareInstance(activeAppType)?.name"></span>...</div>
                 <button class="btn btn-sm" @click="loadInstanceProfiles(getCompareInstance(activeAppType))" :disabled="instProfilesLoading[getCompareInstance(activeAppType)?.id]">Load Profiles</button>
               </div>
@@ -453,12 +453,12 @@
           </template>
           <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType && instProfiles[getCompareInstance(activeAppType)?.id] && !instCompareProfile[getCompareInstance(activeAppType)?.id]">
             <div class="card">
-              <div style="padding:32px;text-align:center;color:#aaa;font-size:13px">Select an Arr profile and a TRaSH profile above to compare.</div>
+              <div style="padding:32px;text-align:center;color:var(--text-muted);font-size:13px">Select an Arr profile and a TRaSH profile above to compare.</div>
             </div>
           </template>
           <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType && instCompareProfile[getCompareInstance(activeAppType)?.id] && !instCompareTrashId[getCompareInstance(activeAppType)?.id]">
             <div class="card">
-              <div style="padding:32px;text-align:center;color:#aaa;font-size:13px">Select a TRaSH profile to compare against.</div>
+              <div style="padding:32px;text-align:center;color:var(--text-muted);font-size:13px">Select a TRaSH profile to compare against.</div>
             </div>
           </template>
           <template x-if="getCompareInstance(activeAppType) && getCompareInstance(activeAppType)?.type === activeAppType && instCompareTrashId[getCompareInstance(activeAppType)?.id]">
@@ -474,7 +474,7 @@
                             <template x-if="instCompareProfile[getCompareInstance(activeAppType)?.id] === ap.id">
                               <div>
                                 <div style="display:none">
-                                  <label style="font-size:12px;color:#aaa;white-space:nowrap">Compare against TRaSH profile:</label>
+                                  <label style="font-size:12px;color:var(--text-muted);white-space:nowrap">Compare against TRaSH profile:</label>
                                   <select class="input" style="width:280px;font-size:12px"
                                           :value="instCompareTrashId[getCompareInstance(activeAppType)?.id] || ''"
                                           @change="runProfileCompare(getCompareInstance(activeAppType), ap.id, $event.target.value)">
@@ -495,7 +495,7 @@
                                 <template x-if="instCompareResult[getCompareInstance(activeAppType)?.id]">
                                   <div>
                                     <template x-if="instCompareResult[getCompareInstance(activeAppType)?.id].error">
-                                      <div style="color:#f85149;font-size:12px" x-text="instCompareResult[getCompareInstance(activeAppType)?.id].error"></div>
+                                      <div style="color:var(--accent-red);font-size:12px" x-text="instCompareResult[getCompareInstance(activeAppType)?.id].error"></div>
                                     </template>
                                     <template x-if="!instCompareResult[getCompareInstance(activeAppType)?.id].error">
                                       <div x-data="{ get cr() { return instCompareResult[getCompareInstance(activeAppType)?.id] }, get iid() { return getCompareInstance(activeAppType)?.id }, get inst() { return getCompareInstance(activeAppType) } }">
@@ -519,9 +519,9 @@
                                             </div>
                                             <template x-if="[...(syncResult.cfDetails || []), ...(syncResult.scoreDetails || []), ...(syncResult.qualityDetails || []), ...(syncResult.settingsDetails || [])].length > 0">
                                               <div style="margin-top:6px">
-                                                <a style="font-size:12px;color:#58a6ff;cursor:pointer;user-select:none" @click="syncResultDetailsOpen = !syncResultDetailsOpen"
+                                                <a style="font-size:12px;color:var(--accent-blue);cursor:pointer;user-select:none" @click="syncResultDetailsOpen = !syncResultDetailsOpen"
                                                    x-text="syncResultDetailsOpen ? '▾ Hide details' : '▸ Show details (' + [...(syncResult.cfDetails || []), ...(syncResult.scoreDetails || []), ...(syncResult.qualityDetails || []), ...(syncResult.settingsDetails || [])].length + ' changes)'"></a>
-                                                <div x-show="syncResultDetailsOpen" style="margin-top:4px;font-size:13px;color:#aaa">
+                                                <div x-show="syncResultDetailsOpen" style="margin-top:4px;font-size:13px;color:var(--text-muted)">
                                                   <template x-for="(d, i) in [...(syncResult.cfDetails || []), ...(syncResult.scoreDetails || []), ...(syncResult.qualityDetails || []), ...(syncResult.settingsDetails || [])]" :key="i">
                                                     <div style="padding:1px 0" x-text="d"></div>
                                                   </template>
@@ -531,7 +531,7 @@
                                             <template x-if="syncResult.errors?.length">
                                               <div style="margin-top:8px;font-size:13px">
                                                 <template x-for="(err, i) in syncResult.errors" :key="i">
-                                                  <div style="color:#f0883e;padding:2px 0" x-text="err"></div>
+                                                  <div style="color:var(--accent-orange-bright);padding:2px 0" x-text="err"></div>
                                                 </template>
                                               </div>
                                             </template>
@@ -550,27 +550,27 @@
                                                 <span> — <span x-text="syncPlan.summary.scoresToSet"></span> scores to set</span>
                                               </template>
                                               <template x-if="syncPlan.summary.scoresToZero > 0">
-                                                <span style="color:#d29922"> — <span x-text="syncPlan.summary.scoresToZero"></span> extra scores zeroed</span>
+                                                <span style="color:var(--accent-orange)"> — <span x-text="syncPlan.summary.scoresToZero"></span> extra scores zeroed</span>
                                               </template>
                                               <template x-if="(syncPlan.settingsPreview || []).length > 0 || (syncPlan.qualityPreview || []).length > 0 || (syncPlan.cfActions || []).some(a => a.action !== 'unchanged') || (syncPlan.scoreActions || []).some(a => a.action !== 'unchanged')">
                                                 <div style="margin-top:6px">
-                                                  <a style="font-size:12px;color:#58a6ff;cursor:pointer;user-select:none" @click="dryrunDetailsOpen = !dryrunDetailsOpen"
+                                                  <a style="font-size:12px;color:var(--accent-blue);cursor:pointer;user-select:none" @click="dryrunDetailsOpen = !dryrunDetailsOpen"
                                                      x-text="dryrunDetailsOpen ? '▾ Hide details' : '▸ Show details'"></a>
-                                                  <div x-show="dryrunDetailsOpen" style="margin-top:4px;font-size:12px;color:#c9d1d9;line-height:1.6">
+                                                  <div x-show="dryrunDetailsOpen" style="margin-top:4px;font-size:12px;color:var(--text-body);line-height:1.6">
                                                     <template x-for="s in (syncPlan.settingsPreview || [])" :key="s">
-                                                      <div><span style="color:#58a6ff">Settings:</span> <span x-text="s"></span></div>
+                                                      <div><span style="color:var(--accent-blue)">Settings:</span> <span x-text="s"></span></div>
                                                     </template>
                                                     <template x-for="q in (syncPlan.qualityPreview || [])" :key="q">
-                                                      <div><span style="color:#d29922">Quality:</span> <span x-text="q"></span></div>
+                                                      <div><span style="color:var(--accent-orange)">Quality:</span> <span x-text="q"></span></div>
                                                     </template>
                                                     <template x-for="a in (syncPlan.cfActions || []).filter(a => a.action === 'create')" :key="'cf-'+a.name">
-                                                      <div><span style="color:#3fb950">Create CF:</span> <span x-text="a.name"></span></div>
+                                                      <div><span style="color:var(--accent-green)">Create CF:</span> <span x-text="a.name"></span></div>
                                                     </template>
                                                     <template x-for="a in (syncPlan.cfActions || []).filter(a => a.action === 'update')" :key="'cfu-'+a.name">
-                                                      <div><span style="color:#58a6ff">Update CF:</span> <span x-text="a.name"></span></div>
+                                                      <div><span style="color:var(--accent-blue)">Update CF:</span> <span x-text="a.name"></span></div>
                                                     </template>
                                                     <template x-for="a in (syncPlan.scoreActions || []).filter(a => a.action !== 'unchanged')" :key="'sc-'+a.cfName">
-                                                      <div><span style="color:#d29922">Score:</span> <span x-text="a.cfName + ': ' + a.oldScore + ' → ' + a.newScore"></span></div>
+                                                      <div><span style="color:var(--accent-orange)">Score:</span> <span x-text="a.cfName + ': ' + a.oldScore + ' → ' + a.newScore"></span></div>
                                                     </template>
                                                   </div>
                                                 </div>
@@ -586,19 +586,19 @@
                                         <!-- Summary bar — single-row: profile identity + status + Sync All Fixes.
                                              Diff counts intentionally removed; the filter chip bar below is the single source of truth for counts.
                                              NOTE: :style uses object form so it MERGES with the base style attribute. A string form would replace it entirely. -->
-                                        <div style="background:#161b22;border:1px solid #444c56;border-radius:8px;padding:10px 14px;margin-bottom:20px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;box-shadow:0 2px 6px rgba(0,0,0,0.4)"
-                                             :style="{ borderColor: ((cr.summary?.wrongScore||0) + (cr.summary?.missing||0) + (cr.summary?.extra||0) + (cr.summary?.settingsDiffs||0) + (cr.summary?.qualityDiffs||0)) > 0 ? '#d29922' : '#3fb950' }">
-                                          <strong style="color:#e1e4e8;font-size:13px" x-text="ap.name"></strong>
-                                          <span style="color:#aaa;font-size:12px">vs</span>
-                                          <strong style="color:#e1e4e8;font-size:13px" x-text="cr.trashProfileName"></strong>
+                                        <div style="background:var(--bg-card);border:1px solid var(--text-muted-secondary);border-radius:8px;padding:10px 14px;margin-bottom:20px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;box-shadow:0 2px 6px rgba(0,0,0,0.4)"
+                                             :style="{ borderColor: ((cr.summary?.wrongScore||0) + (cr.summary?.missing||0) + (cr.summary?.extra||0) + (cr.summary?.settingsDiffs||0) + (cr.summary?.qualityDiffs||0)) > 0 ? 'var(--accent-orange)' : 'var(--accent-green)' }">
+                                          <strong style="color:var(--text-primary);font-size:13px" x-text="ap.name"></strong>
+                                          <span style="color:var(--text-muted);font-size:12px">vs</span>
+                                          <strong style="color:var(--text-primary);font-size:13px" x-text="cr.trashProfileName"></strong>
                                           <span x-show="cr.summary.missing === 0 && cr.summary.wrongScore === 0 && cr.summary.extra === 0 && cr.summary.settingsDiffs === 0 && cr.summary.qualityDiffs === 0"
-                                                style="color:#3fb950;font-size:13px;font-weight:500;margin-left:8px">&#10003; Profile fully in sync</span>
+                                                style="color:var(--accent-green);font-size:13px;font-weight:500;margin-left:8px">&#10003; Profile fully in sync</span>
                                           <span x-show="((cr.summary?.wrongScore||0) + (cr.summary?.missing||0) + (cr.summary?.extra||0) + (cr.summary?.settingsDiffs||0) + (cr.summary?.qualityDiffs||0)) > 0"
-                                                style="color:#d29922;font-size:13px;font-weight:500;margin-left:8px"
+                                                style="color:var(--accent-orange);font-size:13px;font-weight:500;margin-left:8px"
                                                 x-text="'\u26A0 ' + ((cr.summary?.wrongScore||0) + (cr.summary?.missing||0) + (cr.summary?.extra||0) + (cr.summary?.settingsDiffs||0) + (cr.summary?.qualityDiffs||0)) + ' diffs — see filter below for details'"></span>
                                           <div style="margin-left:auto;display:flex;gap:6px;flex-wrap:wrap">
                                             <!-- Reset to default — re-applies the initial "match TRaSH" selection state. -->
-                                            <button class="btn btn-sm" style="font-size:12px;padding:3px 10px;color:#8b949e;border-color:#30363d"
+                                            <button class="btn btn-sm" style="font-size:12px;padding:3px 10px;color:var(--text-secondary);border-color:var(--border-subtle)"
                                                     x-show="compareAdjustedCounts(cr).diffs > 0"
                                                     x-tt="'Undo any manual changes — restore the match-TRaSH default selection'"
                                                     @click="resetCompareToDefault(inst, cr)">&#8634; Reset to default</button>
@@ -613,7 +613,7 @@
 
                                         <!-- Filter chip bar — single source of truth for diff counts. -->
                                         <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-bottom:16px">
-                                          <span style="font-size:11px;font-weight:600;color:#8b949e;text-transform:uppercase;letter-spacing:0.5px;margin-right:6px">Filter</span>
+                                          <span style="font-size:11px;font-weight:600;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-right:6px">Filter</span>
                                           <span class="compare-chip" :class="compareFilter === 'all' ? 'active' : ''" @click="compareFilter = 'all'" x-text="'All (' + compareAdjustedCounts(cr).all + ')'"></span>
                                           <span class="compare-chip" :class="compareFilter === 'diff' ? 'active' : ''" @click="compareFilter = 'diff'" x-text="'Only diffs (' + compareAdjustedCounts(cr).diffs + ')'"></span>
                                           <span class="compare-chip compare-chip-wrong" :class="compareFilter === 'wrong' ? 'active' : ''" @click="compareFilter = 'wrong'" x-text="'⚠ Wrong score (' + compareAdjustedCounts(cr).wrong + ')'"></span>
@@ -625,17 +625,17 @@
                                         <!-- Profile Settings — one card with a 4-column table (Setting | Current | TRaSH | Sync) and sub-header rows for General / Quality / Quality Items. Rows filtered by compareFilter. Entire card hidden if filter yields 0 visible rows. Matches clonarr-compare-redesign-v3.html mockup. -->
                                         <template x-if="(cr.settingsDiffs || []).some(s => compareFilter === 'all' || (compareFilter === 'diff' && !s.match) || (compareFilter === 'wrong' && !s.match) || (compareFilter === 'match' && s.match)) || (cr.qualityDiffs || []).some(q => compareFilter === 'all' || (compareFilter === 'diff' && !q.match) || (compareFilter === 'wrong' && !q.match) || (compareFilter === 'match' && q.match))">
                                           <div class="card" style="margin-bottom:10px;overflow:hidden">
-                                            <div style="padding:10px 14px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px">
+                                            <div style="padding:10px 14px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px">
                                               <span style="font-size:13px;width:14px;text-align:center;flex-shrink:0"
-                                                    :style="(cr.settingsDiffs || []).some(s => !s.match) || (cr.qualityDiffs || []).some(q => !q.match) ? 'color:#d29922' : 'color:#3fb950'"
+                                                    :style="(cr.settingsDiffs || []).some(s => !s.match) || (cr.qualityDiffs || []).some(q => !q.match) ? 'color:var(--accent-orange)' : 'color:var(--accent-green)'"
                                                     x-text="(cr.settingsDiffs || []).some(s => !s.match) || (cr.qualityDiffs || []).some(q => !q.match) ? '⚠' : '✓'"></span>
-                                              <span style="font-size:14px;font-weight:600;color:#c9d1d9">Profile Settings</span>
+                                              <span style="font-size:14px;font-weight:600;color:var(--text-body)">Profile Settings</span>
                                               <span style="display:flex;gap:4px;align-items:center;font-size:11px;margin-left:8px">
                                                 <template x-if="(cr.settingsDiffs || []).filter(s => !s.match).length > 0">
-                                                  <span style="color:#d29922;background:#3d2e0a;padding:1px 6px;border-radius:8px" x-text="(cr.settingsDiffs || []).filter(s => !s.match).length + ' differ'"></span>
+                                                  <span style="color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 6px;border-radius:8px" x-text="(cr.settingsDiffs || []).filter(s => !s.match).length + ' differ'"></span>
                                                 </template>
                                                 <template x-if="(cr.qualityDiffs || []).filter(q => !q.match).length > 0">
-                                                  <span style="color:#d29922;background:#3d2e0a;padding:1px 6px;border-radius:8px" x-text="(cr.qualityDiffs || []).filter(q => !q.match).length + ' quality'"></span>
+                                                  <span style="color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 6px;border-radius:8px" x-text="(cr.qualityDiffs || []).filter(q => !q.match).length + ' quality'"></span>
                                                 </template>
                                               </span>
                                               <div style="flex:1"></div>
@@ -665,7 +665,7 @@
                                                   <tr x-show="compareFilter === 'all' || (compareFilter === 'diff' && !sd.match) || (compareFilter === 'wrong' && !sd.match) || (compareFilter === 'match' && sd.match)">
                                                     <td class="cb">
                                                       <template x-if="!sd.match">
-                                                        <input type="checkbox" style="margin:0;accent-color:#d29922"
+                                                        <input type="checkbox" style="margin:0;accent-color:var(--accent-orange)"
                                                                :checked="(instCompareSettingsSelected[iid] || {})[sd.name] !== false"
                                                                @change="if (!instCompareSettingsSelected[iid]) instCompareSettingsSelected[iid] = {}; instCompareSettingsSelected[iid][sd.name] = $event.target.checked; instCompareSettingsSelected = {...instCompareSettingsSelected}">
                                                       </template>
@@ -685,7 +685,7 @@
                                                   <tr x-show="compareFilter === 'all' || (compareFilter === 'diff' && !sd.match) || (compareFilter === 'wrong' && !sd.match) || (compareFilter === 'match' && sd.match)">
                                                     <td class="cb">
                                                       <template x-if="!sd.match">
-                                                        <input type="checkbox" style="margin:0;accent-color:#d29922"
+                                                        <input type="checkbox" style="margin:0;accent-color:var(--accent-orange)"
                                                                :checked="(instCompareSettingsSelected[iid] || {})[sd.name] !== false"
                                                                @change="if (!instCompareSettingsSelected[iid]) instCompareSettingsSelected[iid] = {}; instCompareSettingsSelected[iid][sd.name] = $event.target.checked; instCompareSettingsSelected = {...instCompareSettingsSelected}">
                                                       </template>
@@ -701,15 +701,15 @@
                                                   <tr x-show="compareFilter === 'all' || (compareFilter === 'diff' && !qd.match) || (compareFilter === 'wrong' && !qd.match) || (compareFilter === 'match' && qd.match)">
                                                     <td class="cb">
                                                       <template x-if="!qd.match">
-                                                        <input type="checkbox" style="margin:0;accent-color:#d29922"
+                                                        <input type="checkbox" style="margin:0;accent-color:var(--accent-orange)"
                                                                :checked="(instCompareQualitySelected[iid] || {})[qd.name] !== false"
                                                                @change="if (!instCompareQualitySelected[iid]) instCompareQualitySelected[iid] = {}; instCompareQualitySelected[iid][qd.name] = $event.target.checked; instCompareQualitySelected = {...instCompareQualitySelected}">
                                                       </template>
                                                     </td>
                                                     <td class="name" x-text="qd.name"></td>
-                                                    <td class="current" :style="qd.currentAllowed ? 'color:#3fb950' : 'color:#f85149'" x-text="qd.currentAllowed ? 'Enabled' : 'Disabled'"></td>
-                                                    <td :style="qd.desiredAllowed ? 'color:#3fb950' : 'color:#f85149'" x-text="qd.desiredAllowed ? 'Enabled' : 'Disabled'"></td>
-                                                    <td :style="(() => { const willSync = (instCompareQualitySelected[iid] || {})[qd.name] !== false; if (qd.match) return qd.currentAllowed ? 'color:#3fb950' : 'color:#8b949e'; const finalVal = willSync ? qd.desiredAllowed : qd.currentAllowed; return finalVal ? (willSync ? 'color:#3fb950;font-weight:600' : 'color:#3fb950') : (willSync ? 'color:#f85149;font-weight:600' : 'color:#6e7681;font-style:italic'); })()"
+                                                    <td class="current" :style="qd.currentAllowed ? 'color:var(--accent-green)' : 'color:var(--accent-red)'" x-text="qd.currentAllowed ? 'Enabled' : 'Disabled'"></td>
+                                                    <td :style="qd.desiredAllowed ? 'color:var(--accent-green)' : 'color:var(--accent-red)'" x-text="qd.desiredAllowed ? 'Enabled' : 'Disabled'"></td>
+                                                    <td :style="(() => { const willSync = (instCompareQualitySelected[iid] || {})[qd.name] !== false; if (qd.match) return qd.currentAllowed ? 'color:var(--accent-green)' : 'color:var(--text-secondary)'; const finalVal = willSync ? qd.desiredAllowed : qd.currentAllowed; return finalVal ? (willSync ? 'color:var(--accent-green);font-weight:600' : 'color:var(--accent-green)') : (willSync ? 'color:var(--accent-red);font-weight:600' : 'color:var(--text-muted-secondary);font-style:italic'); })()"
                                                         x-text="(() => { const willSync = (instCompareQualitySelected[iid] || {})[qd.name] !== false; const finalVal = (qd.match || willSync) ? qd.desiredAllowed : qd.currentAllowed; return finalVal ? 'Enabled' : 'Disabled'; })()"></td>
                                                   </tr>
                                                 </template>
@@ -721,15 +721,15 @@
                                         <!-- Required CFs — same 4-col table layout as Profile Settings, using CB | Name | Current | TRaSH | New columns. Status icons shown inside Name column. -->
                                         <template x-if="(cr.formatItems || []).filter(fi => compareRowVisible(compareFormatItemStatus(fi))).length > 0">
                                           <div class="card" style="margin-bottom:10px;overflow:hidden">
-                                            <div style="padding:10px 14px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px">
+                                            <div style="padding:10px 14px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px">
                                               <span style="font-size:13px;width:14px;text-align:center;flex-shrink:0"
-                                                    :style="cr.formatItems.some(fi => !fi.scoreMatch || !fi.exists) ? 'color:#d29922' : 'color:#3fb950'"
+                                                    :style="cr.formatItems.some(fi => !fi.scoreMatch || !fi.exists) ? 'color:var(--accent-orange)' : 'color:var(--accent-green)'"
                                                     x-text="cr.formatItems.some(fi => !fi.scoreMatch || !fi.exists) ? '⚠' : '✓'"></span>
-                                              <span style="font-size:14px;font-weight:600;color:#c9d1d9">Required CFs</span>
+                                              <span style="font-size:14px;font-weight:600;color:var(--text-body)">Required CFs</span>
                                               <span style="display:flex;gap:4px;align-items:center;font-size:11px;margin-left:8px">
-                                                <span style="color:#3fb950;background:#0d2f1a;padding:1px 6px;border-radius:8px" x-text="cr.formatItems.filter(fi => fi.exists && fi.scoreMatch).length + ' matching'"></span>
-                                                <span x-show="cr.formatItems.some(fi => fi.exists && !fi.scoreMatch)" style="color:#d29922;background:#3d2e0a;padding:1px 6px;border-radius:8px" x-text="cr.formatItems.filter(fi => fi.exists && !fi.scoreMatch).length + ' wrong score'"></span>
-                                                <span x-show="cr.formatItems.some(fi => !fi.exists)" style="color:#f85149;background:#3d1f1f;padding:1px 6px;border-radius:8px" x-text="cr.formatItems.filter(fi => !fi.exists).length + ' missing'"></span>
+                                                <span style="color:var(--accent-green);background:var(--fill-green-soft);padding:1px 6px;border-radius:8px" x-text="cr.formatItems.filter(fi => fi.exists && fi.scoreMatch).length + ' matching'"></span>
+                                                <span x-show="cr.formatItems.some(fi => fi.exists && !fi.scoreMatch)" style="color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 6px;border-radius:8px" x-text="cr.formatItems.filter(fi => fi.exists && !fi.scoreMatch).length + ' wrong score'"></span>
+                                                <span x-show="cr.formatItems.some(fi => !fi.exists)" style="color:var(--accent-red);background:var(--accent-red-bg);padding:1px 6px;border-radius:8px" x-text="cr.formatItems.filter(fi => !fi.exists).length + ' missing'"></span>
                                               </span>
                                               <div style="flex:1"></div>
                                               <span class="compare-section-toggle"
@@ -754,14 +754,14 @@
                                                   <tr x-show="compareRowVisible(compareFormatItemStatus(fi))">
                                                     <td class="cb">
                                                       <template x-if="!fi.exists || !fi.scoreMatch">
-                                                        <input type="checkbox" style="margin:0;accent-color:#d29922"
+                                                        <input type="checkbox" style="margin:0;accent-color:var(--accent-orange)"
                                                                :checked="(instCompareSelected[iid] || {})[fi.trashId]"
                                                                @change="toggleCompareSelect(iid, fi.trashId, $event.target.checked)">
                                                       </template>
                                                     </td>
                                                     <td class="name">
                                                       <span style="margin-right:4px"
-                                                            :style="fi.exists && fi.scoreMatch ? 'color:#3fb950' : fi.exists ? 'color:#d29922' : 'color:#f85149'"
+                                                            :style="fi.exists && fi.scoreMatch ? 'color:var(--accent-green)' : fi.exists ? 'color:var(--accent-orange)' : 'color:var(--accent-red)'"
                                                             x-text="fi.exists && fi.scoreMatch ? '✓' : fi.exists ? '⚠' : '✗'"></span>
                                                       <span x-text="fi.name"></span>
                                                       <span class="cf-info" x-show="fi.description"
@@ -773,7 +773,7 @@
                                                             :class="fi.scoreOverride != null ? 'on' : ''"
                                                             x-tt="fi.scoreOverride != null ? ('Override: this score is set intentionally via a Clonarr sync rule (saved as ' + ((fi.scoreOverride > 0 ? '+' : '') + fi.scoreOverride) + ')') : ''"
                                                             x-text="fi.scoreOverride != null ? 'OR' : ''"></span>
-                                                      <span :style="fi.scoreOverride != null ? 'color:#58a6ff;font-weight:600' : ''"
+                                                      <span :style="fi.scoreOverride != null ? 'color:var(--accent-blue);font-weight:600' : ''"
                                                             x-text="fi.exists ? ((fi.currentScore > 0 ? '+' : '') + fi.currentScore) : '—'"></span>
                                                     </td>
                                                     <td :class="fi.scoreMatch ? 'target-match' : 'target-diff'"
@@ -790,16 +790,16 @@
                                         <!-- CF Groups — flat table. No outer collapse, no per-group collapse. Each group is a subsection header + its CFs listed directly below. Filter predicates hide individual rows AND entire groups when all rows are filtered. -->
                                         <template x-if="(cr.groups || []).filter(g => g.cfs.some(cf => compareRowVisible(compareGroupCFStatus(cf, g)))).length > 0">
                                           <div class="card" style="margin-bottom:10px;overflow:hidden">
-                                            <div style="padding:10px 14px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px">
+                                            <div style="padding:10px 14px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px">
                                               <span style="font-size:13px;width:14px;text-align:center;flex-shrink:0"
-                                                    :style="cr.groups.some(g => g.wrongScore > 0 || g.missing > 0) ? 'color:#d29922' : 'color:#3fb950'"
+                                                    :style="cr.groups.some(g => g.wrongScore > 0 || g.missing > 0) ? 'color:var(--accent-orange)' : 'color:var(--accent-green)'"
                                                     x-text="cr.groups.some(g => g.wrongScore > 0 || g.missing > 0) ? '⚠' : '✓'"></span>
-                                              <span style="font-size:14px;font-weight:600;color:#c9d1d9">CF Groups</span>
+                                              <span style="font-size:14px;font-weight:600;color:var(--text-body)">CF Groups</span>
                                               <span style="display:flex;gap:4px;align-items:center;font-size:11px;margin-left:8px">
-                                                <span style="color:#3fb950;background:#0d2f1a;padding:1px 6px;border-radius:8px" x-text="cr.groups.length + ' groups'"></span>
-                                                <span x-show="cr.groups.some(g => g.wrongScore > 0)" style="color:#d29922;background:#3d2e0a;padding:1px 6px;border-radius:8px"
+                                                <span style="color:var(--accent-green);background:var(--fill-green-soft);padding:1px 6px;border-radius:8px" x-text="cr.groups.length + ' groups'"></span>
+                                                <span x-show="cr.groups.some(g => g.wrongScore > 0)" style="color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 6px;border-radius:8px"
                                                       x-text="cr.groups.reduce((n,g) => n + g.wrongScore, 0) + ' wrong score'"></span>
-                                                <span x-show="cr.groups.some(g => g.missing > 0)" style="color:#f85149;background:#3d1f1f;padding:1px 6px;border-radius:8px"
+                                                <span x-show="cr.groups.some(g => g.missing > 0)" style="color:var(--accent-red);background:var(--accent-red-bg);padding:1px 6px;border-radius:8px"
                                                       x-text="cr.groups.reduce((n,g) => n + g.missing, 0) + ' missing'"></span>
                                               </span>
                                               <div style="flex:1"></div>
@@ -828,32 +828,32 @@
                                                       <td colspan="5">
                                                         <template x-if="row.isGolden">
                                                           <span x-tt="stripHtml(row.group.trashDescription) || 'Exclusive required group — pick one variant'"
-                                                                style="color:#f85149;font-size:14px;margin-right:6px;cursor:help">&#9888;</span>
+                                                                style="color:var(--accent-red);font-size:14px;margin-right:6px;cursor:help">&#9888;</span>
                                                         </template>
                                                         <template x-if="!row.isGolden">
-                                                          <span :style="row.group.wrongScore > 0 || row.group.missing > 0 ? 'color:#d29922' : row.group.present > 0 && row.group.matching === row.group.present ? 'color:#3fb950' : 'color:#8b949e'"
+                                                          <span :style="row.group.wrongScore > 0 || row.group.missing > 0 ? 'color:var(--accent-orange)' : row.group.present > 0 && row.group.matching === row.group.present ? 'color:var(--accent-green)' : 'color:var(--text-secondary)'"
                                                                 x-text="row.group.wrongScore > 0 || row.group.missing > 0 ? '⚠' : row.group.present > 0 && row.group.matching === row.group.present ? '✓' : '○'"
                                                                 style="margin-right:6px"></span>
                                                         </template>
-                                                        <span :style="row.isGolden ? 'color:#f85149' : ''" x-text="row.group.name"></span>
-                                                        <span x-show="row.group.exclusive" :style="row.isGolden ? 'font-size:10px;color:#fff;background:#f85149;padding:1px 6px;border-radius:8px;margin-left:8px;text-transform:none;letter-spacing:0;font-weight:600' : 'font-size:10px;color:#d29922;background:#3d2e0a;padding:1px 6px;border-radius:8px;margin-left:8px;text-transform:none;letter-spacing:0'">pick one</span>
-                                                        <span x-show="row.group.defaultEnabled && !row.isGolden" style="font-size:10px;color:#3fb950;background:#0d2f1a;padding:1px 6px;border-radius:8px;margin-left:4px;text-transform:none;letter-spacing:0">default</span>
+                                                        <span :style="row.isGolden ? 'color:var(--accent-red)' : ''" x-text="row.group.name"></span>
+                                                        <span x-show="row.group.exclusive" :style="row.isGolden ? 'font-size:10px;color:var(--text-on-accent);background:var(--accent-red);padding:1px 6px;border-radius:8px;margin-left:8px;text-transform:none;letter-spacing:0;font-weight:600' : 'font-size:10px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 6px;border-radius:8px;margin-left:8px;text-transform:none;letter-spacing:0'">pick one</span>
+                                                        <span x-show="row.group.defaultEnabled && !row.isGolden" style="font-size:10px;color:var(--accent-green);background:var(--fill-green-soft);padding:1px 6px;border-radius:8px;margin-left:4px;text-transform:none;letter-spacing:0">default</span>
                                                         <span style="float:right;font-size:10px;display:inline-flex;gap:4px">
                                                           <template x-if="row.group.present > 0">
-                                                            <span style="color:#3fb950;background:#0d2f1a;padding:1px 6px;border-radius:8px;text-transform:none;letter-spacing:0" x-text="row.group.present + '/' + row.group.total + ' in use'"></span>
+                                                            <span style="color:var(--accent-green);background:var(--fill-green-soft);padding:1px 6px;border-radius:8px;text-transform:none;letter-spacing:0" x-text="row.group.present + '/' + row.group.total + ' in use'"></span>
                                                           </template>
-                                                          <span x-show="row.group.wrongScore > 0" style="color:#d29922;background:#3d2e0a;padding:1px 6px;border-radius:8px;text-transform:none;letter-spacing:0" x-text="row.group.wrongScore + ' wrong score'"></span>
-                                                          <span x-show="row.group.missing > 0" style="color:#f85149;background:#3d1f1f;padding:1px 6px;border-radius:8px;text-transform:none;letter-spacing:0" x-text="row.group.missing + ' missing'"></span>
+                                                          <span x-show="row.group.wrongScore > 0" style="color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 6px;border-radius:8px;text-transform:none;letter-spacing:0" x-text="row.group.wrongScore + ' wrong score'"></span>
+                                                          <span x-show="row.group.missing > 0" style="color:var(--accent-red);background:var(--accent-red-bg);padding:1px 6px;border-radius:8px;text-transform:none;letter-spacing:0" x-text="row.group.missing + ' missing'"></span>
                                                         </span>
                                                       </td>
                                                     </template>
                                                     <template x-if="row.type === 'multi'">
-                                                      <td colspan="5" style="color:#d29922;background:#3d2e0a">&#9888; Multiple CFs scored — TRaSH recommends only one with a non-zero score</td>
+                                                      <td colspan="5" style="color:var(--accent-orange);background:var(--accent-orange-bg)">&#9888; Multiple CFs scored — TRaSH recommends only one with a non-zero score</td>
                                                     </template>
                                                     <template x-if="row.type === 'cf'">
                                                       <td class="cb">
                                                         <template x-if="(row.group.exclusive && row.group.defaultEnabled) || (row.cf.exists && row.cf.inUse && !row.cf.scoreMatch) || (!row.cf.exists && row.group.defaultEnabled && row.cf.required)">
-                                                          <input type="checkbox" style="margin:0;accent-color:#d29922"
+                                                          <input type="checkbox" style="margin:0;accent-color:var(--accent-orange)"
                                                                  :checked="(instCompareSelected[iid] || {})[row.cf.trashId]"
                                                                  @change="toggleCompareSelect(iid, row.cf.trashId, $event.target.checked)">
                                                         </template>
@@ -862,7 +862,7 @@
                                                     <template x-if="row.type === 'cf'">
                                                       <td class="name">
                                                         <span style="margin-right:4px"
-                                                              :style="row.cf.exists && row.cf.inUse && row.cf.scoreMatch ? 'color:#3fb950' : row.cf.exists && row.cf.inUse ? 'color:#d29922' : !row.cf.exists && row.group.defaultEnabled && row.cf.required ? 'color:#f85149' : 'color:#8b949e'"
+                                                              :style="row.cf.exists && row.cf.inUse && row.cf.scoreMatch ? 'color:var(--accent-green)' : row.cf.exists && row.cf.inUse ? 'color:var(--accent-orange)' : !row.cf.exists && row.group.defaultEnabled && row.cf.required ? 'color:var(--accent-red)' : 'color:var(--text-secondary)'"
                                                               x-text="row.cf.exists && row.cf.inUse && row.cf.scoreMatch ? '✓' : row.cf.exists && row.cf.inUse ? '⚠' : !row.cf.exists && row.group.defaultEnabled && row.cf.required ? '✗' : '○'"></span>
                                                         <span x-text="row.cf.name"></span>
                                                         <span class="cf-info" x-show="row.cf.description"
@@ -872,7 +872,7 @@
                                                           <span style="font-size:10px;margin-left:4px" x-tt="'Required by TRaSH'">&#128274;</span>
                                                         </template>
                                                         <template x-if="row.cf.default">
-                                                          <span style="font-size:10px;color:#3fb950;background:#0d2f1a;padding:1px 5px;border-radius:6px;margin-left:4px">rec</span>
+                                                          <span style="font-size:10px;color:var(--accent-green);background:var(--fill-green-soft);padding:1px 5px;border-radius:6px;margin-left:4px">rec</span>
                                                         </template>
                                                       </td>
                                                     </template>
@@ -882,7 +882,7 @@
                                                               :class="row.cf.scoreOverride != null ? 'on' : ''"
                                                               x-tt="row.cf.scoreOverride != null ? ('Override: this score is set intentionally via a Clonarr sync rule (saved as ' + ((row.cf.scoreOverride > 0 ? '+' : '') + row.cf.scoreOverride) + ')') : ''"
                                                               x-text="row.cf.scoreOverride != null ? 'OR' : ''"></span>
-                                                        <span :style="row.cf.scoreOverride != null ? 'color:#58a6ff;font-weight:600' : ''"
+                                                        <span :style="row.cf.scoreOverride != null ? 'color:var(--accent-blue);font-weight:600' : ''"
                                                               x-text="row.cf.exists ? ((row.cf.currentScore > 0 ? '+' : '') + row.cf.currentScore) : '—'"></span>
                                                       </td>
                                                     </template>
@@ -904,10 +904,10 @@
                                         <!-- Extra in Arr — flat table, no collapse. Hidden when compareFilter excludes 'extra'. -->
                                         <template x-if="cr.summary?.extra > 0 && compareRowVisible('extra')">
                                           <div class="card" style="margin-bottom:10px;overflow:hidden">
-                                            <div style="padding:10px 14px;border-bottom:1px solid #21262d;display:flex;align-items:center;gap:8px">
-                                              <span style="font-size:13px;width:14px;text-align:center;flex-shrink:0;color:#58a6ff">&#9432;</span>
-                                              <span style="font-size:14px;font-weight:600;color:#c9d1d9">Extra in Arr</span>
-                                              <span style="font-size:11px;color:#58a6ff;background:#0d2847;padding:1px 6px;border-radius:8px;margin-left:8px" x-text="cr.summary.extra + ' CFs'"></span>
+                                            <div style="padding:10px 14px;border-bottom:1px solid var(--bg-muted);display:flex;align-items:center;gap:8px">
+                                              <span style="font-size:13px;width:14px;text-align:center;flex-shrink:0;color:var(--accent-blue)">&#9432;</span>
+                                              <span style="font-size:14px;font-weight:600;color:var(--text-body)">Extra in Arr</span>
+                                              <span style="font-size:11px;color:var(--accent-blue);background:var(--fill-blue-soft);padding:1px 6px;border-radius:8px;margin-left:8px" x-text="cr.summary.extra + ' CFs'"></span>
                                               <div style="flex:1"></div>
                                               <span class="compare-section-toggle" @click.stop="toggleAllInCompareSection(iid, cr, 'extras')">toggle all</span>
                                               <button class="btn btn-sm btn-primary" style="font-size:11px;padding:2px 10px;margin-left:8px"
@@ -915,7 +915,7 @@
                                                       @click="compareQuickSyncOpen(inst, cr, 'extras')">Remove selected</button>
                                             </div>
                                             <div>
-                                            <div style="font-size:12px;color:#aaa;padding:6px 14px 2px">
+                                            <div style="font-size:12px;color:var(--text-muted);padding:6px 14px 2px">
                                               CFs scored in your Arr profile but not part of this TRaSH profile. Selecting and removing will reset their score to 0.
                                             </div>
                                             <template x-for="ecf in (cr.extraCFs || [])" :key="ecf.format">
@@ -927,17 +927,17 @@
                                                 </label>
                                                 <div class="compare-cf-name">
                                                   <span x-text="ecf.name"
-                                                        :style="(instRemoveSelected[iid] || {})[ecf.format] ? 'color:#f47067;text-decoration:line-through' : 'color:#aaa'"></span>
+                                                        :style="(instRemoveSelected[iid] || {})[ecf.format] ? 'color:var(--accent-red-soft);text-decoration:line-through' : 'color:var(--text-muted)'"></span>
                                                   <template x-if="(instRemoveSelected[iid] || {})[ecf.format]">
                                                     <span class="compare-action-label remove">will be removed</span>
                                                   </template>
                                                 </div>
                                                 <div class="compare-cf-scores">
-                                                  <span style="color:#aaa" x-text="'score: ' + ecf.score"></span>
+                                                  <span style="color:var(--text-muted)" x-text="'score: ' + ecf.score"></span>
                                                 </div>
                                                 <div class="compare-cf-actions">
                                                   <template x-if="(instRemoveSelected[iid] || {})[ecf.format]">
-                                                    <button class="btn btn-sm" style="padding:1px 5px;font-size:11px;white-space:nowrap;background:#3d1f1f;color:#f47067;border-color:#f4706744"
+                                                    <button class="btn btn-sm" style="padding:1px 5px;font-size:11px;white-space:nowrap;background:var(--accent-red-bg);color:var(--accent-red-soft);border-color:color-mix(in srgb, var(--accent-red-soft) 27%, transparent)"
                                                             @click.stop="removeSingleCF(inst, ecf.format, cr.arrProfileId)">Remove</button>
                                                   </template>
                                                 </div>
@@ -955,7 +955,7 @@
                                                         !(cr.formatItems || []).some(fi => compareRowVisible(compareFormatItemStatus(fi))) &&
                                                         !(cr.groups || []).some(g => g.cfs.some(cf => compareRowVisible(compareGroupCFStatus(cf, g)))) &&
                                                         !(compareFilter === 'extra' && cr.summary?.extra > 0)">
-                                          <div style="padding:32px;text-align:center;color:#8b949e;font-size:13px;background:#0d1117;border:1px solid #21262d;border-radius:6px;margin-top:6px">
+                                          <div style="padding:32px;text-align:center;color:var(--text-secondary);font-size:13px;background:var(--bg-page);border:1px solid var(--bg-muted);border-radius:6px;margin-top:6px">
                                             <span x-text="'No ' + (compareFilter === 'diff' ? 'diffs' : compareFilter) + ' found — try a different filter'"></span>
                                           </div>
                                         </template>
@@ -970,7 +970,7 @@
                       </div>
                     </template>
                     <template x-if="!instProfiles[getCompareInstance(activeAppType)?.id]">
-                      <div style="font-size:12px;color:#aaa;padding:4px 0">Click "Load Profiles" to fetch profiles from this instance</div>
+                      <div style="font-size:12px;color:var(--text-muted);padding:4px 0">Click "Load Profiles" to fetch profiles from this instance</div>
                     </template>
                   </div>
           </template>

--- a/ui/static/partials/sections/quality-size.html
+++ b/ui/static/partials/sections/quality-size.html
@@ -2,13 +2,13 @@
       <!-- ===== Quality Definitions sub-tab ===== -->
       <div class="page" x-show="currentSection === 'quality-size'">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Quality Definitions</div>
-        <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">TRaSH recommended file sizes (MB per minute of video) for each quality. These limits help Radarr/Sonarr choose the right quality when multiple releases are available. Select an instance to compare current values and sync.</div>
+        <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">TRaSH recommended file sizes (MB per minute of video) for each quality. These limits help Radarr/Sonarr choose the right quality when multiple releases are available. Select an instance to compare current values and sync.</div>
         <template x-if="getQualitySizes(activeAppType).length > 0">
           <div>
             <!-- Instance selector + quality size type -->
             <div class="card" style="padding:0;overflow:visible">
-              <div style="display:flex;align-items:center;gap:12px;padding:10px 16px;border-bottom:1px solid #21262d">
-                <span style="font-size:13px;color:#aaa">Instance:</span>
+              <div style="display:flex;align-items:center;gap:12px;padding:10px 16px;border-bottom:1px solid var(--bg-muted)">
+                <span style="font-size:13px;color:var(--text-muted)">Instance:</span>
                 <select class="input" style="width:200px;font-size:12px;padding:4px 8px"
                         @change="qsInstanceId = { ...qsInstanceId, [activeAppType]: $event.target.value }; if ($event.target.value) { const _inst = instances.find(i => i.id === $event.target.value); if (_inst) testInstance(_inst); loadInstanceQS(activeAppType, $event.target.value); }">
                   <option value="" :selected="!qsInstanceId[activeAppType]">TRaSH only</option>
@@ -17,20 +17,20 @@
                   </template>
                 </select>
                 <template x-if="qsInstanceId[activeAppType] && instanceStatus[qsInstanceId[activeAppType]] === 'connected'">
-                  <span style="font-size:13px;color:#3fb950">Connected</span>
+                  <span style="font-size:13px;color:var(--accent-green)">Connected</span>
                 </template>
                 <template x-if="qsInstanceId[activeAppType] && instanceStatus[qsInstanceId[activeAppType]] === 'failed'">
-                  <span style="font-size:13px;color:#f85149">Connection failed</span>
+                  <span style="font-size:13px;color:var(--accent-red)">Connection failed</span>
                 </template>
                 <template x-if="qsInstanceId[activeAppType] && !instanceStatus[qsInstanceId[activeAppType]]">
-                  <span style="font-size:13px;color:#d29922">Not tested</span>
+                  <span style="font-size:13px;color:var(--accent-orange)">Not tested</span>
                 </template>
                 <template x-if="!qsInstanceId[activeAppType]">
-                  <span style="font-size:13px;color:#aaa">Select an instance to compare and sync</span>
+                  <span style="font-size:13px;color:var(--text-muted)">Select an instance to compare and sync</span>
                 </template>
               </div>
               <div style="display:flex;gap:8px;align-items:center;padding:10px 16px">
-                <span style="font-size:13px;color:#aaa">Type:</span>
+                <span style="font-size:13px;color:var(--text-muted)">Type:</span>
                 <template x-for="(qsType, idx) in getQualitySizes(activeAppType)" :key="qsType.trash_id">
                   <button class="btn btn-sm"
                           :class="{ 'btn-primary': (selectedQSType[activeAppType] || 0) === idx }"
@@ -52,9 +52,9 @@
 
             <div class="card" style="padding:16px 20px">
               <!-- Auto-sync toggle bar (above header when instance selected) -->
-              <div style="display:flex;align-items:center;justify-content:flex-end;padding:8px 0 6px;border-bottom:1px solid #21262d;gap:8px"
+              <div style="display:flex;align-items:center;justify-content:flex-end;padding:8px 0 6px;border-bottom:1px solid var(--bg-muted);gap:8px"
                    x-show="qsInstanceId[activeAppType]">
-                <label style="font-size:13px;color:#aaa;display:flex;align-items:center;gap:6px;cursor:pointer;user-select:none">
+                <label style="font-size:13px;color:var(--text-muted);display:flex;align-items:center;gap:6px;cursor:pointer;user-select:none">
                   <span>Auto-sync</span>
                   <label class="toggle">
                     <input type="checkbox"
@@ -64,41 +64,41 @@
                   </label>
                 </label>
                 <template x-if="qsAutoSync[activeAppType]?.enabled && qsAutoSync[activeAppType]?.type === (getQualitySizes(activeAppType)[selectedQSType[activeAppType] || 0]?.type || '')">
-                  <span style="font-size:12px;color:#aaa">Syncs Auto-mode qualities on every TRaSH pull</span>
+                  <span style="font-size:12px;color:var(--text-muted)">Syncs Auto-mode qualities on every TRaSH pull</span>
                 </template>
                 <template x-if="qsAutoSync[activeAppType]?.enabled && qsAutoSync[activeAppType]?.type !== (getQualitySizes(activeAppType)[selectedQSType[activeAppType] || 0]?.type || '')">
-                  <span style="font-size:12px;color:#d29922">Auto-sync is active for <strong x-text="qsAutoSync[activeAppType].type"></strong> — enable here to switch</span>
+                  <span style="font-size:12px;color:var(--accent-orange)">Auto-sync is active for <strong x-text="qsAutoSync[activeAppType].type"></strong> — enable here to switch</span>
                 </template>
                 <template x-if="!qsAutoSync[activeAppType]?.enabled">
-                  <span style="font-size:12px;color:#aaa">Set each quality to Auto or Custom, then enable</span>
+                  <span style="font-size:12px;color:var(--text-muted)">Set each quality to Auto or Custom, then enable</span>
                 </template>
               </div>
               <!-- Header row -->
-              <div class="qs-row" style="border-bottom:1px solid #30363d;padding-bottom:6px;margin-bottom:4px">
-                <div class="qs-name" style="font-size:13px;color:#aaa;font-weight:400">Quality</div>
-                <div class="qs-col" style="font-size:13px;color:#aaa;font-family:inherit">TRaSH Min</div>
-                <div class="qs-col" style="font-size:13px;color:#aaa;font-family:inherit">TRaSH Pref</div>
-                <div class="qs-col" style="font-size:13px;color:#aaa;font-family:inherit">TRaSH Max</div>
+              <div class="qs-row" style="border-bottom:1px solid var(--border-subtle);padding-bottom:6px;margin-bottom:4px">
+                <div class="qs-name" style="font-size:13px;color:var(--text-muted);font-weight:400">Quality</div>
+                <div class="qs-col" style="font-size:13px;color:var(--text-muted);font-family:inherit">TRaSH Min</div>
+                <div class="qs-col" style="font-size:13px;color:var(--text-muted);font-family:inherit">TRaSH Pref</div>
+                <div class="qs-col" style="font-size:13px;color:var(--text-muted);font-family:inherit">TRaSH Max</div>
                 <template x-if="qsInstanceId[activeAppType]">
-                  <div style="width:1px;background:#30363d;margin:0 4px;align-self:stretch"></div>
+                  <div style="width:1px;background:var(--border-subtle);margin:0 4px;align-self:stretch"></div>
                 </template>
                 <template x-if="qsInstanceId[activeAppType]">
-                  <div class="qs-col" style="font-size:13px;color:#aaa;font-family:inherit">Instance Min</div>
+                  <div class="qs-col" style="font-size:13px;color:var(--text-muted);font-family:inherit">Instance Min</div>
                 </template>
                 <template x-if="qsInstanceId[activeAppType]">
-                  <div class="qs-col" style="font-size:13px;color:#aaa;font-family:inherit">Instance Pref</div>
+                  <div class="qs-col" style="font-size:13px;color:var(--text-muted);font-family:inherit">Instance Pref</div>
                 </template>
                 <template x-if="qsInstanceId[activeAppType]">
-                  <div class="qs-col" style="font-size:13px;color:#aaa;font-family:inherit">Instance Max</div>
+                  <div class="qs-col" style="font-size:13px;color:var(--text-muted);font-family:inherit">Instance Max</div>
                 </template>
                 <template x-if="qsInstanceId[activeAppType]">
-                  <div style="width:1px;background:#30363d;margin:0 4px;align-self:stretch"></div>
+                  <div style="width:1px;background:var(--border-subtle);margin:0 4px;align-self:stretch"></div>
                 </template>
                 <template x-if="qsInstanceId[activeAppType]">
-                  <div style="font-size:13px;color:#aaa;font-family:inherit;width:58px;flex-shrink:0;text-align:center" x-tt="'Auto: follows TRaSH values. Custom: use your own values.'">Sync Mode</div>
+                  <div style="font-size:13px;color:var(--text-muted);font-family:inherit;width:58px;flex-shrink:0;text-align:center" x-tt="'Auto: follows TRaSH values. Custom: use your own values.'">Sync Mode</div>
                 </template>
                 <template x-if="qsInstanceId[activeAppType]">
-                  <div style="font-size:13px;color:#aaa;font-family:inherit;width:68px;flex-shrink:0;text-align:center">Action</div>
+                  <div style="font-size:13px;color:var(--text-muted);font-family:inherit;width:68px;flex-shrink:0;text-align:center">Action</div>
                 </template>
               </div>
 
@@ -106,12 +106,12 @@
               <template x-for="qs in getSelectedQS(activeAppType)" :key="qs.quality">
                 <div class="qs-row" :style="qsRowStyle(activeAppType, qs)">
                   <div class="qs-name" x-text="qs.quality"></div>
-                  <div class="qs-col" style="color:#e1e4e8" x-text="qs.min.toFixed(1)"></div>
-                  <div class="qs-col" style="color:#e1e4e8" x-text="qs.preferred.toFixed(1)"></div>
-                  <div class="qs-col" style="color:#aaa" x-text="qs.max.toFixed(1)"></div>
+                  <div class="qs-col" style="color:var(--text-primary)" x-text="qs.min.toFixed(1)"></div>
+                  <div class="qs-col" style="color:var(--text-primary)" x-text="qs.preferred.toFixed(1)"></div>
+                  <div class="qs-col" style="color:var(--text-muted)" x-text="qs.max.toFixed(1)"></div>
                   <!-- Instance comparison columns: read-only in Sync mode, editable in Custom mode -->
                   <template x-if="qsInstanceId[activeAppType]">
-                    <div style="width:1px;background:#21262d;margin:0 4px;align-self:stretch"></div>
+                    <div style="width:1px;background:var(--bg-muted);margin:0 4px;align-self:stretch"></div>
                   </template>
                   <template x-if="qsInstanceId[activeAppType] && !isQSCustom(activeAppType, qs.quality)">
                     <div class="qs-col" :style="qsCellStyle(activeAppType, qs, 'min')"
@@ -128,24 +128,24 @@
                   <!-- Custom mode: inline editable inputs replacing the read-only values -->
                   <template x-if="qsInstanceId[activeAppType] && isQSCustom(activeAppType, qs.quality)">
                     <input class="input" type="number" step="0.1" min="0"
-                           style="width:55px;padding:2px 4px;font-size:13px;font-family:'SF Mono',Monaco,monospace;text-align:right;background:#1c2129;border-color:#d29922"
+                           style="width:55px;padding:2px 4px;font-size:13px;font-family:'SF Mono',Monaco,monospace;text-align:right;background:var(--bg-elevated-hover);border-color:var(--accent-orange)"
                            :value="getQSOverrideVal(activeAppType, qs.quality, 'min', qs.min)"
                            @input="setQSOverrideVal(activeAppType, qs.quality, 'min', parseFloat($event.target.value))">
                   </template>
                   <template x-if="qsInstanceId[activeAppType] && isQSCustom(activeAppType, qs.quality)">
                     <input class="input" type="number" step="0.1" min="0"
-                           style="width:55px;padding:2px 4px;font-size:13px;font-family:'SF Mono',Monaco,monospace;text-align:right;background:#1c2129;border-color:#d29922"
+                           style="width:55px;padding:2px 4px;font-size:13px;font-family:'SF Mono',Monaco,monospace;text-align:right;background:var(--bg-elevated-hover);border-color:var(--accent-orange)"
                            :value="getQSOverrideVal(activeAppType, qs.quality, 'preferred', qs.preferred)"
                            @input="setQSOverrideVal(activeAppType, qs.quality, 'preferred', parseFloat($event.target.value))">
                   </template>
                   <template x-if="qsInstanceId[activeAppType] && isQSCustom(activeAppType, qs.quality)">
                     <input class="input" type="number" step="0.1" min="0"
-                           style="width:55px;padding:2px 4px;font-size:13px;font-family:'SF Mono',Monaco,monospace;text-align:right;background:#1c2129;border-color:#d29922"
+                           style="width:55px;padding:2px 4px;font-size:13px;font-family:'SF Mono',Monaco,monospace;text-align:right;background:var(--bg-elevated-hover);border-color:var(--accent-orange)"
                            :value="getQSOverrideVal(activeAppType, qs.quality, 'max', qs.max)"
                            @input="setQSOverrideVal(activeAppType, qs.quality, 'max', parseFloat($event.target.value))">
                   </template>
                   <template x-if="qsInstanceId[activeAppType]">
-                    <div style="width:1px;background:#21262d;margin:0 4px;align-self:stretch"></div>
+                    <div style="width:1px;background:var(--bg-muted);margin:0 4px;align-self:stretch"></div>
                   </template>
                   <template x-if="qsInstanceId[activeAppType]">
                     <div style="width:58px;flex-shrink:0;text-align:center">
@@ -172,8 +172,8 @@
             <!-- Change summary -->
             <div style="padding:8px 20px 12px;font-size:13px"
                  x-show="qsInstanceId[activeAppType] && qsInstanceDefs[activeAppType]">
-              <span style="color:#3fb950" x-show="qsChangeCount(activeAppType) === 0">All Auto-mode qualities match TRaSH</span>
-              <span style="color:#d29922" x-show="qsChangeCount(activeAppType) > 0"
+              <span style="color:var(--accent-green)" x-show="qsChangeCount(activeAppType) === 0">All Auto-mode qualities match TRaSH</span>
+              <span style="color:var(--accent-orange)" x-show="qsChangeCount(activeAppType) > 0"
                     x-text="qsChangeCount(activeAppType) + ' qualities differ from TRaSH — click Sync Now per row or enable Auto-sync'"></span>
             </div>
           </div>

--- a/ui/static/partials/sections/scoring.html
+++ b/ui/static/partials/sections/scoring.html
@@ -159,7 +159,7 @@
                     <span style="font-size:12px;color:var(--text-muted);margin-left:6px">&#9662;</span>
                   </button>
                   <div x-show="sandbox[activeAppType].indexerDropdown" x-cloak
-                    style="position:absolute;top:100%;right:0;margin-top:4px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:6px;padding:4px 0;min-width:200px;max-height:250px;overflow-y:auto;z-index:50;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
+                    style="position:absolute;top:100%;right:0;margin-top:4px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:6px;padding:4px 0;min-width:200px;max-height:250px;overflow-y:auto;z-index:50;box-shadow:0 8px 24px var(--alpha-shadow)">
                     <div style="padding:4px 10px;font-size:13px;color:var(--text-muted);border-bottom:1px solid var(--bg-muted);margin-bottom:2px;display:flex;justify-content:space-between">
                       <span>Filter indexers</span>
                       <a style="color:var(--accent-blue);cursor:pointer" @click="sandboxToggleAllIndexers(activeAppType)"

--- a/ui/static/partials/sections/scoring.html
+++ b/ui/static/partials/sections/scoring.html
@@ -352,7 +352,7 @@
                 <template x-for="(res, idx) in visibleSandboxResults(activeAppType)" :key="res._sid">
                   <tbody>
                     <tr :draggable="!sandbox[activeAppType].filterToSelected"
-                        @dragstart="if (!sandbox[activeAppType].filterToSelected) sandboxDragStart(activeAppType, res)"
+                        @dragstart="if (!sandbox[activeAppType].filterToSelected) { event.dataTransfer.setData('text/plain', ''); sandboxDragStart(activeAppType, res); }"
                         @dragover.prevent="if (!sandbox[activeAppType].filterToSelected) sandboxDragOver(activeAppType, res)"
                         @drop.prevent="if (!sandbox[activeAppType].filterToSelected) sandboxDrop(activeAppType, res)"
                         @dragend="sandbox[activeAppType].dragSrc = null; sandbox[activeAppType].dragOver = null"

--- a/ui/static/partials/sections/scoring.html
+++ b/ui/static/partials/sections/scoring.html
@@ -2,18 +2,18 @@
       <!-- ===== Scoring Sandbox sub-tab ===== -->
       <div class="page" x-show="currentSection === 'scoring' || (currentSection === 'advanced' && advancedTab === 'scoring')" style="max-width:none">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Scoring Sandbox</div>
-        <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">Test how releases score against your profiles. Paste a release name or search Prowlarr, then see which Custom Formats match and the total score.</div>
+        <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">Test how releases score against your profiles. Paste a release name or search Prowlarr, then see which Custom Formats match and the total score.</div>
 
         <div style="padding:20px">
           <!-- App type + Instance selector for CF matching -->
           <div style="display:flex;gap:12px;align-items:center;margin-bottom:16px;flex-wrap:wrap">
-            <label style="font-size:12px;color:#aaa;white-space:nowrap" x-tt="'Instance used to detect Custom Formats via the Arr Parse API'">Parse with:</label>
+            <label style="font-size:12px;color:var(--text-muted);white-space:nowrap" x-tt="'Instance used to detect Custom Formats via the Arr Parse API'">Parse with:</label>
             <select class="input" style="max-width:250px;font-size:12px" x-model="sandbox[activeAppType].instanceId" @change="sandboxInstanceChanged(activeAppType)">
               <template x-for="inst in instancesOfType(activeAppType)" :key="inst.id">
                 <option :value="inst.id" x-text="inst.name"></option>
               </template>
             </select>
-            <label style="font-size:12px;color:#aaa;white-space:nowrap;margin-left:12px" x-tt="'Profile whose CF scores are applied to calculate total'">Score against:</label>
+            <label style="font-size:12px;color:var(--text-muted);white-space:nowrap;margin-left:12px" x-tt="'Profile whose CF scores are applied to calculate total'">Score against:</label>
             <select class="input" style="max-width:300px;font-size:12px" x-model="sandbox[activeAppType].profileKey" @change="rescoreSandbox(activeAppType)">
               <option value="">— Select profile —</option>
               <template x-for="gn in getTrashProfileGroups(activeAppType)" :key="'sg:'+gn">
@@ -34,7 +34,7 @@
                 </template>
               </optgroup>
             </select>
-            <label style="font-size:12px;color:#aaa;white-space:nowrap;margin-left:12px" x-tt="'Optional second profile for side-by-side comparison'">Compare with:</label>
+            <label style="font-size:12px;color:var(--text-muted);white-space:nowrap;margin-left:12px" x-tt="'Optional second profile for side-by-side comparison'">Compare with:</label>
             <select class="input" style="max-width:300px;font-size:12px" x-model="sandbox[activeAppType].compareKey" @change="rescoreCompare(activeAppType)">
               <option value="">— None —</option>
               <template x-for="gn in getTrashProfileGroups(activeAppType)" :key="'cg:'+gn">
@@ -64,20 +64,20 @@
           </div>
 
           <!-- Quick Edit Panel -->
-          <div x-show="sandbox[activeAppType].editOpen" style="margin-bottom:16px;border:1px solid #d29922;border-radius:6px;background:#161b22;overflow:visible">
-            <div style="padding:8px 14px;background:#1c2129;display:flex;align-items:center;gap:12px;border-bottom:1px solid #30363d">
-              <span style="font-size:12px;font-weight:600;color:#d29922">Score Editor</span>
-              <span style="font-size:13px;color:#aaa">Test score changes without affecting saved profiles. All changes are temporary.</span>
+          <div x-show="sandbox[activeAppType].editOpen" style="margin-bottom:16px;border:1px solid var(--accent-orange);border-radius:6px;background:var(--bg-card);overflow:visible">
+            <div style="padding:8px 14px;background:var(--bg-elevated-hover);display:flex;align-items:center;gap:12px;border-bottom:1px solid var(--border-subtle)">
+              <span style="font-size:12px;font-weight:600;color:var(--accent-orange)">Score Editor</span>
+              <span style="font-size:13px;color:var(--text-muted)">Test score changes without affecting saved profiles. All changes are temporary.</span>
               <div style="flex:1"></div>
               <div style="display:flex;align-items:center;gap:8px">
-                <span style="font-size:13px;color:#aaa" x-tt="'Minimum total score required for a release to PASS'">Min Score:</span>
+                <span style="font-size:13px;color:var(--text-muted)" x-tt="'Minimum total score required for a release to PASS'">Min Score:</span>
                 <input type="number" class="pb-input" style="width:70px;font-size:13px"
                        :value="sandbox[activeAppType].editMinScore ?? sandbox[activeAppType].editOriginal?.minScore ?? 0"
                        @input="sandbox[activeAppType].editMinScore = parseInt($event.target.value) || 0; debounceSandboxEdit(activeAppType)">
               </div>
-              <button class="btn btn-sm" style="font-size:12px;border-color:#d29922;color:#d29922" @click="resetSandboxEdit(activeAppType)">Reset to Profile</button>
+              <button class="btn btn-sm" style="font-size:12px;border-color:var(--accent-orange);color:var(--accent-orange)" @click="resetSandboxEdit(activeAppType)">Reset to Profile</button>
             </div>
-            <div style="padding:10px 14px;column-width:250px;column-gap:24px;column-rule:1px solid #21262d">
+            <div style="padding:10px 14px;column-width:250px;column-gap:24px;column-rule:1px solid var(--bg-muted)">
               <!-- Profile CFs -->
               <template x-for="s in sandbox[activeAppType].editOriginal?.scores || []" :key="s.trashId || s.name">
                 <div style="display:flex;align-items:center;gap:6px;padding:3px 0;break-inside:avoid">
@@ -87,10 +87,10 @@
                            @change="sandbox[activeAppType].editToggles[s.trashId || s.name] = $event.target.checked; debounceSandboxEdit(activeAppType)">
                     <span class="slider"></span>
                   </label>
-                  <span style="font-size:13px;color:#c9d1d9;white-space:nowrap" x-text="s.name"></span>
+                  <span style="font-size:13px;color:var(--text-body);white-space:nowrap" x-text="s.name"></span>
                   <input type="number" class="pb-input" style="width:60px;flex-shrink:0;font-size:12px;text-align:right;font-family:monospace"
                          :value="sandbox[activeAppType].editScores[s.trashId || s.name] ?? s.score"
-                         :style="(sandbox[activeAppType].editScores[s.trashId || s.name] ?? s.score) !== s.score ? 'border-color:#d29922;color:#d29922' : ''"
+                         :style="(sandbox[activeAppType].editScores[s.trashId || s.name] ?? s.score) !== s.score ? 'border-color:var(--accent-orange);color:var(--accent-orange)' : ''"
                          @input="sandbox[activeAppType].editScores[s.trashId || s.name] = parseInt($event.target.value) || 0; debounceSandboxEdit(activeAppType)">
                 </div>
               </template>
@@ -98,17 +98,17 @@
               <template x-for="key in Object.keys(sandbox[activeAppType].editToggles).filter(k => sandbox[activeAppType].editToggles[k] === 'added')" :key="'add:'+key">
                 <div style="display:flex;align-items:center;gap:6px;padding:3px 0;break-inside:avoid">
                   <button @click="delete sandbox[activeAppType].editToggles[key]; delete sandbox[activeAppType].editScores[key]; debounceSandboxEdit(activeAppType)"
-                          style="background:none;border:none;color:#f85149;font-size:12px;cursor:pointer;padding:0 2px;flex-shrink:0;width:30px;text-align:center" x-tt="'Remove'">✕</button>
-                  <span style="font-size:13px;color:#d29922;white-space:nowrap" x-text="sandbox[activeAppType]._addedCFNames?.[key] || key"></span>
-                  <input type="number" class="pb-input" style="width:60px;flex-shrink:0;font-size:12px;text-align:right;font-family:monospace;border-color:#d29922"
+                          style="background:none;border:none;color:var(--accent-red);font-size:12px;cursor:pointer;padding:0 2px;flex-shrink:0;width:30px;text-align:center" x-tt="'Remove'">✕</button>
+                  <span style="font-size:13px;color:var(--accent-orange);white-space:nowrap" x-text="sandbox[activeAppType]._addedCFNames?.[key] || key"></span>
+                  <input type="number" class="pb-input" style="width:60px;flex-shrink:0;font-size:12px;text-align:right;font-family:monospace;border-color:var(--accent-orange)"
                          :value="sandbox[activeAppType].editScores[key] ?? 0"
                          @input="sandbox[activeAppType].editScores[key] = parseInt($event.target.value) || 0; debounceSandboxEdit(activeAppType)">
                 </div>
               </template>
             </div>
             <!-- Add CF button -->
-            <div style="padding:6px 14px;border-top:1px solid #21262d">
-              <button class="btn btn-sm" style="font-size:13px;border-color:#d29922;color:#d29922" @click="openSandboxCFBrowser(activeAppType)">+ Add Custom Formats</button>
+            <div style="padding:6px 14px;border-top:1px solid var(--bg-muted)">
+              <button class="btn btn-sm" style="font-size:13px;border-color:var(--accent-orange);color:var(--accent-orange)" @click="openSandboxCFBrowser(activeAppType)">+ Add Custom Formats</button>
             </div>
           </div>
 
@@ -120,7 +120,7 @@
                 :disabled="!config.prowlarr?.enabled">
                 Prowlarr Search
               </button>
-              <span x-show="!config.prowlarr?.enabled" style="font-size:13px;color:#aaa;align-self:center">Configure Prowlarr in Settings to enable search</span>
+              <span x-show="!config.prowlarr?.enabled" style="font-size:13px;color:var(--text-muted);align-self:center">Configure Prowlarr in Settings to enable search</span>
             </div>
 
             <!-- Paste mode -->
@@ -134,12 +134,12 @@
                   <span x-show="!sandbox[activeAppType].parsing">Parse</span>
                 </button>
               </div>
-              <div style="margin-top:6px;font-size:13px;color:#aaa">Press Enter or click Parse. Paste multiple names (one per line) using the area below.</div>
+              <div style="margin-top:6px;font-size:13px;color:var(--text-muted)">Press Enter or click Parse. Paste multiple names (one per line) using the area below.</div>
               <textarea class="input" style="width:100%;margin-top:8px;font-size:13px;font-family:monospace;min-height:60px"
                 x-show="sandbox[activeAppType].showBulk" x-model="sandbox[activeAppType].bulkInput"
                 placeholder="One release name per line..."></textarea>
               <div style="margin-top:4px">
-                <a style="font-size:13px;color:#58a6ff;cursor:pointer" @click="sandbox[activeAppType].showBulk = !sandbox[activeAppType].showBulk"
+                <a style="font-size:13px;color:var(--accent-blue);cursor:pointer" @click="sandbox[activeAppType].showBulk = !sandbox[activeAppType].showBulk"
                   x-text="sandbox[activeAppType].showBulk ? 'Hide bulk input' : 'Bulk paste (multiple releases)'"></a>
                 <button x-show="sandbox[activeAppType].showBulk && sandbox[activeAppType].bulkInput?.trim()" class="btn btn-sm" style="margin-left:8px"
                   @click="sandboxParseBulk(activeAppType)" :disabled="sandbox[activeAppType].parsing">Parse All</button>
@@ -156,20 +156,20 @@
                   <button class="btn btn-sm" style="font-size:12px;min-width:150px;text-align:left;display:flex;justify-content:space-between;align-items:center"
                     @click="sandbox[activeAppType].indexerDropdown = !sandbox[activeAppType].indexerDropdown">
                     <span x-text="sandboxIndexerLabel(activeAppType)"></span>
-                    <span style="font-size:12px;color:#aaa;margin-left:6px">&#9662;</span>
+                    <span style="font-size:12px;color:var(--text-muted);margin-left:6px">&#9662;</span>
                   </button>
                   <div x-show="sandbox[activeAppType].indexerDropdown" x-cloak
-                    style="position:absolute;top:100%;right:0;margin-top:4px;background:#161b22;border:1px solid #30363d;border-radius:6px;padding:4px 0;min-width:200px;max-height:250px;overflow-y:auto;z-index:50;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
-                    <div style="padding:4px 10px;font-size:13px;color:#aaa;border-bottom:1px solid #21262d;margin-bottom:2px;display:flex;justify-content:space-between">
+                    style="position:absolute;top:100%;right:0;margin-top:4px;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:6px;padding:4px 0;min-width:200px;max-height:250px;overflow-y:auto;z-index:50;box-shadow:0 8px 24px rgba(0,0,0,0.4)">
+                    <div style="padding:4px 10px;font-size:13px;color:var(--text-muted);border-bottom:1px solid var(--bg-muted);margin-bottom:2px;display:flex;justify-content:space-between">
                       <span>Filter indexers</span>
-                      <a style="color:#58a6ff;cursor:pointer" @click="sandboxToggleAllIndexers(activeAppType)"
+                      <a style="color:var(--accent-blue);cursor:pointer" @click="sandboxToggleAllIndexers(activeAppType)"
                         x-text="sandbox[activeAppType].selectedIndexers?.length === (sandbox[activeAppType].indexers || []).length ? 'None' : 'All'"></a>
                     </div>
                     <template x-for="idx in sandbox[activeAppType].indexers || []" :key="idx.id">
-                      <label style="display:flex;align-items:center;gap:8px;padding:4px 10px;font-size:12px;cursor:pointer;color:#c9d1d9"
-                        @mouseenter="$el.style.background='#1c2129'" @mouseleave="$el.style.background='transparent'">
+                      <label style="display:flex;align-items:center;gap:8px;padding:4px 10px;font-size:12px;cursor:pointer;color:var(--text-body)"
+                        @mouseenter="$el.style.background='var(--bg-elevated-hover)'" @mouseleave="$el.style.background='transparent'">
                         <input type="checkbox" :checked="sandbox[activeAppType].selectedIndexers?.includes(idx.id)"
-                          @change="sandboxToggleIndexer(activeAppType, idx.id)" style="accent-color:#58a6ff">
+                          @change="sandboxToggleIndexer(activeAppType, idx.id)" style="accent-color:var(--accent-blue)">
                         <span x-text="idx.name"></span>
                       </label>
                     </template>
@@ -187,11 +187,11 @@
                 <input type="text" x-model="sandbox[activeAppType].searchFilterText" placeholder="Filter results..." class="input input-sm" style="width:160px;height:28px;font-size:13px;padding:2px 8px">
                 <template x-for="res in ['2160p','1080p','720p','480p']" :key="res">
                   <button class="btn btn-sm" style="font-size:12px;padding:2px 8px;height:24px"
-                    :style="sandbox[activeAppType].searchFilterRes === res ? 'background:#238636;color:#fff;border-color:#238636' : ''"
+                    :style="sandbox[activeAppType].searchFilterRes === res ? 'background:var(--accent-green-strong);color:var(--text-on-accent);border-color:var(--accent-green-strong)' : ''"
                     @click="sandbox[activeAppType].searchFilterRes = sandbox[activeAppType].searchFilterRes === res ? '' : res"
                     x-text="res"></button>
                 </template>
-                <span style="font-size:12px;color:#aaa;margin-left:auto"
+                <span style="font-size:12px;color:var(--text-muted);margin-left:auto"
                   x-text="filteredSearchResults(activeAppType).length + '/' + sandbox[activeAppType].searchResults.length + ' shown'"></span>
                 <button class="btn btn-sm" style="font-size:12px;padding:2px 8px;height:24px"
                         @click="sandbox[activeAppType].searchResults = []; sandbox[activeAppType].searchFilterText = ''; sandbox[activeAppType].searchFilterRes = ''"
@@ -199,14 +199,14 @@
               </div>
 
               <!-- Search results -->
-              <div x-show="sandbox[activeAppType].searchResults?.length > 0" style="margin-top:6px;max-height:300px;overflow-y:auto;border:1px solid #21262d;border-radius:6px">
+              <div x-show="sandbox[activeAppType].searchResults?.length > 0" style="margin-top:6px;max-height:300px;overflow-y:auto;border:1px solid var(--bg-muted);border-radius:6px">
                 <template x-for="(rel, ri) in filteredSearchResults(activeAppType)" :key="rel.guid">
-                  <div style="display:flex;align-items:flex-start;gap:8px;padding:8px 12px;border-bottom:1px solid #21262d;font-size:12px"
+                  <div style="display:flex;align-items:flex-start;gap:8px;padding:8px 12px;border-bottom:1px solid var(--bg-muted);font-size:12px"
                     :style="ri === filteredSearchResults(activeAppType).length - 1 ? 'border-bottom:none' : ''">
                     <input type="checkbox" :checked="rel._selected" @change="rel._selected = !rel._selected" style="margin-top:3px">
                     <div style="flex:1;min-width:0">
-                      <div style="font-family:monospace;font-size:13px;word-break:break-all;color:#c9d1d9" x-text="rel.title"></div>
-                      <div style="font-size:12px;color:#aaa;margin-top:2px">
+                      <div style="font-family:monospace;font-size:13px;word-break:break-all;color:var(--text-body)" x-text="rel.title"></div>
+                      <div style="font-size:12px;color:var(--text-muted);margin-top:2px">
                         <span x-text="rel.indexer"></span> &middot;
                         <span x-text="formatBytes(rel.size)"></span> &middot;
                         <span x-text="rel.seeders + ' seeders'"></span>
@@ -220,10 +220,10 @@
                   :disabled="sandbox[activeAppType].parsing || !sandbox[activeAppType].searchResults?.some(r => r._selected)">
                   Score Selected
                 </button>
-                <span style="font-size:13px;color:#aaa"
+                <span style="font-size:13px;color:var(--text-muted)"
                   x-text="(sandbox[activeAppType].searchResults?.filter(r => r._selected)?.length || 0) + ' selected'"></span>
               </div>
-              <div x-show="sandbox[activeAppType].searchError" style="margin-top:8px;font-size:12px;color:#f85149" x-text="sandbox[activeAppType].searchError"></div>
+              <div x-show="sandbox[activeAppType].searchError" style="margin-top:8px;font-size:12px;color:var(--accent-red)" x-text="sandbox[activeAppType].searchError"></div>
             </div>
           </div>
 
@@ -234,7 +234,7 @@
                 <!-- Action buttons sit above the checkbox column so the cause/effect is visually co-located. -->
                 <div style="display:flex;gap:6px;flex-wrap:wrap">
                   <button class="btn btn-sm"
-                          :style="sandbox[activeAppType].filterToSelected ? 'background:#1f6feb;border-color:#1f6feb;color:#fff' : ''"
+                          :style="sandbox[activeAppType].filterToSelected ? 'background:var(--accent-blue-strong);border-color:var(--accent-blue-strong);color:var(--text-on-accent)' : ''"
                           :disabled="!sandbox[activeAppType].filterToSelected && sandboxSelectedCount(activeAppType) === 0"
                           @click="sandbox[activeAppType].filterToSelected = !sandbox[activeAppType].filterToSelected"
                           x-tt="sandbox[activeAppType].filterToSelected ? 'Show all releases again' : 'Hide unchecked rows'"
@@ -244,11 +244,11 @@
                           x-tt="'Uncheck all'">Reset filter</button>
                   <button class="btn btn-sm" @click="sandbox[activeAppType].results = []; saveSandboxResults(activeAppType)">Clear</button>
                 </div>
-                <div style="font-size:14px;font-weight:600;color:#c9d1d9">
+                <div style="font-size:14px;font-weight:600;color:var(--text-body)">
                   <span x-text="sandbox[activeAppType].results.length + ' Release' + (sandbox[activeAppType].results.length > 1 ? 's' : '')"></span>
-                  <span x-show="sandboxSelectedCount(activeAppType) > 0" style="font-size:12px;color:#58a6ff;font-weight:500;margin-left:6px"
+                  <span x-show="sandboxSelectedCount(activeAppType) > 0" style="font-size:12px;color:var(--accent-blue);font-weight:500;margin-left:6px"
                         x-text="'· ' + sandboxSelectedCount(activeAppType) + ' selected'"></span>
-                  <span x-show="sandbox[activeAppType].sortCol === 'manual'" style="font-size:12px;color:#a371f7;font-weight:500;margin-left:6px" x-tt="'Custom order from drag-reorder. Click a column header to resort.'">· manual order</span>
+                  <span x-show="sandbox[activeAppType].sortCol === 'manual'" style="font-size:12px;color:var(--accent-purple);font-weight:500;margin-left:6px" x-tt="'Custom order from drag-reorder. Click a column header to resort.'">· manual order</span>
                 </div>
               </div>
 
@@ -257,8 +257,8 @@
                    on the active set · selection-driven actions. Selection-driven
                    actions only appear when ≥1 row is checkbox-selected, so the
                    row stays clean when the user is just browsing. -->
-              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:12px;padding:8px 10px;background:#0d1117;border:1px solid #21262d;border-radius:6px">
-                <span style="font-size:12px;color:#aaa;font-weight:500">Score sets:</span>
+              <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:12px;padding:8px 10px;background:var(--bg-page);border:1px solid var(--bg-muted);border-radius:6px">
+                <span style="font-size:12px;color:var(--text-muted);font-weight:500">Score sets:</span>
                 <select class="input" style="height:28px;font-size:12px;padding:2px 6px;max-width:280px"
                         x-model="sandbox[activeAppType].activeScoreSet"
                         @change="sandboxSetActiveScoreSet(activeAppType, sandbox[activeAppType].activeScoreSet)"
@@ -274,7 +274,7 @@
                     <button class="btn btn-sm" style="height:28px;font-size:12px;padding:2px 8px"
                             @click="sandboxRenameScoreSet(activeAppType, sandbox[activeAppType].activeScoreSet)"
                             x-tt="'Rename the active score set'">Rename</button>
-                    <button class="btn btn-sm" style="height:28px;font-size:12px;padding:2px 8px;color:#f85149;border-color:#3d1f1f"
+                    <button class="btn btn-sm" style="height:28px;font-size:12px;padding:2px 8px;color:var(--accent-red);border-color:var(--accent-red-bg)"
                             @click="sandboxDeleteScoreSet(activeAppType, sandbox[activeAppType].activeScoreSet)"
                             x-tt="'Delete the active score set (releases stay in your results)'">Delete</button>
                   </span>
@@ -292,9 +292,9 @@
                      "N selected →" arrow can't orphan from its actions
                      when the row wraps on narrow viewports. -->
                 <span style="display:inline-flex;gap:6px;align-items:center" x-show="sandboxSelectedCount(activeAppType) > 0">
-                  <span style="font-size:12px;color:#58a6ff"
+                  <span style="font-size:12px;color:var(--accent-blue)"
                         x-text="sandboxSelectedCount(activeAppType) + ' selected →'"></span>
-                  <button class="btn btn-sm" style="height:28px;font-size:12px;padding:2px 8px;color:#d29922;border-color:#3d2f1f"
+                  <button class="btn btn-sm" style="height:28px;font-size:12px;padding:2px 8px;color:var(--accent-orange);border-color:var(--accent-orange-bg)"
                           x-show="sandbox[activeAppType].activeScoreSet"
                           @click="sandboxRemoveSelectedFromScoreSet(activeAppType)"
                           x-tt="'Remove the selected releases from this score set only — they stay in your results'">− Remove from set</button>
@@ -315,17 +315,17 @@
                    so the table goes blank. Surface a helper banner so the
                    state is obvious and the user has clear next steps. -->
               <div x-show="sandbox[activeAppType].activeScoreSet && ((sandbox[activeAppType].scoreSets || []).find(s => s.id === sandbox[activeAppType].activeScoreSet)?.titles?.length || 0) === 0"
-                   style="padding:8px 12px;background:#3d2f1f;color:#d29922;border:1px solid #3d2f1f;border-radius:6px;font-size:13px;margin-bottom:12px;line-height:1.5">
+                   style="padding:8px 12px;background:var(--accent-orange-bg);color:var(--accent-orange);border:1px solid var(--accent-orange-bg);border-radius:6px;font-size:13px;margin-bottom:12px;line-height:1.5">
                 This score set is empty. Switch to <strong>— Show all releases —</strong> above to find rows to add, or click <strong>Delete</strong> to remove the empty set.
               </div>
 
               <!-- Compact table view -->
-              <table style="width:100%;border-collapse:collapse;border:1px solid #30363d;border-radius:6px">
+              <table style="width:100%;border-collapse:collapse;border:1px solid var(--border-subtle);border-radius:6px">
                 <thead>
-                  <tr style="background:#161b22;font-size:12px;color:#aaa;text-transform:uppercase;letter-spacing:0.5px;user-select:none">
+                  <tr style="background:var(--bg-card);font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;user-select:none">
                     <th style="width:22px;padding:5px 2px 5px 6px"></th>
                     <th style="width:24px;padding:5px 2px;text-align:center">
-                      <input type="checkbox" style="accent-color:#58a6ff;cursor:pointer" x-tt="'Select/deselect all'"
+                      <input type="checkbox" style="accent-color:var(--accent-blue);cursor:pointer" x-tt="'Select/deselect all'"
                              :checked="sandbox[activeAppType].results.length > 0 && sandbox[activeAppType].results.every(r => r._selected === true)"
                              @change="toggleSandboxSelectAll(activeAppType)">
                     </th>
@@ -356,85 +356,85 @@
                         @dragover.prevent="if (!sandbox[activeAppType].filterToSelected) sandboxDragOver(activeAppType, res)"
                         @drop.prevent="if (!sandbox[activeAppType].filterToSelected) sandboxDrop(activeAppType, res)"
                         @dragend="sandbox[activeAppType].dragSrc = null; sandbox[activeAppType].dragOver = null"
-                        :style="sandbox[activeAppType].dragSrc === res ? 'opacity:0.35' : (sandbox[activeAppType].dragOver === res && sandbox[activeAppType].dragSrc && sandbox[activeAppType].dragSrc !== res ? 'box-shadow:inset 0 2px 0 #58a6ff' : '')"
-                        @mouseenter="if (sandbox[activeAppType].dragSrc !== res) $el.style.background='#1c2129'" @mouseleave="$el.style.background=''">
-                      <td style="padding:5px 2px 5px 6px;border-bottom:1px solid #21262d;text-align:center;color:#6e7681;user-select:none;font-size:12px"
+                        :style="sandbox[activeAppType].dragSrc === res ? 'opacity:0.35' : (sandbox[activeAppType].dragOver === res && sandbox[activeAppType].dragSrc && sandbox[activeAppType].dragSrc !== res ? 'box-shadow:inset 0 2px 0 var(--accent-blue)' : '')"
+                        @mouseenter="if (sandbox[activeAppType].dragSrc !== res) $el.style.background='var(--bg-elevated-hover)'" @mouseleave="$el.style.background=''">
+                      <td style="padding:5px 2px 5px 6px;border-bottom:1px solid var(--bg-muted);text-align:center;color:var(--text-muted-secondary);user-select:none;font-size:12px"
                           :style="sandbox[activeAppType].filterToSelected ? 'opacity:0.2;cursor:default' : 'cursor:grab'"
                           x-tt="sandbox[activeAppType].filterToSelected ? 'Drag disabled while filtering' : 'Drag to reorder'">⋮⋮</td>
-                      <td style="padding:5px 2px;border-bottom:1px solid #21262d;text-align:center" @click.stop>
-                        <input type="checkbox" style="accent-color:#58a6ff;cursor:pointer"
+                      <td style="padding:5px 2px;border-bottom:1px solid var(--bg-muted);text-align:center" @click.stop>
+                        <input type="checkbox" style="accent-color:var(--accent-blue);cursor:pointer"
                                :checked="res._selected === true"
                                @change="res._selected = $event.target.checked">
                       </td>
-                      <td style="padding:5px 2px;border-bottom:1px solid #21262d;text-align:center" @click.stop>
+                      <td style="padding:5px 2px;border-bottom:1px solid var(--bg-muted);text-align:center" @click.stop>
                         <button @click.stop="openSandboxCopy(activeAppType, res)" x-tt="'Show release details for copying'"
-                          style="background:none;border:none;color:#8b949e;font-size:12px;cursor:pointer;padding:0 4px;line-height:1"
-                          @mouseenter="$el.style.color='#58a6ff'" @mouseleave="$el.style.color='#8b949e'">⧉</button>
+                          style="background:none;border:none;color:var(--text-secondary);font-size:12px;cursor:pointer;padding:0 4px;line-height:1"
+                          @mouseenter="$el.style.color='var(--accent-blue)'" @mouseleave="$el.style.color='var(--text-secondary)'">⧉</button>
                       </td>
-                      <td style="padding:5px 6px;border-bottom:1px solid #21262d;font-family:monospace;font-size:12px;color:#c9d1d9;word-break:break-all;line-height:1.4" x-text="res.title"></td>
-                      <td style="padding:5px 4px;border-bottom:1px solid #21262d;font-size:12px;line-height:1.5;white-space:normal;word-break:keep-all">
+                      <td style="padding:5px 6px;border-bottom:1px solid var(--bg-muted);font-family:monospace;font-size:12px;color:var(--text-body);word-break:break-all;line-height:1.4" x-text="res.title"></td>
+                      <td style="padding:5px 4px;border-bottom:1px solid var(--bg-muted);font-size:12px;line-height:1.5;white-space:normal;word-break:keep-all">
                         <template x-for="(b, bi) in res.scoring?.breakdown?.filter(x => x.matched) || []" :key="b.name">
                           <span style="display:inline-block;margin-right:4px">
-                            <span x-show="bi > 0" style="color:#30363d;margin-right:4px">·</span>
-                            <span style="color:#aaa" x-text="b.name"></span>
+                            <span x-show="bi > 0" style="color:var(--border-subtle);margin-right:4px">·</span>
+                            <span style="color:var(--text-muted)" x-text="b.name"></span>
                             <span style="font-family:monospace;font-size:11px;font-weight:600;margin-left:2px"
-                                  :style="b.score > 0 ? 'color:#3fb950' : b.score < 0 ? 'color:#f85149' : 'color:#aaa'"
+                                  :style="b.score > 0 ? 'color:var(--accent-green)' : b.score < 0 ? 'color:var(--accent-red)' : 'color:var(--text-muted)'"
                                   x-text="b.score !== 0 ? ((b.score > 0 ? '+' : '') + b.score) : '0'"></span>
                           </span>
                         </template>
                       </td>
-                      <td style="padding:5px 4px;border-bottom:1px solid #21262d;text-align:center;white-space:nowrap">
+                      <td style="padding:5px 4px;border-bottom:1px solid var(--bg-muted);text-align:center;white-space:nowrap">
                         <span style="font-size:11px;padding:1px 5px;border-radius:3px;font-weight:500"
-                              :style="sandboxQualityAllowed(res, activeAppType, sandbox[activeAppType].profileKey) === false ? 'background:#3d1f1f;color:#f85149;text-decoration:line-through;text-decoration-thickness:1px' : 'background:#1c2128;color:#aaa'"
+                              :style="sandboxQualityAllowed(res, activeAppType, sandbox[activeAppType].profileKey) === false ? 'background:var(--accent-red-bg);color:var(--accent-red);text-decoration:line-through;text-decoration-thickness:1px' : 'background:var(--bg-elevated);color:var(--text-muted)'"
                               x-tt="sandboxQualityAllowed(res, activeAppType, sandbox[activeAppType].profileKey) === false ? 'Quality not allowed by selected profile — Sonarr/Radarr would reject this release' : ''"
                               x-text="res.parsed?.quality || '—'"></span>
                       </td>
-                      <td style="padding:5px 4px;border-bottom:1px solid #21262d;text-align:center;font-size:12px;color:#aaa;white-space:nowrap" x-text="res.parsed?.releaseGroup || '—'"></td>
-                      <td style="padding:5px 4px;border-bottom:1px solid #21262d;text-align:right;font-family:monospace;font-size:12px;font-weight:600;white-space:nowrap"
-                          :style="(res.scoring?.total ?? 0) >= 0 ? 'color:#3fb950' : 'color:#f85149'"
+                      <td style="padding:5px 4px;border-bottom:1px solid var(--bg-muted);text-align:center;font-size:12px;color:var(--text-muted);white-space:nowrap" x-text="res.parsed?.releaseGroup || '—'"></td>
+                      <td style="padding:5px 4px;border-bottom:1px solid var(--bg-muted);text-align:right;font-family:monospace;font-size:12px;font-weight:600;white-space:nowrap"
+                          :style="(res.scoring?.total ?? 0) >= 0 ? 'color:var(--accent-green)' : 'color:var(--accent-red)'"
                           x-text="res.scoring?.total ?? '—'"></td>
-                      <td style="padding:5px 4px;border-bottom:1px solid #21262d;text-align:center;white-space:nowrap">
+                      <td style="padding:5px 4px;border-bottom:1px solid var(--bg-muted);text-align:center;white-space:nowrap">
                         <span style="font-size:11px;font-weight:600;padding:1px 5px;border-radius:3px"
-                              :style="sandboxResultStatus(res, res.scoring, activeAppType).pass ? 'color:#3fb950;background:#0f2d1a' : 'color:#f85149;background:#3d1f1f'"
+                              :style="sandboxResultStatus(res, res.scoring, activeAppType).pass ? 'color:var(--accent-green);background:var(--fill-green-soft)' : 'color:var(--accent-red);background:var(--accent-red-bg)'"
                               x-tt="sandboxResultStatus(res, res.scoring, activeAppType).reason || 'Score reaches Min and quality is allowed by the profile'"
                               x-text="sandboxResultStatus(res, res.scoring, activeAppType).pass ? 'PASS' : 'FAIL'"></span>
                       </td>
-                      <td style="padding:5px 2px;border-bottom:1px solid #21262d;text-align:center;white-space:nowrap">
+                      <td style="padding:5px 2px;border-bottom:1px solid var(--bg-muted);text-align:center;white-space:nowrap">
                         <button @click.stop="sandbox[activeAppType].results.splice(sandbox[activeAppType].results.indexOf(res), 1); saveSandboxResults(activeAppType)" x-tt="'Remove from results (deletes the row entirely — does not affect score sets)'"
-                          style="background:none;border:none;color:#aaa;font-size:13px;cursor:pointer;padding:0 4px;line-height:1"
-                          @mouseenter="$el.style.color='#f85149'" @mouseleave="$el.style.color='#8b949e'">&times;</button>
+                          style="background:none;border:none;color:var(--text-muted);font-size:13px;cursor:pointer;padding:0 4px;line-height:1"
+                          @mouseenter="$el.style.color='var(--accent-red)'" @mouseleave="$el.style.color='var(--text-secondary)'">&times;</button>
                       </td>
                     </tr>
                     <!-- Compare profile row -->
-                    <tr x-show="sandbox[activeAppType].compareKey && res.scoringB" style="background:#0d1117">
-                      <td style="padding:3px 2px 3px 6px;border-bottom:1px solid #30363d"></td>
-                      <td style="padding:3px 2px;border-bottom:1px solid #30363d"></td>
-                      <td style="padding:3px 2px;border-bottom:1px solid #30363d"></td>
-                      <td style="padding:3px 6px 3px 18px;border-bottom:1px solid #30363d;white-space:nowrap;font-size:11px;color:#58a6ff" x-text="'↳ ' + (sandboxCompareProfileName(activeAppType) || 'Compare')"></td>
-                      <td style="padding:3px 4px;border-bottom:1px solid #30363d;font-size:12px;line-height:1.5;white-space:normal;word-break:keep-all">
+                    <tr x-show="sandbox[activeAppType].compareKey && res.scoringB" style="background:var(--bg-page)">
+                      <td style="padding:3px 2px 3px 6px;border-bottom:1px solid var(--border-subtle)"></td>
+                      <td style="padding:3px 2px;border-bottom:1px solid var(--border-subtle)"></td>
+                      <td style="padding:3px 2px;border-bottom:1px solid var(--border-subtle)"></td>
+                      <td style="padding:3px 6px 3px 18px;border-bottom:1px solid var(--border-subtle);white-space:nowrap;font-size:11px;color:var(--accent-blue)" x-text="'↳ ' + (sandboxCompareProfileName(activeAppType) || 'Compare')"></td>
+                      <td style="padding:3px 4px;border-bottom:1px solid var(--border-subtle);font-size:12px;line-height:1.5;white-space:normal;word-break:keep-all">
                         <template x-for="(b, bi) in res.scoringB?.breakdown?.filter(x => x.matched) || []" :key="'b'+b.name">
                           <span style="display:inline-block;margin-right:4px">
-                            <span x-show="bi > 0" style="color:#30363d;margin-right:4px">·</span>
-                            <span style="color:#aaa" x-text="b.name"></span>
+                            <span x-show="bi > 0" style="color:var(--border-subtle);margin-right:4px">·</span>
+                            <span style="color:var(--text-muted)" x-text="b.name"></span>
                             <span style="font-family:monospace;font-size:11px;font-weight:600;margin-left:2px"
-                                  :style="b.score > 0 ? 'color:#3fb950' : b.score < 0 ? 'color:#f85149' : 'color:#aaa'"
+                                  :style="b.score > 0 ? 'color:var(--accent-green)' : b.score < 0 ? 'color:var(--accent-red)' : 'color:var(--text-muted)'"
                                   x-text="b.score !== 0 ? ((b.score > 0 ? '+' : '') + b.score) : '0'"></span>
                           </span>
                         </template>
                       </td>
-                      <td style="padding:3px 4px;border-bottom:1px solid #30363d"></td>
-                      <td style="padding:3px 4px;border-bottom:1px solid #30363d"></td>
-                      <td style="padding:3px 4px;border-bottom:1px solid #30363d;text-align:right;font-family:monospace;font-size:12px;font-weight:600;white-space:nowrap"
-                          :style="(res.scoringB?.total ?? 0) >= 0 ? 'color:#3fb950' : 'color:#f85149'"
+                      <td style="padding:3px 4px;border-bottom:1px solid var(--border-subtle)"></td>
+                      <td style="padding:3px 4px;border-bottom:1px solid var(--border-subtle)"></td>
+                      <td style="padding:3px 4px;border-bottom:1px solid var(--border-subtle);text-align:right;font-family:monospace;font-size:12px;font-weight:600;white-space:nowrap"
+                          :style="(res.scoringB?.total ?? 0) >= 0 ? 'color:var(--accent-green)' : 'color:var(--accent-red)'"
                           x-text="res.scoringB?.total ?? '—'"></td>
-                      <td style="padding:3px 4px;border-bottom:1px solid #30363d;text-align:center;white-space:nowrap">
+                      <td style="padding:3px 4px;border-bottom:1px solid var(--border-subtle);text-align:center;white-space:nowrap">
                         <span style="font-size:11px;font-weight:600;padding:1px 5px;border-radius:3px"
-                              :style="sandboxResultStatus(res, res.scoringB, activeAppType, sandbox[activeAppType].compareKey).pass ? 'color:#3fb950;background:#0f2d1a' : 'color:#f85149;background:#3d1f1f'"
+                              :style="sandboxResultStatus(res, res.scoringB, activeAppType, sandbox[activeAppType].compareKey).pass ? 'color:var(--accent-green);background:var(--fill-green-soft)' : 'color:var(--accent-red);background:var(--accent-red-bg)'"
                               x-tt="sandboxResultStatus(res, res.scoringB, activeAppType, sandbox[activeAppType].compareKey).reason || 'Score reaches Min and quality is allowed by the compare profile'"
                               x-text="sandboxResultStatus(res, res.scoringB, activeAppType, sandbox[activeAppType].compareKey).pass ? 'PASS' : 'FAIL'"></span>
                       </td>
-                      <td style="padding:4px 4px;border-bottom:1px solid #30363d;text-align:center;font-size:12px;font-family:monospace;white-space:nowrap"
-                          :style="((res.scoringB?.total ?? 0) - (res.scoring?.total ?? 0)) > 0 ? 'color:#3fb950' : ((res.scoringB?.total ?? 0) - (res.scoring?.total ?? 0)) < 0 ? 'color:#f85149' : 'color:#aaa'"
+                      <td style="padding:4px 4px;border-bottom:1px solid var(--border-subtle);text-align:center;font-size:12px;font-family:monospace;white-space:nowrap"
+                          :style="((res.scoringB?.total ?? 0) - (res.scoring?.total ?? 0)) > 0 ? 'color:var(--accent-green)' : ((res.scoringB?.total ?? 0) - (res.scoring?.total ?? 0)) < 0 ? 'color:var(--accent-red)' : 'color:var(--text-muted)'"
                           x-text="((res.scoringB?.total ?? 0) - (res.scoring?.total ?? 0)) > 0 ? '+' + ((res.scoringB?.total ?? 0) - (res.scoring?.total ?? 0)) : ((res.scoringB?.total ?? 0) - (res.scoring?.total ?? 0))"></td>
                     </tr>
                   </tbody>
@@ -444,7 +444,7 @@
           </template>
 
           <!-- Empty state -->
-          <div x-show="!sandbox[activeAppType].results?.length && !sandbox[activeAppType].parsing" style="text-align:center;padding:40px;color:#aaa;font-size:13px">
+          <div x-show="!sandbox[activeAppType].results?.length && !sandbox[activeAppType].parsing" style="text-align:center;padding:40px;color:var(--text-muted);font-size:13px">
             Paste a release name or search Prowlarr to see how it scores.
           </div>
         </div>

--- a/ui/static/partials/sections/settings.html
+++ b/ui/static/partials/sections/settings.html
@@ -201,15 +201,27 @@
           <div class="settings-section-title">Display</div>
           <div class="settings-section-desc">UI appearance settings.</div>
           <div class="setting-row">
+            <div class="setting-label">Theme</div>
+            <div class="setting-value" style="display:flex;align-items:center;gap:12px">
+              <template x-for="opt in [{label:'System',value:'system'},{label:'Light',value:'light'},{label:'Dark',value:'dark'}]" :key="opt.value">
+                <label style="display:flex;align-items:center;gap:5px;cursor:pointer;font-size:13px">
+                  <input type="radio" name="theme" :value="opt.value" :checked="theme === opt.value" @change="setTheme(opt.value)" style="accent-color:var(--accent-blue)">
+                  <span x-text="opt.label" :style="theme === opt.value ? 'color:var(--text-primary)' : 'color:var(--text-muted)'"></span>
+                </label>
+              </template>
+              <span style="font-size:13px;color:var(--text-secondary)" x-text="theme === 'system' ? '(matches OS)' : ''"></span>
+            </div>
+          </div>
+          <div class="setting-row">
             <div class="setting-label">UI Scale</div>
             <div class="setting-value" style="display:flex;align-items:center;gap:12px">
               <template x-for="opt in [{label:'Compact',value:'1'},{label:'Default',value:'1.1'},{label:'Large',value:'1.2'}]" :key="opt.value">
                 <label style="display:flex;align-items:center;gap:5px;cursor:pointer;font-size:13px">
-                  <input type="radio" name="uiScale" :value="opt.value" :checked="uiScale === opt.value" @change="setUIScale(opt.value)" style="accent-color:#58a6ff">
-                  <span x-text="opt.label" :style="uiScale === opt.value ? 'color:#e1e4e8' : 'color:#aaa'"></span>
+                  <input type="radio" name="uiScale" :value="opt.value" :checked="uiScale === opt.value" @change="setUIScale(opt.value)" style="accent-color:var(--accent-blue)">
+                  <span x-text="opt.label" :style="uiScale === opt.value ? 'color:var(--text-primary)' : 'color:var(--text-muted)'"></span>
                 </label>
               </template>
-              <span style="font-size:13px;color:#8b949e" x-text="uiScale === '1' ? '(current default)' : Math.round(parseFloat(uiScale) * 100) + '%'"></span>
+              <span style="font-size:13px;color:var(--text-secondary)" x-text="uiScale === '1' ? '(current default)' : Math.round(parseFloat(uiScale) * 100) + '%'"></span>
             </div>
           </div>
         </div>

--- a/ui/static/partials/sections/settings.html
+++ b/ui/static/partials/sections/settings.html
@@ -2,7 +2,7 @@
   <!-- ==================== SETTINGS PAGE ==================== -->
   <div class="page" x-show="currentSection === 'settings'" x-cloak>
     <div style="font-size:18px;font-weight:600;margin-bottom:4px">Settings</div>
-    <div style="font-size:14px;color:#aaa;margin-bottom:16px;line-height:1.5">Configure Clonarr — instances, TRaSH repository, Prowlarr, notifications, and display.</div>
+    <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">Configure Clonarr — instances, TRaSH repository, Prowlarr, notifications, and display.</div>
 
     <div class="settings-layout">
       <!-- Sidebar nav -->
@@ -29,25 +29,25 @@
             <button class="btn btn-sm btn-primary" @click="openInstanceModal()">+ Add Instance</button>
           </div>
           <template x-if="instances.length === 0">
-            <div style="color:#aaa;font-size:13px;padding:8px 0">No instances configured. Add your first Radarr or Sonarr instance.</div>
+            <div style="color:var(--text-muted);font-size:13px;padding:8px 0">No instances configured. Add your first Radarr or Sonarr instance.</div>
           </template>
           <template x-for="inst in [...instances].sort((a, b) => a.type.localeCompare(b.type) || a.name.localeCompare(b.name))" :key="inst.id">
             <div class="inst-row">
               <img class="inst-icon" :src="instanceIconUrl(inst)" :alt="inst.type">
               <div style="font-size:13px;font-weight:500;min-width:80px" x-text="inst.name"></div>
-              <div style="font-size:13px;color:#aaa;margin-left:4px" x-text="inst.url"></div>
+              <div style="font-size:13px;color:var(--text-muted);margin-left:4px" x-text="inst.url"></div>
               <div style="margin-left:auto;text-align:right;white-space:nowrap">
                 <template x-if="instanceStatus[inst.id] === 'testing'">
                   <span class="status-testing"><span class="spinner"></span></span>
                 </template>
                 <template x-if="instanceStatus[inst.id] === 'connected'">
-                  <span class="status-connected">Connected<span x-show="instanceVersion[inst.id]" style="color:#aaa;font-weight:400;font-size:13px" x-text="' · v' + instanceVersion[inst.id]"></span></span>
+                  <span class="status-connected">Connected<span x-show="instanceVersion[inst.id]" style="color:var(--text-muted);font-weight:400;font-size:13px" x-text="' · v' + instanceVersion[inst.id]"></span></span>
                 </template>
                 <template x-if="instanceStatus[inst.id] === 'failed'">
                   <span class="status-failed">Failed</span>
                 </template>
                 <template x-if="!instanceStatus[inst.id]">
-                  <span style="font-size:12px;color:#aaa">Not tested</span>
+                  <span style="font-size:12px;color:var(--text-muted)">Not tested</span>
                 </template>
               </div>
               <button class="btn btn-sm" style="margin-left:8px" @click="testInstance(inst)">Test</button>
@@ -81,7 +81,7 @@
                   <option :value="opt.value" x-text="opt.label"></option>
                 </template>
               </select>
-              <span style="font-size:12px;color:#aaa">Auto-pull TRaSH data at this interval</span>
+              <span style="font-size:12px;color:var(--text-muted)">Auto-pull TRaSH data at this interval</span>
             </div>
           </div>
           <div class="setting-row">
@@ -89,13 +89,13 @@
             <div class="setting-value" style="font-size:13px">
               <template x-if="trashStatus.cloned">
                 <span>
-                  Commit <code x-text="trashStatus.commitHash" style="background:#21262d;padding:2px 6px;border-radius:4px;font-size:12px"></code>
+                  Commit <code x-text="trashStatus.commitHash" style="background:var(--bg-muted);padding:2px 6px;border-radius:4px;font-size:12px"></code>
                   — Radarr: <span x-text="trashStatus.radarrCFs"></span> CFs, <span x-text="trashStatus.radarrProfiles"></span> profiles
                   — Sonarr: <span x-text="trashStatus.sonarrCFs"></span> CFs, <span x-text="trashStatus.sonarrProfiles"></span> profiles
                 </span>
               </template>
               <template x-if="!trashStatus.cloned">
-                <span style="color:#aaa">Not cloned yet. Click Pull in the nav bar.</span>
+                <span style="color:var(--text-muted)">Not cloned yet. Click Pull in the nav bar.</span>
               </template>
             </div>
           </div>
@@ -109,7 +109,7 @@
             <div class="setting-label">Connection</div>
             <div class="setting-value" style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
               <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-                <input type="checkbox" x-model="config.prowlarr.enabled" @change="saveConfig(['prowlarr'])" style="accent-color:#58a6ff">
+                <input type="checkbox" x-model="config.prowlarr.enabled" @change="saveConfig(['prowlarr'])" style="accent-color:var(--accent-blue)">
               </label>
               <input class="input" style="width:250px" x-model="config.prowlarr.url" @change="saveConfig(['prowlarr'])" placeholder="http://prowlarr:9696" autocomplete="one-time-code">
               <input class="input" style="width:250px" x-model="config.prowlarr.apiKey" @change="saveConfig(['prowlarr'])" placeholder="API key" autocomplete="one-time-code">
@@ -118,8 +118,8 @@
                 <span x-show="!prowlarrTesting">Test</span>
               </button>
               <span x-show="prowlarrTestResult" style="font-size:12px">
-                <span :style="prowlarrTestResult?.ok ? 'color:#3fb950' : 'color:#f85149'" x-text="prowlarrTestResult?.message"></span>
-                <span x-show="prowlarrTestResult?.version" style="color:#aaa;font-size:13px" x-text="' · v' + prowlarrTestResult?.version"></span>
+                <span :style="prowlarrTestResult?.ok ? 'color:var(--accent-green)' : 'color:var(--accent-red)'" x-text="prowlarrTestResult?.message"></span>
+                <span x-show="prowlarrTestResult?.version" style="color:var(--text-muted);font-size:13px" x-text="' · v' + prowlarrTestResult?.version"></span>
               </span>
             </div>
           </div>
@@ -130,7 +130,7 @@
                      :value="(config.prowlarr.radarrCategories || []).join(', ')"
                      @change="config.prowlarr.radarrCategories = parseCategoryList($event.target.value); saveConfig(['prowlarr'])"
                      placeholder="2000 (default)">
-              <span style="font-size:12px;color:#8b949e">Category IDs for movie searches</span>
+              <span style="font-size:12px;color:var(--text-secondary)">Category IDs for movie searches</span>
             </div>
           </div>
           <div class="setting-row">
@@ -140,11 +140,11 @@
                      :value="(config.prowlarr.sonarrCategories || []).join(', ')"
                      @change="config.prowlarr.sonarrCategories = parseCategoryList($event.target.value); saveConfig(['prowlarr'])"
                      placeholder="5000 (default)">
-              <span style="font-size:12px;color:#8b949e">Category IDs for TV searches</span>
+              <span style="font-size:12px;color:var(--text-secondary)">Category IDs for TV searches</span>
             </div>
           </div>
-          <div style="font-size:12px;color:#8b949e;margin-top:8px;padding-top:8px;border-top:1px solid #21262d;line-height:1.5">
-            Leave blank for defaults. Add sub-IDs (e.g. <code style="background:#21262d;padding:1px 4px;border-radius:2px;color:#c9d1d9">2000, 2040, 2045</code>) if your indexer only tags specific sub-categories and root-only searches return no results.
+          <div style="font-size:12px;color:var(--text-secondary);margin-top:8px;padding-top:8px;border-top:1px solid var(--bg-muted);line-height:1.5">
+            Leave blank for defaults. Add sub-IDs (e.g. <code style="background:var(--bg-muted);padding:1px 4px;border-radius:2px;color:var(--text-body)">2000, 2040, 2045</code>) if your indexer only tags specific sub-categories and root-only searches return no results.
           </div>
         </div>
 
@@ -159,18 +159,18 @@
               @click="openAgentModal()">+ Add notification agent</button>
           </div>
           <template x-if="notificationAgents.length === 0">
-            <div style="color:#aaa;font-size:13px;padding:8px 0">No notification agents configured. Add Discord, Gotify, or Pushover to receive auto-sync alerts.</div>
+            <div style="color:var(--text-muted);font-size:13px;padding:8px 0">No notification agents configured. Add Discord, Gotify, or Pushover to receive auto-sync alerts.</div>
           </template>
           <template x-for="agent in notificationAgents" :key="agent.id">
             <div class="inst-row">
               <img class="inst-icon" :src="agentIconSrc(agent.type)" :alt="agent.type">
               <div style="font-size:13px;font-weight:500;min-width:120px" x-text="agent.name || agent.type"></div>
-              <div style="font-size:12px;color:#8b949e;text-transform:capitalize;margin-right:4px" x-text="agent.type"></div>
+              <div style="font-size:12px;color:var(--text-secondary);text-transform:capitalize;margin-right:4px" x-text="agent.type"></div>
               <!-- Enable toggle -->
-              <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:#8b949e;margin-left:4px" @click.stop>
+              <label style="display:flex;align-items:center;gap:6px;cursor:pointer;font-size:13px;color:var(--text-secondary);margin-left:4px" @click.stop>
                 <input type="checkbox" :checked="agent.enabled"
                   @change="toggleAgentEnabled(agent)"
-                  style="accent-color:#58a6ff">
+                  style="accent-color:var(--accent-blue)">
                 <span x-text="agent.enabled ? 'Enabled' : 'Disabled'"></span>
               </label>
               <!-- Test result -->
@@ -259,7 +259,7 @@
             <div class="setting-label">Trusted Networks</div>
             <div class="setting-value">
               <input type="text" class="input" placeholder="e.g. 192.168.86.0/24, 10.66.0.0/24" x-model="config.trustedNetworks" @input="configDirty = true" :disabled="authStatus.trustedNetworksLocked">
-              <div class="setting-help" x-show="authStatus.trustedNetworksLocked" x-cloak style="color:#d29922">
+              <div class="setting-help" x-show="authStatus.trustedNetworksLocked" x-cloak style="color:var(--accent-orange)">
                 <strong>Locked by <code>TRUSTED_NETWORKS</code> environment variable.</strong> To change the value, edit the Unraid template (or <code>docker-compose.yml</code>) and restart the container. Unsetting the env var unlocks this field.
               </div>
               <div class="setting-help" x-show="!authStatus.trustedNetworksLocked">
@@ -278,7 +278,7 @@
             <div class="setting-label">Trusted Proxies</div>
             <div class="setting-value">
               <input type="text" class="input" placeholder="e.g. 172.17.0.1" x-model="config.trustedProxies" @input="configDirty = true" :disabled="authStatus.trustedProxiesLocked">
-              <div class="setting-help" x-show="authStatus.trustedProxiesLocked" x-cloak style="color:#d29922">
+              <div class="setting-help" x-show="authStatus.trustedProxiesLocked" x-cloak style="color:var(--accent-orange)">
                 <strong>Locked by <code>TRUSTED_PROXIES</code> environment variable.</strong> To change the value, edit the Unraid template (or <code>docker-compose.yml</code>) and restart the container.
               </div>
               <div class="setting-help" x-show="!authStatus.trustedProxiesLocked">Only needed if Clonarr runs behind a reverse proxy (SWAG, Authelia, etc). List the proxy's IP so <code>X-Forwarded-For</code> is trusted. Leave empty for direct access. Lock via env var <code>TRUSTED_PROXIES</code> in the Unraid template for host-level control.</div>
@@ -302,11 +302,11 @@
                 <span x-show="!pwChangeSaving">Save security settings</span>
                 <span x-show="pwChangeSaving">Saving...</span>
               </button>
-              <span x-show="securitySaveMsg" x-text="securitySaveMsg" :style="securitySaveOk ? 'color:#3fb950;margin-left:10px;font-size:13px' : 'color:#f85149;margin-left:10px;font-size:13px'"></span>
+              <span x-show="securitySaveMsg" x-text="securitySaveMsg" :style="securitySaveOk ? 'color:var(--accent-green);margin-left:10px;font-size:13px' : 'color:var(--accent-red);margin-left:10px;font-size:13px'"></span>
             </div>
           </div>
 
-          <div style="border-top:1px solid #30363d;margin:20px 0"></div>
+          <div style="border-top:1px solid var(--border-subtle);margin:20px 0"></div>
 
           <!-- API Key -->
           <div class="setting-row">
@@ -332,7 +332,7 @@
             </div>
           </div>
 
-          <div style="border-top:1px solid #30363d;margin:20px 0"></div>
+          <div style="border-top:1px solid var(--border-subtle);margin:20px 0"></div>
 
           <!-- Password change -->
           <div class="settings-section-title" style="font-size:14px;margin-bottom:12px">Change password</div>
@@ -362,7 +362,7 @@
                 <span x-show="!pwChangeSaving">Change password</span>
                 <span x-show="pwChangeSaving">Saving...</span>
               </button>
-              <span x-show="pwChangeMsg" x-text="pwChangeMsg" :style="pwChangeOk ? 'color:#3fb950;margin-left:10px;font-size:13px' : 'color:#f85149;margin-left:10px;font-size:13px'"></span>
+              <span x-show="pwChangeMsg" x-text="pwChangeMsg" :style="pwChangeOk ? 'color:var(--accent-green);margin-left:10px;font-size:13px' : 'color:var(--accent-red);margin-left:10px;font-size:13px'"></span>
               <div class="setting-help">Changing your password signs out other sessions. You will remain logged in on this browser.</div>
             </div>
           </div>
@@ -377,40 +377,40 @@
             <div class="setting-value" style="display:flex;align-items:center;gap:10px">
               <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
                 <input type="checkbox" :checked="config.devMode" @change="toggleAdvancedMode($event.target.checked)">
-                <span style="font-size:13px;color:#aaa">Adds the Advanced tab (Profile Builder, Scoring Sandbox, CF Group Builder) and the Prowlarr integration settings.</span>
+                <span style="font-size:13px;color:var(--text-muted)">Adds the Advanced tab (Profile Builder, Scoring Sandbox, CF Group Builder) and the Prowlarr integration settings.</span>
               </label>
-              <span x-show="config.devMode" style="font-size:12px;color:#d29922">Active</span>
+              <span x-show="config.devMode" style="font-size:12px;color:var(--accent-orange)">Active</span>
             </div>
           </div>
           <div class="setting-row" x-show="config.devFeatures">
-            <div class="setting-label" x-tt="'Adds TRaSH schema fields (trash_id, trash_scores, group number, HTML description) to the Custom Format editor, Profile Builder, and CF Group Builder. Enable this only if you author content for the TRaSH-Guides repository or need to set TRaSH IDs manually. Consumers syncing TRaSH profiles to Arr do NOT need this.'">Show TRaSH schema fields <span style="font-size:11px;color:#7d8590;font-weight:normal">(CLONARR_DEV_FEATURES)</span></div>
+            <div class="setting-label" x-tt="'Adds TRaSH schema fields (trash_id, trash_scores, group number, HTML description) to the Custom Format editor, Profile Builder, and CF Group Builder. Enable this only if you author content for the TRaSH-Guides repository or need to set TRaSH IDs manually. Consumers syncing TRaSH profiles to Arr do NOT need this.'">Show TRaSH schema fields <span style="font-size:11px;color:var(--text-muted-secondary);font-weight:normal">(CLONARR_DEV_FEATURES)</span></div>
             <div class="setting-value" style="display:flex;align-items:center;gap:10px">
               <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
                 <input type="checkbox" :checked="config.trashSchemaFields" @change="config.trashSchemaFields = $event.target.checked; saveConfig(['trashSchemaFields'])">
-                <span style="font-size:13px;color:#aaa">Surfaces trash_id, trash_scores, group number, and HTML description fields in CF editor, Profile Builder and CF Group Builder. For TRaSH-Guides contributors only.</span>
+                <span style="font-size:13px;color:var(--text-muted)">Surfaces trash_id, trash_scores, group number, and HTML description fields in CF editor, Profile Builder and CF Group Builder. For TRaSH-Guides contributors only.</span>
               </label>
-              <span x-show="config.trashSchemaFields" style="font-size:12px;color:#d29922">Active</span>
+              <span x-show="config.trashSchemaFields" style="font-size:12px;color:var(--accent-orange)">Active</span>
             </div>
           </div>
           <div class="setting-row" x-show="authStatus.urlBase">
             <div class="setting-label">URL Base</div>
             <div class="setting-value">
               <input type="text" :value="authStatus.urlBase" disabled style="width:220px;opacity:0.7">
-              <span style="font-size:12px;color:#aaa;margin-left:8px">Set via <code>URL_BASE</code> env var. Restart to change.</span>
+              <span style="font-size:12px;color:var(--text-muted);margin-left:8px">Set via <code>URL_BASE</code> env var. Restart to change.</span>
             </div>
           </div>
           <div class="setting-row">
             <div class="setting-label">Debug Logging</div>
             <div class="setting-value" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
               <label style="display:flex;align-items:center;gap:6px;cursor:pointer">
-                <input type="checkbox" x-model="config.debugLogging" @change="saveConfig(['debugLogging'])" style="accent-color:#58a6ff">
-                <span style="font-size:12px;color:#aaa">Write to /config/debug.log (max 1MB, auto-rotates)</span>
+                <input type="checkbox" x-model="config.debugLogging" @change="saveConfig(['debugLogging'])" style="accent-color:var(--accent-blue)">
+                <span style="font-size:12px;color:var(--text-muted)">Write to /config/debug.log (max 1MB, auto-rotates)</span>
               </label>
               <template x-if="config.debugLogging">
                 <span style="display:flex;align-items:center;gap:8px;margin-left:8px">
-                  <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:#aaa"
+                  <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:var(--text-muted)"
                          x-tt="'Bundle UI navigation events (activity.log) into the download. Off by default — most bug reports only need the operation trace.'">
-                    <input type="checkbox" x-model="includeActivityLog" style="accent-color:#58a6ff">
+                    <input type="checkbox" x-model="includeActivityLog" style="accent-color:var(--accent-blue)">
                     <span>Include activity log</span>
                   </label>
                   <a class="btn btn-sm"


### PR DESCRIPTION
## Summary
- Adds a Theme control under **Settings → Display** with three options: **System** (default), **Light**, and **Dark**. System mode follows `prefers-color-scheme` and tracks OS theme changes live via a `matchMedia` listener.
- Persists the user's choice in `localStorage` (key `clonarr-theme`), per-device, mirroring the existing `uiScale` pattern. No backend/config changes — purely client-side.
- Resolves the effective theme synchronously in an inline `<head>` script to prevent flash-of-wrong-theme on load.
- Adds a `prefers-color-scheme: light` override to the server-rendered auth pages (login + first-run setup) so they match the OS theme.
- Fixes several Firefox-vs-Chromium parity bugs uncovered while testing the new theme.

## Why the diff is large
The bulk of the changes are a **token sweep**: ~914 hardcoded color literals (hex, rgba, named) across 31 partial files and 2 JS feature modules were replaced with `var(--*)` references defined in [tokens.css](ui/static/css/tokens.css). The token system was already there — it just wasn't being used outside the standalone CSS files. After the sweep, `tokens.css` is the single source of truth for color in the UI; switching themes is a matter of redefining variables in `[data-theme=]`.

## Light palette design
- Page background is a muted warm-grey (`#ebeef2`) rather than pure white — easier on the eyes. Cards stay `#ffffff` to pop against the page.
- Muted text passes WCAG AA on the new background (`--text-muted: #4d535b` ≈ 7.5:1).
- New tokens added for previously-orphaned colors: `--code-string`, `--badge-feat-bg`/`--badge-fix-bg`/`--badge-other-bg`, `--banner-warn-bg`/`--banner-warn-border`/`--banner-warn-text`, `--alpha-purple`.
- 5 unique 8-digit RGBA literals (e.g. `#f8514980`) were replaced with `color-mix(in srgb, var(--accent-*) N%, transparent)` so alpha-tinted colors adapt to whichever theme is active.

## Cross-browser parity fixes
- **UI Scale was broken in older Firefox.** [main.js](ui/static/js/main.js) and [features/profiles.js](ui/static/js/features/profiles.js) set `document.documentElement.style.zoom`. `zoom` is Chromium-original; Firefox only added it in v126 (May 2024). Now guarded with `CSS.supports('zoom', '1')` so older Firefox no-ops cleanly instead of silently failing.
- **Drag-and-drop didn't start in Firefox.** Six `@dragstart` handlers in the Profile Builder, Profile Detail, Scoring Sandbox, and CF Group Builder mutated Alpine state but never called `event.dataTransfer.setData(...)`, which Firefox requires to initiate a drag operation. All six now call it via Alpine's implicit `event`.
- **Scrollbars looked wildly different per browser.** Chromium got fat default scrollbars; Firefox got thin. [base.css](ui/static/css/base.css) now sets `scrollbar-color` and `scrollbar-width` (Firefox always; Chromium 121+, Jan 2024) so both browsers render thin themed scrollbars that flip with light/dark mode.
- **No keyboard focus rings on clickable `<div>`s.** Tab navigation gave inconsistent or invisible focus indication in both browsers. [base.css](ui/static/css/base.css) now applies a 2px `--accent-blue` outline via `:focus-visible` (keyboard-only, doesn't trigger on mouse clicks).

## Notable fixes uncovered during the sweep
- **Success toast** was previously blue background with green border and green text (mismatched) — now consistently green.
- **Warning toast text** used `--cat-hq-release-groups` (yellow), invisible on the light yellow warning background — now uses `--accent-orange`.
- **Toast box-shadow** was a hardcoded heavy black; now `var(--alpha-shadow)` (lighter in light mode).
- **TMDb info callout** on File Naming was blue text on the page background — now dark body text on `--fill-blue-soft` with a blue border-left, the standard high-contrast info-box pattern.
- **`{edition-{Edition Tags}}` code chips** were rendering with `--accent-purple-soft` set to a too-light `#c297ff` in the light palette — bumped to `#6639ba` (Primer purple-6) for proper contrast.

## Files
- New JS: theme state in [state.js](ui/static/js/state.js), `setTheme`/`applyTheme` in [features/profiles.js](ui/static/js/features/profiles.js), init wiring + scale guard in [main.js](ui/static/js/main.js).
- New UI: theme row in [partials/sections/settings.html](ui/static/partials/sections/settings.html).
- Pre-paint script + auth-page CSS overrides: [index.html](ui/static/index.html), [internal/api/auth_handlers.go](internal/api/auth_handlers.go).
- Tokens: [css/tokens.css](ui/static/css/tokens.css) (light palette + new tokens).
- Cross-browser: [css/base.css](ui/static/css/base.css) (scrollbar + focus-visible), 6 drag handlers across `partials/overlays/` and `partials/sections/`.
- Sweep: 31 partial files, [features/profiles.js](ui/static/js/features/profiles.js), [features/quality-sizes.js](ui/static/js/features/quality-sizes.js).

## Test plan
- [x] Fresh load with no localStorage entry: page renders matching OS theme. No FOUC on hard reload.
- [x] Settings → Display → toggle between System / Light / Dark. UI flips immediately, choice persists across reload.
- [x] Pick **System**, then toggle the OS theme — UI updates live without reload.
- [x] Visual sweep in light mode across: Profiles, Custom Formats, Quality Definitions, File Naming (incl. TMDb tip box and Edition Tags chips), Maintenance, Scoring Sandbox, all Settings panels, Profile Builder/Detail overlays, Sync/Backup/Restore/Confirm modals, the changelog dropdown, and toast notifications (info/warning/error variants).
- [x] Visual sweep in dark mode — confirm no regressions; the swept literals all matched dark-palette values, so dark should be visually identical to the previous version.
- [x] Auth flow in OS dark + OS light: log out, hit `/login`, and verify the page matches OS theme. Same check for the first-run setup page.
- [x] **Firefox-specific:** drag a quality item in Profile Builder, drag a search result row in Scoring Sandbox, drag a custom format in CF Group Builder. All three should start the drag (previously broken).
- [x] **Firefox-specific:** Settings → Display → UI Scale on Firefox 126+ should resize the UI; older Firefox no-ops without errors.
- [x] **Both browsers:** Tab through the UI — focus ring should appear on every interactive element (buttons, links, clickable cards, tabs, inputs). Mouse clicks should NOT show the focus ring.
- [x] **Both browsers:** scrollbars on long lists (Profiles, Custom Formats) render thin and themed in both light and dark mode.
- [x] Final grep — no remaining hardcoded color literals in `ui/static/**/*.{html,css,js}` or `internal/`:
