### PR TITLE
Fix instance Test rejecting DNS hostnames with mixed-IP resolution

### DIFF
--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -154,33 +154,50 @@ func (s *Server) handleTestInstance(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// isBlockedHost returns true if the hostname resolves to a non-routable or metadata address.
-func isBlockedHost(rawURL string) bool {
+// isBlockedHost reports whether rawURL should be rejected at validation time.
+// A host is blocked when it parses, resolves to at least one address, and
+// EVERY resolved address is non-routable. If at least one address is routable
+// the host is allowed — the dialer will pick a usable one. DNS failures pass
+// through so the connection-error path surfaces the real problem.
+func isBlockedHost(rawURL string) (bool, string) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
-		return true
+		return true, "Invalid URL"
 	}
 	host := u.Hostname()
 	if host == "" {
-		return true
+		return true, "URL has no host"
 	}
-	// Resolve hostname to IPs
 	ips, err := net.LookupHost(host)
-	if err != nil {
-		return false // allow — DNS failure will surface as connection error
+	if err != nil || len(ips) == 0 {
+		return false, "" // allow — DNS failure surfaces as connection error
 	}
+	sawAny := false
 	for _, ipStr := range ips {
 		ip := net.ParseIP(ipStr)
 		if ip == nil {
 			continue
 		}
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
-			return true
+		if v4 := ip.To4(); v4 != nil { // normalize ::ffff:1.2.3.4
+			ip = v4
 		}
-		// Block cloud metadata (169.254.169.254)
-		if ip.Equal(net.ParseIP("169.254.169.254")) {
-			return true
+		sawAny = true
+		if !isNonRoutable(ip) {
+			return false, "" // at least one routable address — allow
 		}
+	}
+	if !sawAny {
+		return false, "" // unparseable IPs only — let dialer fail
+	}
+	return true, "All resolved addresses are non-routable (loopback, link-local, or cloud-metadata)"
+}
+
+func isNonRoutable(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+		return true
+	}
+	if ip.Equal(net.ParseIP("169.254.169.254")) {
+		return true
 	}
 	return false
 }
@@ -203,8 +220,8 @@ func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
 	if !strings.HasPrefix(req.URL, "http://") && !strings.HasPrefix(req.URL, "https://") {
 		req.URL = "http://" + req.URL
 	}
-	if isBlockedHost(req.URL) {
-		writeError(w, 400, "URL resolves to a blocked address")
+	if blocked, reason := isBlockedHost(req.URL); blocked {
+		writeError(w, 400, reason)
 		return
 	}
 

--- a/internal/api/instances_test.go
+++ b/internal/api/instances_test.go
@@ -1,0 +1,39 @@
+package api
+
+import "testing"
+
+func TestIsBlockedHost(t *testing.T) {
+	cases := []struct {
+		name        string
+		url         string
+		wantBlocked bool
+	}{
+		{"loopback v4", "http://127.0.0.1/", true},
+		{"loopback v6", "http://[::1]/", true},
+		{"aws metadata", "http://169.254.169.254/", true},
+		{"link-local v4", "http://169.254.1.1/", true},
+		{"unspecified", "http://0.0.0.0/", true},
+		{"v4-mapped loopback", "http://[::ffff:127.0.0.1]/", true},
+		{"public v4", "http://1.1.1.1/", false},
+		{"public v6", "http://[2606:4700:4700::1111]/", false},
+		{"rfc1918", "http://10.0.0.5/", false},
+		{"tailscale cgnat", "http://100.99.136.67/", false},
+		{"empty", "", true},
+		{"parse error", "http://%zz/", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			blocked, reason := isBlockedHost(tc.url)
+			if blocked != tc.wantBlocked {
+				t.Errorf("isBlockedHost(%q) blocked=%v reason=%q, want blocked=%v",
+					tc.url, blocked, reason, tc.wantBlocked)
+			}
+			if blocked && reason == "" {
+				t.Errorf("isBlockedHost(%q) blocked but returned empty reason", tc.url)
+			}
+			if !blocked && reason != "" {
+				t.Errorf("isBlockedHost(%q) not blocked but returned reason %q", tc.url, reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adding a Sonarr/Radarr instance by DNS name (e.g. `http://randomaddress:8989/`) failed with **"URL resolves to a blocked address"**, while the equivalent raw IP (`http://111.22.111.22:8989/`) connected fine. This PR fixes the validation so DNS hostnames work and surfaces a clearer error when the host genuinely is unreachable.

| Before | After |
| --- | --- |
| Hostname rejected if **any** resolved IP was non-routable | Hostname rejected only if **every** resolved IP is non-routable |
| Generic "URL resolves to a blocked address" | Concrete reason ("Invalid URL", "URL has no host", or "All resolved addresses are non-routable…") |

## Root cause

`isBlockedHost` in [`internal/api/instances.go`](internal/api/instances.go) iterated `net.LookupHost` results and bailed out the moment any single IP looked non-routable:

```go
for _, ipStr := range ips {
    ...
    if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ... {
        return true   // ← whole host blocked on first bad address
    }
}
```

A DNS name on a Tailscale / dual-stack / mDNS host commonly resolves to several records — a routable IPv4 (CGNAT `100.x.y.z`, RFC1918) **plus** an IPv6 link-local or other auxiliary record. The dialer would happily pick the routable one, but this loop rejected the whole host on the link-local entry. Raw IPs worked because `LookupHost` on a literal returns just that IP.

## Threat model

Arr instances are admin-configured trusted endpoints — not user-supplied content like webhooks (those go through `netsec.SafeClient` which is unaffected). The check here is a **soft typo-guard** for obvious foot-guns (loopback, AWS metadata `169.254.169.254`), not an SSRF defense. Loosening "any-bad blocks" to "all-bad blocks" preserves the typo-guard while letting normal DNS work.

## Changes

- **`internal/api/instances.go`** — `isBlockedHost` now returns `(bool, string)`. Allows a host if at least one resolved address is routable; blocks only when every address is non-routable. Normalizes IPv4-mapped IPv6 (`::ffff:1.2.3.4`) before predicate checks. The single caller in `handleTestConnection` was updated to surface the reason directly.
- **`internal/api/instances_test.go`** — new table-driven test covering loopback (v4/v6), AWS metadata, link-local, unspecified, v4-mapped loopback, public IPs, RFC1918, Tailscale CGNAT, and parse errors.

## Scope verified

I audited every other place in the repo that touches a user-supplied URL/host/IP. `isBlockedHost` was the only offender — `TRUSTED_PROXIES`, `ResolveTrustedProxies`, instance save/update handlers, Prowlarr URL, and all notification webhook clients (Discord/Gotify/ntfy/Apprise/Pushover) already accept hostnames correctly. `ParseTrustedNetworks` and `ParseClientIP` are IP-literal-only by design (CIDRs and X-Forwarded-For).
