### PR TITLE
feat(ui): Accessibility overhaul for keyboard navigation and screen readers

### DIFF
--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -40,6 +40,10 @@ func (s *Server) handleCreateInstance(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 400, "Invalid JSON")
 		return
 	}
+	inst.Name = strings.TrimSpace(inst.Name)
+	inst.Type = strings.TrimSpace(inst.Type)
+	inst.URL = strings.TrimSpace(inst.URL)
+	inst.APIKey = strings.TrimSpace(inst.APIKey)
 
 	if inst.Name == "" || inst.URL == "" || inst.APIKey == "" {
 		writeError(w, 400, "name, url, and apiKey are required")
@@ -75,6 +79,10 @@ func (s *Server) handleUpdateInstance(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 400, "Invalid JSON")
 		return
 	}
+	inst.Name = strings.TrimSpace(inst.Name)
+	inst.Type = strings.TrimSpace(inst.Type)
+	inst.URL = strings.TrimSpace(inst.URL)
+	inst.APIKey = strings.TrimSpace(inst.APIKey)
 
 	if inst.Name == "" || inst.URL == "" {
 		writeError(w, 400, "name and url are required")
@@ -213,6 +221,8 @@ func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 400, "Invalid JSON")
 		return
 	}
+	req.URL = strings.TrimSpace(req.URL)
+	req.APIKey = strings.TrimSpace(req.APIKey)
 	if req.URL == "" || req.APIKey == "" {
 		writeError(w, 400, "url and apiKey are required")
 		return
@@ -2240,4 +2250,3 @@ func (s *Server) handleTrashNaming(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, ad.Naming)
 }
-

--- a/internal/api/instances_test.go
+++ b/internal/api/instances_test.go
@@ -1,6 +1,196 @@
 package api
 
-import "testing"
+import (
+	"bytes"
+	"clonarr/internal/core"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func instanceJSON(t *testing.T, body any) *bytes.Reader {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+	return bytes.NewReader(data)
+}
+
+func decodeInstanceResponse(t *testing.T, w *httptest.ResponseRecorder) core.Instance {
+	t.Helper()
+	var inst core.Instance
+	if err := json.NewDecoder(w.Result().Body).Decode(&inst); err != nil {
+		t.Fatalf("decode instance response: %v", err)
+	}
+	return inst
+}
+
+func TestHandleCreateInstanceTrimsAndPersists(t *testing.T) {
+	app := setupTestApp(t)
+	server := &Server{Core: app}
+	req := httptest.NewRequest(http.MethodPost, "/api/instances", instanceJSON(t, map[string]string{
+		"name":   " Radarr HD ",
+		"type":   " radarr ",
+		"url":    " http://arr.local:7878 ",
+		"apiKey": " secret-key ",
+	}))
+	w := httptest.NewRecorder()
+
+	server.handleCreateInstance(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusCreated)
+	}
+	created := decodeInstanceResponse(t, w)
+	stored, ok := app.Config.GetInstance(created.ID)
+	if !ok {
+		t.Fatalf("created instance %q not found in config", created.ID)
+	}
+	if stored.Name != "Radarr HD" || stored.Type != "radarr" || stored.URL != "http://arr.local:7878" || stored.APIKey != "secret-key" {
+		t.Fatalf("stored instance = %#v, want trimmed fields", stored)
+	}
+}
+
+func TestHandleCreateInstanceRejectsWhitespaceRequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		body map[string]string
+	}{
+		{
+			name: "name",
+			body: map[string]string{"name": "   ", "type": "radarr", "url": "http://arr.local:7878", "apiKey": "secret-key"},
+		},
+		{
+			name: "url",
+			body: map[string]string{"name": "Radarr HD", "type": "radarr", "url": "   ", "apiKey": "secret-key"},
+		},
+		{
+			name: "api key",
+			body: map[string]string{"name": "Radarr HD", "type": "radarr", "url": "http://arr.local:7878", "apiKey": "   "},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := setupTestApp(t)
+			server := &Server{Core: app}
+			req := httptest.NewRequest(http.MethodPost, "/api/instances", instanceJSON(t, tc.body))
+			w := httptest.NewRecorder()
+
+			server.handleCreateInstance(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestHandleUpdateInstanceTrimsAndPreservesWhitespaceAPIKey(t *testing.T) {
+	app := setupTestApp(t)
+	existing, err := app.Config.AddInstance(core.Instance{
+		Name:   "Old",
+		Type:   "radarr",
+		URL:    "http://old.local:7878",
+		APIKey: "saved-key",
+	})
+	if err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	server := &Server{Core: app}
+	req := httptest.NewRequest(http.MethodPut, "/api/instances/"+existing.ID, instanceJSON(t, map[string]string{
+		"name":   " Sonarr 4K ",
+		"type":   " sonarr ",
+		"url":    " http://new.local:8989 ",
+		"apiKey": "   ",
+	}))
+	req.SetPathValue("id", existing.ID)
+	w := httptest.NewRecorder()
+
+	server.handleUpdateInstance(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	stored, ok := app.Config.GetInstance(existing.ID)
+	if !ok {
+		t.Fatalf("updated instance %q not found in config", existing.ID)
+	}
+	if stored.Name != "Sonarr 4K" || stored.Type != "sonarr" || stored.URL != "http://new.local:8989" || stored.APIKey != "saved-key" {
+		t.Fatalf("stored instance = %#v, want trimmed fields with preserved API key", stored)
+	}
+}
+
+func TestHandleUpdateInstanceRejectsWhitespaceRequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		body map[string]string
+	}{
+		{
+			name: "name",
+			body: map[string]string{"name": "   ", "type": "radarr", "url": "http://arr.local:7878", "apiKey": "secret-key"},
+		},
+		{
+			name: "url",
+			body: map[string]string{"name": "Radarr HD", "type": "radarr", "url": "   ", "apiKey": "secret-key"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := setupTestApp(t)
+			existing, err := app.Config.AddInstance(core.Instance{
+				Name:   "Old",
+				Type:   "radarr",
+				URL:    "http://old.local:7878",
+				APIKey: "saved-key",
+			})
+			if err != nil {
+				t.Fatalf("seed instance: %v", err)
+			}
+			server := &Server{Core: app}
+			req := httptest.NewRequest(http.MethodPut, "/api/instances/"+existing.ID, instanceJSON(t, tc.body))
+			req.SetPathValue("id", existing.ID)
+			w := httptest.NewRecorder()
+
+			server.handleUpdateInstance(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestHandleTestConnectionRejectsWhitespaceRequiredFields(t *testing.T) {
+	cases := []struct {
+		name string
+		body map[string]string
+	}{
+		{
+			name: "url",
+			body: map[string]string{"url": "   ", "apiKey": "secret-key"},
+		},
+		{
+			name: "api key",
+			body: map[string]string{"url": "http://arr.local:7878", "apiKey": "   "},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := setupTestApp(t)
+			server := &Server{Core: app}
+			req := httptest.NewRequest(http.MethodPost, "/api/test-connection", instanceJSON(t, tc.body))
+			w := httptest.NewRecorder()
+
+			server.handleTestConnection(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
 
 func TestIsBlockedHost(t *testing.T) {
 	cases := []struct {

--- a/ui/static/css/base.css
+++ b/ui/static/css/base.css
@@ -14,3 +14,13 @@
      <div>s, buttons, links, and inputs uniformly. */
   :focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; border-radius: 2px; }
 
+  /* Skip-link: visually hidden until focused, then jumps into the top-left
+     corner. First focusable element on the page so keyboard users can skip
+     past the topnav directly to <main id="main-content">. */
+  .skip-link { position: absolute; left: -9999px; top: 0; background: var(--bg-card); color: var(--text-primary); padding: 8px 12px; border: 2px solid var(--accent-blue); border-radius: 4px; z-index: 9999; text-decoration: none; font-weight: 500; }
+  .skip-link:focus { left: 8px; top: 8px; }
+  /* Suppress the default focus outline on <main> when it receives focus
+     programmatically from the skip-link — it's a focus target, not an
+     interactive element. */
+  main:focus { outline: none; }
+

--- a/ui/static/css/base.css
+++ b/ui/static/css/base.css
@@ -19,8 +19,8 @@
      past the topnav directly to <main id="main-content">. */
   .skip-link { position: absolute; left: -9999px; top: 0; background: var(--bg-card); color: var(--text-primary); padding: 8px 12px; border: 2px solid var(--accent-blue); border-radius: 4px; z-index: 9999; text-decoration: none; font-weight: 500; }
   .skip-link:focus { left: 8px; top: 8px; }
+  .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
   /* Suppress the default focus outline on <main> when it receives focus
      programmatically from the skip-link — it's a focus target, not an
      interactive element. */
   main:focus { outline: none; }
-

--- a/ui/static/css/components.css
+++ b/ui/static/css/components.css
@@ -1,6 +1,9 @@
   /* Cards */
   .card { background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 8px; margin-bottom: 16px; overflow: hidden; }
 
+  /* Form Error */
+  .field-error { color: var(--accent-red); font-size: 12px; margin-top: 4px; }
+
   /* Instance cards */
   .instance-header { display: flex; align-items: center; padding: 16px 20px; cursor: pointer; user-select: none; }
   .instance-header:hover { background: var(--bg-elevated-hover); }

--- a/ui/static/css/components.css
+++ b/ui/static/css/components.css
@@ -43,9 +43,10 @@
   /* Settings — sidebar + content panel layout (matching vpn-gateway / PurgeBot) */
   .settings-layout { display: flex; gap: 0; min-height: 400px; background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 8px; }
   .settings-sidebar { width: 180px; flex-shrink: 0; border-right: 1px solid var(--border-subtle); padding-top: 8px; }
-  .settings-nav { display: block; padding: 10px 16px; font-size: 14px; color: var(--text-secondary); cursor: pointer; border-left: 3px solid transparent; transition: color 0.15s, background 0.15s; }
+  .settings-nav { display: block; padding: 10px 16px; font-size: 14px; color: var(--text-secondary); cursor: pointer; border-left: 3px solid transparent; transition: color 0.15s, background 0.15s; text-decoration: none; }
   .settings-nav:hover { color: var(--text-body); background: var(--alpha-hover); }
   .settings-nav-active { color: var(--text-body); border-left-color: var(--accent-green); background: var(--alpha-active); }
+  .settings-nav:focus-visible { outline-offset: -2px; }
   .settings-content { flex: 1; padding: 16px 24px; }
   .settings-section-title { font-size: 16px; font-weight: 600; color: var(--text-body); margin-bottom: 4px; }
   .settings-section-desc { font-size: 13px; color: var(--text-secondary); margin-bottom: 16px; line-height: 1.5; }

--- a/ui/static/css/components.css
+++ b/ui/static/css/components.css
@@ -32,6 +32,28 @@
   .btn-sm { padding: 4px 10px; font-size:13px; }
   .btn-icon { background:none; border:none; color:var(--text-muted); cursor:pointer; font-size:15px; padding:2px 4px; border-radius:4px; line-height:1; }
   .btn-icon:hover { color:var(--text-primary); background:var(--bg-muted); }
+  .collapse-toggle,
+  .sort-header,
+  .inline-action {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+    padding: 0;
+    text-align: left;
+  }
+  .collapse-toggle { width: 100%; }
+  .collapse-toggle:focus-visible,
+  .sort-header:focus-visible,
+  .inline-action:focus-visible,
+  .profile-group-header:focus-visible,
+  .detail-section-header:focus-visible,
+  .pb-cat-header:focus-visible,
+  .cf-section-title:focus-visible,
+  .pb-state-pill:focus-visible { outline-offset: -2px; }
+  .inline-action { display: inline-flex; align-items: center; }
+  .inline-action:hover { text-decoration: underline; }
   /* Toggle switches */
   /* .toggle styles live in the dedicated block below. Kept separate from the
      rest of reset styles to avoid breaking legacy dev/cached pages during editing. */
@@ -117,4 +139,3 @@
   .empty-state .icon { font-size: 32px; margin-bottom: 12px; }
   .empty-state .title { font-size: 16px; color: var(--text-primary); margin-bottom: 8px; }
   .empty-state .desc { font-size: 13px; }
-

--- a/ui/static/css/features/builders.css
+++ b/ui/static/css/features/builders.css
@@ -38,7 +38,7 @@
   .pb-hint { font-size:12px; color: var(--text-secondary); margin-left: 96px; }
   .pb-separator { border-top: 1px solid var(--bg-muted); margin: 2px 0; }
   /* CF category list */
-  .pb-cat-header { display: flex; align-items: center; padding: 10px 16px; cursor: pointer; user-select: none; gap: 8px; }
+  .pb-cat-header { display: flex; align-items: center; padding: 10px 16px; cursor: pointer; user-select: none; gap: 8px; border: 0; background: transparent; width: 100%; text-align: left; color: inherit; font-family: inherit; }
   .pb-group-header { display: flex; align-items: center; padding: 6px 16px 6px 24px; cursor: pointer; user-select: none; gap: 6px; border-top: 1px solid var(--bg-card); }
   .pb-group-header:hover { background: var(--bg-elevated-hover); }
   .pb-group-header .group-name { font-size: 12px; color: var(--text-body); font-weight: 500; }
@@ -54,7 +54,7 @@
   .pb-cf-name { flex: 1; font-size: 13px; display: flex; align-items: center; gap: 6px; min-width: 0; }
   /* pb-req-pill removed — replaced by pb-state-pill (Req/Opt/Fmt three-state) */
   /* Three-state CF pills (group CFs) */
-  .pb-state-pill { font-size:12px; padding: 2px 8px; border-radius: 10px; cursor: pointer; user-select: none; border: 1px solid var(--border-subtle); font-weight: 600; color: var(--text-muted); background: var(--bg-card); }
+  .pb-state-pill { font-size:12px; padding: 2px 8px; border-radius: 10px; cursor: pointer; user-select: none; border: 1px solid var(--border-subtle); font-weight: 600; color: var(--text-muted); background: var(--bg-card); font-family: inherit; line-height: 1.2; }
   .pb-state-pill:hover { border-color: var(--text-secondary); color: var(--text-muted); }
   .pb-state-pill.active-req { background: var(--fill-green-soft); color: var(--accent-green); border-color: var(--accent-green-strong); }
   .pb-state-pill.active-opt { background: var(--fill-orange-soft); color: var(--accent-orange); border-color: var(--accent-orange-strong); }
@@ -86,4 +86,3 @@
   .pd-settings .toggle .slider { border-radius: 7px; }
   .pd-settings .toggle .slider:before { width: 10px; height: 10px; }
   .pd-settings .toggle input:checked + .slider:before { transform: translateX(12px); }
-

--- a/ui/static/css/features/cf-detail.css
+++ b/ui/static/css/features/cf-detail.css
@@ -1,6 +1,6 @@
   /* CF sections in profile detail */
   .cf-section { padding: 0; }
-  .cf-section-title { display: flex; align-items: center; padding: 6px 16px 6px 24px; cursor: pointer; user-select: none; gap: 6px; border-top: 1px solid var(--bg-card); font-size: 12px; font-weight: 500; color: var(--text-body); }
+  .cf-section-title { display: flex; align-items: center; padding: 6px 16px 6px 24px; cursor: pointer; user-select: none; gap: 6px; border: 0; border-top: 1px solid var(--bg-card); background: transparent; width: 100%; text-align: left; font-family: inherit; font-size: 12px; font-weight: 500; color: var(--text-body); }
   .cf-row { display: flex; align-items: center; padding: 6px 16px 6px 36px; border-bottom: 1px solid var(--bg-card); gap: 8px; }
   .cf-row:hover { background: var(--bg-elevated-hover); }
   .cf-row:last-child { border-bottom: none; }
@@ -12,7 +12,7 @@
 
   /* Detail section headers */
   .detail-section { background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 6px; margin-bottom: 6px; overflow: hidden; }
-  .detail-section-header { display: flex; align-items: center; padding: 10px 16px; cursor: pointer; user-select: none; gap: 8px; }
+  .detail-section-header { display: flex; align-items: center; padding: 10px 16px; cursor: pointer; user-select: none; gap: 8px; border: 0; background: transparent; width: 100%; text-align: left; color: inherit; font-family: inherit; }
   .detail-section-header:hover { background: var(--bg-elevated-hover); }
   .detail-section-label { font-size: 13px; font-weight: 600; flex: 1; }
   .detail-section-count { font-size:13px; color: var(--text-secondary); margin-right: auto; }

--- a/ui/static/css/features/profiles.css
+++ b/ui/static/css/features/profiles.css
@@ -33,9 +33,10 @@
   .subtab:hover { color: var(--text-primary); }
   .subtab.active { color: var(--text-primary); border-bottom-color: var(--accent-blue); }
   .profile-tabs { display: flex; gap: 0; padding: 0 24px; background: var(--bg-page); border-bottom: 1px solid var(--bg-muted); }
-  .profile-tab { padding: 10px 16px; font-size: 15px; color: var(--text-soft); cursor: pointer; border-bottom: 2px solid transparent; user-select: none; font-weight: 500; }
+  .profile-tab { padding: 10px 16px; font-size: 15px; color: var(--text-soft); cursor: pointer; border-bottom: 2px solid transparent; user-select: none; font-weight: 500; text-decoration: none; display: inline-flex; align-items: center; }
   .profile-tab:hover { color: var(--text-muted); }
   .profile-tab.active { color: var(--text-primary); border-bottom-color: var(--accent-blue); }
+  .profile-tab:focus-visible { outline-offset: -2px; }
 
   /* App type toggle pills */
   .app-pill { padding: 5px 16px; font-size: 12px; font-weight: 500; border: 1px solid var(--border-subtle); border-radius: 20px; cursor: pointer; background: transparent; color: var(--text-muted); transition: all 0.15s; }

--- a/ui/static/css/features/profiles.css
+++ b/ui/static/css/features/profiles.css
@@ -27,7 +27,7 @@
   .back-link { color: var(--accent-blue); font-size: 13px; cursor: pointer; text-decoration: none; }
   .back-link:hover { text-decoration: underline; }
 
-  /* Sub-tabs (under Radarr/Sonarr) */
+  /* Legacy subtabs plus the current app/section navigation bar */
   .subtabs { display: flex; gap: 0; border-bottom: 1px solid var(--border-subtle); padding: 0 24px; background: var(--bg-card); }
   .subtab { padding: 10px 16px; font-size: 14px; color: var(--text-soft); cursor: pointer; border: 0; border-bottom: 2px solid transparent; background: transparent; user-select: none; font-family: inherit; }
   .subtab:hover { color: var(--text-primary); }
@@ -39,7 +39,7 @@
   .profile-tab.active { color: var(--text-primary); border-bottom-color: var(--accent-blue); }
   .profile-tab:focus-visible { outline-offset: -2px; }
 
-  /* App type toggle pills */
+  /* App type toggle pills used by older embedded controls */
   .app-pill { padding: 5px 16px; font-size: 12px; font-weight: 500; border: 1px solid var(--border-subtle); border-radius: 20px; cursor: pointer; background: transparent; color: var(--text-muted); transition: all 0.15s; }
   .app-pill:hover { color: var(--text-primary); border-color: var(--text-secondary); }
   .app-pill.active-radarr { background: var(--fill-radarr); color: var(--accent-orange-bright); border-color: var(--accent-orange-bright); }

--- a/ui/static/css/features/profiles.css
+++ b/ui/static/css/features/profiles.css
@@ -1,5 +1,5 @@
   /* Profile group headers (collapsible) */
-  .profile-group-header { display: flex; align-items: center; padding: 10px 16px; font-size: 13px; color: var(--text-primary); font-weight: 500; border-bottom: 1px solid var(--bg-muted); cursor: pointer; user-select: none; gap: 8px; }
+  .profile-group-header { display: flex; align-items: center; padding: 10px 16px; font-size: 13px; color: var(--text-primary); font-weight: 500; border: 0; border-bottom: 1px solid var(--bg-muted); background: transparent; width: 100%; text-align: left; cursor: pointer; user-select: none; gap: 8px; font-family: inherit; }
   .profile-group-header:hover { background: var(--bg-elevated-hover); }
   .profile-group-chevron { font-size:12px; transition: transform 0.2s; color: var(--text-secondary); }
   .profile-group-chevron.open { transform: rotate(90deg); }
@@ -29,9 +29,10 @@
 
   /* Sub-tabs (under Radarr/Sonarr) */
   .subtabs { display: flex; gap: 0; border-bottom: 1px solid var(--border-subtle); padding: 0 24px; background: var(--bg-card); }
-  .subtab { padding: 10px 16px; font-size: 14px; color: var(--text-soft); cursor: pointer; border-bottom: 2px solid transparent; user-select: none; }
+  .subtab { padding: 10px 16px; font-size: 14px; color: var(--text-soft); cursor: pointer; border: 0; border-bottom: 2px solid transparent; background: transparent; user-select: none; font-family: inherit; }
   .subtab:hover { color: var(--text-primary); }
   .subtab.active { color: var(--text-primary); border-bottom-color: var(--accent-blue); }
+  .subtab:focus-visible { outline-offset: -2px; }
   .profile-tabs { display: flex; gap: 0; padding: 0 24px; background: var(--bg-page); border-bottom: 1px solid var(--bg-muted); }
   .profile-tab { padding: 10px 16px; font-size: 15px; color: var(--text-soft); cursor: pointer; border-bottom: 2px solid transparent; user-select: none; font-weight: 500; text-decoration: none; display: inline-flex; align-items: center; }
   .profile-tab:hover { color: var(--text-muted); }

--- a/ui/static/css/features/sync-compare.css
+++ b/ui/static/css/features/sync-compare.css
@@ -68,7 +68,7 @@
   .compare-section-title { font-size:13px; font-weight: 600; text-transform: uppercase; color: var(--text-muted); padding: 8px 0 4px; letter-spacing: 0.5px; }
   .compare-section-header { display: flex; align-items: center; gap: 8px; padding: 8px 0 4px; }
   .compare-section-header .compare-section-title { padding: 0; }
-  .compare-section-toggle { font-size:12px; color: var(--accent-blue); cursor: pointer; margin-left: auto; }
+  .compare-section-toggle { font-size:12px; color: var(--accent-blue); cursor: pointer; margin-left: auto; background: transparent; border: 0; padding: 0; font-family: inherit; }
   .compare-section-toggle:hover { text-decoration: underline; }
   /* Compare settings table — 4-col layout so Current and TRaSH values line up vertically instead of wrapping inline. Source: clonarr-compare-redesign-v3.html mockup. */
   .cmp-settings-table { width: 100%; border-collapse: collapse; font-size: 12px; }
@@ -101,7 +101,7 @@
   .cmp-settings-table td.actions { text-align: right; }
 
   /* Compare view filter chips — sized to match the diff chips in the summary bar */
-  .compare-chip { display: inline-flex; align-items: center; padding: 2px 10px; border-radius: 10px; border: 1px solid var(--border-subtle); background: var(--bg-card); color: var(--text-muted); font-size: 12px; line-height: 1.4; cursor: pointer; user-select: none; transition: border-color 0.12s, color 0.12s, background 0.12s; }
+  .compare-chip { display: inline-flex; align-items: center; padding: 2px 10px; border-radius: 10px; border: 1px solid var(--border-subtle); background: var(--bg-card); color: var(--text-muted); font-size: 12px; line-height: 1.4; cursor: pointer; user-select: none; transition: border-color 0.12s, color 0.12s, background 0.12s; font-family: inherit; }
   .compare-chip:hover { border-color: var(--accent-blue); color: var(--text-body); }
   .compare-chip.active { background: var(--accent-blue); color: var(--bg-page); border-color: var(--accent-blue); font-weight: 600; }
   .compare-chip-wrong.active { background: var(--accent-orange); border-color: var(--accent-orange); }

--- a/ui/static/css/layout.css
+++ b/ui/static/css/layout.css
@@ -2,9 +2,12 @@
   .topnav { display: flex; align-items: center; background: var(--bg-card); border-bottom: 1px solid var(--border-subtle); padding: 0 24px; height: 56px; }
   .topnav .logo { font-size: 18px; font-weight: 700; color: var(--accent-blue); margin-right: 32px; letter-spacing: -0.5px; }
   .topnav .tabs { display: flex; gap: 0; height: 100%; }
-  .topnav .tab { padding: 0 20px; height: 100%; display: flex; align-items: center; color: var(--text-soft); cursor: pointer; border-bottom: 2px solid transparent; font-size: 15px; font-weight: 500; transition: all 0.15s; user-select: none; }
+  .topnav .tab { padding: 0 20px; height: 100%; display: flex; align-items: center; color: var(--text-soft); cursor: pointer; border-bottom: 2px solid transparent; font-size: 15px; font-weight: 500; transition: all 0.15s; user-select: none; text-decoration: none; }
   .topnav .tab:hover { color: var(--text-primary); }
   .topnav .tab.active { color: var(--text-primary); border-bottom-color: var(--accent-blue); }
+  /* Inset focus ring so it sits inside the 56px topnav cell (default
+     outline-offset would clip against the bottom border). */
+  .topnav .tab:focus-visible { outline-offset: -2px; }
   .topnav .badge { background: var(--border-subtle); color: var(--text-muted); font-size:13px; padding: 1px 6px; border-radius: 10px; margin-left: 6px; }
   .topnav .tab.active .badge { background: var(--accent-blue-muted); color: var(--accent-blue); }
   .topnav .spacer { flex: 1; }

--- a/ui/static/css/tokens.css
+++ b/ui/static/css/tokens.css
@@ -133,10 +133,10 @@
   /* Text — bumped contrast for legibility on muted bg */
   --text-primary: #1f2328;
   --text-body: #24292f;
-  --text-secondary: #4d535b;
-  --text-muted: #4d535b;
-  --text-muted-secondary: #57606a;
-  --text-soft: #4d535b;
+  --text-secondary: #32383f;
+  --text-muted: #42474e;
+  --text-muted-secondary: #525964;
+  --text-soft: #525964;
   --text-inverse: #ffffff;
   --text-on-accent: #ffffff;
 

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -40,9 +40,16 @@
 </head>
 <body>
 
+<!-- Skip-link: first focusable element on the page so keyboard users can
+     jump past the topnav. preventDefault keeps location.hash clean — our
+     hash routing would otherwise interpret #main-content as a nav target. -->
+<a href="#main-content" class="skip-link"
+   onclick="event.preventDefault(); var m = document.getElementById('main-content'); if (m) m.focus();">Skip to main content</a>
+
 <div x-data="clonarr" x-init="init()" x-cloak>
 
   {{template "layout/top-nav" .}}
+  <main id="main-content" tabindex="-1">
   {{template "sections/app-pages" .}}
   {{template "sections/advanced" .}}
   {{template "overlays/profile-builder" .}}
@@ -50,6 +57,7 @@
   {{template "modals/cleanup-result" .}}
   {{template "sections/settings" .}}
   {{template "sections/about" .}}
+  </main>
   {{template "modals/instance" .}}
   {{template "modals/notification-agent" .}}
   {{template "modals/sandbox-cf-browser" .}}

--- a/ui/static/js/features/instances.js
+++ b/ui/static/js/features/instances.js
@@ -11,6 +11,15 @@ export default {
   },
 
   methods: {
+    normalizedInstanceForm() {
+      return {
+        name: (this.instanceForm.name || '').trim(),
+        type: (this.instanceForm.type || '').trim(),
+        url: (this.instanceForm.url || '').trim(),
+        apiKey: (this.instanceForm.apiKey || '').trim(),
+      };
+    },
+
     async loadInstances() {
       try {
         const r = await fetch('/api/instances');
@@ -41,13 +50,13 @@ export default {
     },
 
     async saveInstance() {
+      const data = this.normalizedInstanceForm();
       this.instanceFormErrors = {};
-      if (!this.instanceForm.url) this.instanceFormErrors.url = 'URL is required';
-      if (!this.instanceForm.name) this.instanceFormErrors.name = 'Name is required';
-      if (!this.editingInstance && !this.instanceForm.apiKey) this.instanceFormErrors.apiKey = 'API Key is required';
+      if (!data.url) this.instanceFormErrors.url = 'URL is required';
+      if (!data.name) this.instanceFormErrors.name = 'Name is required';
+      if (!this.editingInstance && !data.apiKey) this.instanceFormErrors.apiKey = 'API Key is required';
       if (Object.keys(this.instanceFormErrors).length > 0) return;
 
-      const data = { ...this.instanceForm };
       let r;
       if (this.editingInstance) {
         if (!data.apiKey) data.apiKey = this.editingInstance.apiKey;
@@ -124,15 +133,16 @@ export default {
     async testConnectionInModal() {
       this.modalTestResult = 'testing';
       try {
+        const formData = this.normalizedInstanceForm();
         let r;
-        if (this.editingInstance && !this.instanceForm.apiKey) {
+        if (this.editingInstance && !formData.apiKey) {
           // Use saved instance endpoint, which has the real API key.
           r = await fetch(`/api/instances/${this.editingInstance.id}/test`, { method: 'POST' });
         } else {
           r = await fetch('/api/test-connection', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ url: this.instanceForm.url, apiKey: this.instanceForm.apiKey })
+            body: JSON.stringify({ url: formData.url, apiKey: formData.apiKey })
           });
         }
         const data = await r.json();

--- a/ui/static/js/features/instances.js
+++ b/ui/static/js/features/instances.js
@@ -6,6 +6,7 @@ export default {
     showInstanceModal: false,
     editingInstance: null,
     instanceForm: { name: '', type: 'radarr', url: '', apiKey: '' },
+    instanceFormErrors: {},
     modalTestResult: null,
   },
 
@@ -40,6 +41,12 @@ export default {
     },
 
     async saveInstance() {
+      this.instanceFormErrors = {};
+      if (!this.instanceForm.url) this.instanceFormErrors.url = 'URL is required';
+      if (!this.instanceForm.name) this.instanceFormErrors.name = 'Name is required';
+      if (!this.editingInstance && !this.instanceForm.apiKey) this.instanceFormErrors.apiKey = 'API Key is required';
+      if (Object.keys(this.instanceFormErrors).length > 0) return;
+
       const data = { ...this.instanceForm };
       let r;
       if (this.editingInstance) {

--- a/ui/static/js/features/navigation.js
+++ b/ui/static/js/features/navigation.js
@@ -95,6 +95,53 @@ export default {
       return hash;
     },
 
+    // navHref builds the hash that a target section/sub-tab would produce,
+    // without mutating any state. Used by nav anchors so right-click → "Open
+    // in new tab" and "Copy link address" work, and the browser can show the
+    // URL on hover.
+    //
+    // opts: { appType, profileTab, advancedTab, settingsSection } — each
+    // defaults to the current state when omitted.
+    navHref(section, opts = {}) {
+      if (section === 'settings') {
+        return '#settings/' + (opts.settingsSection || this.settingsSection || 'instances');
+      }
+      if (section === 'about') return '#about';
+      const app = opts.appType || this.activeAppType;
+      let hash = '#' + app + '/' + section;
+      if (section === 'profiles') {
+        hash += '/' + (opts.profileTab || this.getProfileTab(app) || 'trash-sync');
+      } else if (section === 'advanced') {
+        hash += '/' + (opts.advancedTab || this.advancedTab || 'builder');
+      }
+      return hash;
+    },
+
+    // cfgbNeedsConfirm intercepts an app-type anchor click when the CF Group
+    // Builder has unsaved work. Returns true (and pops a confirm modal) only
+    // for plain left-clicks; modifier-clicks (Ctrl/Cmd/Shift/middle-click) are
+    // allowed through so right-click → "Open in new tab" preserves the dirty
+    // draft in the original tab.
+    cfgbNeedsConfirm($event, appType) {
+      if ($event.metaKey || $event.ctrlKey || $event.shiftKey || $event.altKey || $event.button === 1) return false;
+      if (this.currentSection !== 'advanced' || this.advancedTab !== 'group-builder') return false;
+      if (appType === this.activeAppType) return false;
+      if (typeof this.cfgbIsDirty !== 'function' || !this.cfgbIsDirty()) return false;
+      const label = this.cfgbEditingId
+        ? 'changes to "' + (this.cfgbName || '(unnamed)') + '"'
+        : 'the unsaved cf-group draft';
+      const targetHref = this.navHref('advanced', { appType, advancedTab: 'group-builder' });
+      this.confirmModal = {
+        show: true,
+        title: 'Discard unsaved cf-group work?',
+        message: 'Switch to ' + appType + ' and discard ' + label + '?\n\nThe saved copy on disk (if any) is unaffected.',
+        confirmLabel: 'Switch to ' + appType,
+        onConfirm: () => { location.hash = targetHref; },
+        onCancel: () => {},
+      };
+      return true;
+    },
+
     pushNav() {
       if (this._navSkipPush) return;
       const hash = this.buildNavHash();
@@ -103,9 +150,13 @@ export default {
 
     restoreFromHash(hash) {
       if (!hash || hash === '#') return false;
+      // Guard against the watch-loop: pushNav writes the hash, the browser
+      // fires hashchange, this runs, watchers re-fire pushNav. Early-return
+      // when the hash already matches the state we'd produce.
+      if (hash === this.buildNavHash()) return true;
       const parts = hash.replace(/^#/, '').split('/');
       const validSections = ['profiles','custom-formats','quality-size','naming','maintenance','advanced','settings','about'];
-      const validSettings = ['instances','trash','prowlarr','notifications','display','advanced'];
+      const validSettings = ['instances','trash','prowlarr','notifications','display','security','advanced'];
       const validProfileTabs = ['trash-sync','history','compare'];
       const validAdvancedTabs = ['builder','scoring','import'];
       this._navSkipPush = true;

--- a/ui/static/js/features/navigation.js
+++ b/ui/static/js/features/navigation.js
@@ -94,7 +94,7 @@ export default {
       const app = this.activeAppType;
       let hash = '#' + app + '/' + s;
       if (s === 'profiles') hash += '/' + (this.getProfileTab(app) || 'trash-sync');
-      else if (s === 'advanced') hash += '/' + (this.advancedTab || 'group-builder');
+      else if (s === 'advanced') hash += '/' + (this.advancedTab || 'builder');
       return hash;
     },
 

--- a/ui/static/js/features/navigation.js
+++ b/ui/static/js/features/navigation.js
@@ -3,6 +3,9 @@ export default {
     _navSkipPush: false,
   },
   methods: {
+    // Legacy tab-switching helpers are kept for older call sites. New
+    // navigation should use real anchors from navHref(), with section/app
+    // side effects attached to state watchers in init().
     switchTab(tab) {
       this.debugLog('UI', `Tab: ${tab}`);
       this.currentTab = tab;
@@ -10,7 +13,7 @@ export default {
       this.profileDetail = null;
       this.syncPlan = null;
       this.syncResult = null;
-      // Auto-select maintenance instance for this tab type if only one
+      // Auto-select maintenance instance for this legacy app tab if only one.
       const typeInsts = this.instances.filter(i => i.type === tab);
       if (typeInsts.length === 1 && this.maintenanceInstanceId !== typeInsts[0].id) {
         this.maintenanceInstanceId = typeInsts[0].id;
@@ -72,7 +75,7 @@ export default {
         this.loadCleanupKeep();
         this.loadCleanupCFNames();
       }
-      // Reload tab-scoped data that depends on appType. The CF Group Builder
+      // Reload app-scoped Advanced data. The CF Group Builder
       // pulls CFs, profiles, and saved groups per Radarr/Sonarr — without this
       // the Radarr list keeps showing when the user flips to Sonarr.
       // Scoring Sandbox has the same issue; reload it too for parity.
@@ -82,7 +85,7 @@ export default {
       }
     },
 
-    // --- Browser History API (back/forward navigation) ---
+    // --- Hash routing (back/forward, bookmarks, copyable nav links) ---
     // Hash format: #appType/section[/subtab] — e.g. #radarr/profiles/compare, #settings/prowlarr, #about
     buildNavHash() {
       const s = this.currentSection;
@@ -91,7 +94,7 @@ export default {
       const app = this.activeAppType;
       let hash = '#' + app + '/' + s;
       if (s === 'profiles') hash += '/' + (this.getProfileTab(app) || 'trash-sync');
-        else if (s === 'advanced') hash += '/' + (this.advancedTab || 'group-builder');
+      else if (s === 'advanced') hash += '/' + (this.advancedTab || 'group-builder');
       return hash;
     },
 
@@ -158,7 +161,7 @@ export default {
       const validSections = ['profiles','custom-formats','quality-size','naming','maintenance','advanced','settings','about'];
       const validSettings = ['instances','trash','prowlarr','notifications','display','security','advanced'];
       const validProfileTabs = ['trash-sync','history','compare'];
-        const validAdvancedTabs = ['builder','group-builder','scoring','import'];
+      const validAdvancedTabs = ['builder','group-builder','scoring','import'];
       this._navSkipPush = true;
       try {
         if (parts[0] === 'settings') {

--- a/ui/static/js/features/navigation.js
+++ b/ui/static/js/features/navigation.js
@@ -91,7 +91,7 @@ export default {
       const app = this.activeAppType;
       let hash = '#' + app + '/' + s;
       if (s === 'profiles') hash += '/' + (this.getProfileTab(app) || 'trash-sync');
-      else if (s === 'advanced') hash += '/' + (this.advancedTab || 'builder');
+        else if (s === 'advanced') hash += '/' + (this.advancedTab || 'group-builder');
       return hash;
     },
 
@@ -158,7 +158,7 @@ export default {
       const validSections = ['profiles','custom-formats','quality-size','naming','maintenance','advanced','settings','about'];
       const validSettings = ['instances','trash','prowlarr','notifications','display','security','advanced'];
       const validProfileTabs = ['trash-sync','history','compare'];
-      const validAdvancedTabs = ['builder','scoring','import'];
+        const validAdvancedTabs = ['builder','group-builder','scoring','import'];
       this._navSkipPush = true;
       try {
         if (parts[0] === 'settings') {

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -149,6 +149,67 @@ export function clonarr() {
       };
       this.$watch('advancedTab', ensureSandbox);
       this.$watch('currentSection', ensureSandbox);
+
+      // Nav anchors set location.hash directly, which fires hashchange (not
+      // popstate). Mirror the popstate handler so anchor clicks restore state.
+      // restoreFromHash early-returns when hash already matches state, so this
+      // is safe to fire alongside watchers that call pushNav.
+      window.addEventListener('hashchange', () => this.restoreFromHash(location.hash));
+
+      // Section change clears stale per-section state (was inline in the old
+      // switchSection). Fires for both anchor clicks and hash restoration.
+      this.$watch('currentSection', () => {
+        this.profileDetail = null;
+        this.syncPlan = null;
+        this.syncResult = null;
+      });
+
+      // Settings → Security loads the API key. Was inline on the old
+      // settings-nav @click; now driven by state so right-click → "Open in
+      // new tab" on `#settings/security` also fetches.
+      this.$watch('settingsSection', (s) => {
+        if (s === 'security') this.fetchApiKey();
+      });
+
+      // Advanced → CF Group Builder loads CFs/profiles for the active app
+      // type. Was inline on the @click; now state-driven.
+      this.$watch('advancedTab', (t) => {
+        if (this.currentSection === 'advanced' && t === 'group-builder') {
+          this.cfgbLoad(this.activeAppType);
+        }
+      });
+
+      // Profiles → History loads sync history for every instance of the
+      // active app type. Triggers on tab change OR app-type change while the
+      // History tab is active.
+      const ensureHistory = () => {
+        if (this.currentSection === 'profiles' && this.getProfileTab(this.activeAppType) === 'history') {
+          this.instancesOfType(this.activeAppType).forEach(i => this.loadSyncHistory(i.id));
+        }
+      };
+      this.$watch('profileTabs', ensureHistory);
+
+      // App-type change (Radarr ↔ Sonarr) replays the side-effects that used
+      // to live in _doSwitchAppType: clear stale per-section state, auto-pick
+      // the maintenance instance when only one exists for the new type, and
+      // reload Advanced sub-tabs that are app-type-scoped.
+      this.$watch('activeAppType', (appType) => {
+        this.profileDetail = null;
+        this.syncPlan = null;
+        this.syncResult = null;
+        const typeInsts = this.instances.filter(i => i.type === appType);
+        if (typeInsts.length === 1) {
+          this.maintenanceInstanceId = typeInsts[0].id;
+          this.cleanupInstanceId = typeInsts[0].id;
+          this.loadCleanupKeep();
+          this.loadCleanupCFNames();
+        }
+        if (this.currentSection === 'advanced') {
+          if (this.advancedTab === 'group-builder') this.cfgbLoad(appType);
+          else if (this.advancedTab === 'scoring') this.loadSandbox(appType);
+        }
+        ensureHistory();
+      });
       await this.loadConfig();
       this.fetchAuthStatus(); // render header user-menu and banner state early
       await this.loadInstances();

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -74,6 +74,9 @@ let scrollLockCount = 0;
 let scrollLockSnapshot = null;
 const inertElementState = new WeakMap();
 const activeModalTraps = [];
+let activeTooltipData = null;
+let activeTooltipOwner = null;
+let tooltipEscapeListenerRegistered = false;
 
 function isVisibleFocusable(el) {
   if (!(el instanceof HTMLElement)) return false;
@@ -281,6 +284,19 @@ function registerModalTrapDirective(Alpine) {
     });
 
     cleanup(deactivate);
+  });
+}
+
+function registerTooltipEscapeListener() {
+  if (tooltipEscapeListenerRegistered) return;
+  tooltipEscapeListenerRegistered = true;
+  window.addEventListener('keydown', (event) => {
+    if (event.key !== 'Escape') return;
+    if (activeTooltipData?.tt?.show && activeTooltipData.hideTooltip) {
+      activeTooltipData.hideTooltip();
+    }
+    activeTooltipData = null;
+    activeTooltipOwner = null;
   });
 }
 
@@ -655,10 +671,11 @@ Object.assign(window, {
 function registerClonarr() {
   window.Alpine.data('clonarr', clonarr);
   registerModalTrapDirective(window.Alpine);
+  registerTooltipEscapeListener();
   // x-tt="'tooltip text'" — viewport-aware custom tooltip directive.
   // Replaces native title="" for elements where the OS tooltip would overflow
   // the viewport (right-edge buttons, long messages). Wires hover, focus, and
-  // Escape handlers to showTooltip / hideTooltip on the root clonarr scope.
+  // shared Escape handling to showTooltip / hideTooltip on the root clonarr scope.
   // Static text:   x-tt="'Reset all overrides'"
   // Dynamic text:  x-tt="someDynamicExpr"
   window.Alpine.directive('tt', (el, { expression }, { evaluateLater, cleanup }) => {
@@ -672,38 +689,44 @@ function registerClonarr() {
 
     // evaluateLater resolves on a microtask; track the current trigger so a
     // dynamic tooltip cannot appear after pointer/focus already left.
+    const tooltipOwner = {};
     let currentEl = null;
     const onEnter = (e) => {
       currentEl = e.currentTarget;
       const target = e.currentTarget;
       getTipText((text) => {
         if (text && currentEl === target) {
-          window.Alpine.$data(el).showTooltip(target, text);
+          const data = window.Alpine.$data(el);
+          if (data && data.showTooltip) {
+            data.showTooltip(target, text);
+            activeTooltipData = data;
+            activeTooltipOwner = tooltipOwner;
+          }
         }
       });
     };
     const onLeave = () => {
       currentEl = null;
       const data = window.Alpine.$data(el);
-      if (data && data.hideTooltip) data.hideTooltip();
-    };
-    const onEsc = (e) => {
-      if (e.key === 'Escape') {
-        const data = window.Alpine.$data(el);
-        if (data && data.tt && data.tt.show) data.hideTooltip();
+      if (activeTooltipOwner === tooltipOwner && data && data.hideTooltip) {
+        data.hideTooltip();
+        activeTooltipData = null;
+        activeTooltipOwner = null;
       }
     };
     el.addEventListener('mouseenter', onEnter);
     el.addEventListener('mouseleave', onLeave);
     el.addEventListener('focusin', onEnter);
     el.addEventListener('focusout', onLeave);
-    window.addEventListener('keydown', onEsc);
     cleanup(() => {
       el.removeEventListener('mouseenter', onEnter);
       el.removeEventListener('mouseleave', onLeave);
       el.removeEventListener('focusin', onEnter);
       el.removeEventListener('focusout', onLeave);
-      window.removeEventListener('keydown', onEsc);
+      if (activeTooltipOwner === tooltipOwner) {
+        activeTooltipData = null;
+        activeTooltipOwner = null;
+      }
     });
   });
 }

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -659,10 +659,13 @@ function registerClonarr() {
   // Dynamic text:  x-tt="someDynamicExpr"
   window.Alpine.directive('tt', (el, { expression }, { evaluateLater, cleanup }) => {
     const getTipText = evaluateLater(expression);
-    // currentEl tracks the element the user is hovering RIGHT NOW. evaluateLater
-    // resolves via microtask, so for dynamic expressions the user could already
-    // have moved away by the time the callback fires. We compare against the
-    // currentEl snapshot to avoid showing a stale tooltip after mouseleave.
+    let idStr = el.getAttribute('id');
+    if (!idStr) {
+      idStr = 'tt-' + Math.random().toString(36).substr(2, 9);
+      el.setAttribute('id', idStr);
+    }
+    el.setAttribute('aria-describedby', 'global-tooltip');
+
     let currentEl = null;
     const onEnter = (e) => {
       currentEl = e.currentTarget;
@@ -678,11 +681,23 @@ function registerClonarr() {
       const data = window.Alpine.$data(el);
       if (data && data.hideTooltip) data.hideTooltip();
     };
+    const onEsc = (e) => {
+      if (e.key === 'Escape') {
+        const data = window.Alpine.$data(el);
+        if (data && data.tt && data.tt.show) data.hideTooltip();
+      }
+    };
     el.addEventListener('mouseenter', onEnter);
     el.addEventListener('mouseleave', onLeave);
+    el.addEventListener('focusin', onEnter);
+    el.addEventListener('focusout', onLeave);
+    window.addEventListener('keydown', onEsc);
     cleanup(() => {
       el.removeEventListener('mouseenter', onEnter);
       el.removeEventListener('mouseleave', onLeave);
+      el.removeEventListener('focusin', onEnter);
+      el.removeEventListener('focusout', onLeave);
+      window.removeEventListener('keydown', onEsc);
     });
   });
 }

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -52,6 +52,234 @@ function applyFeatureModules(target) {
   return target;
 }
 
+const modalFocusableSelector = [
+  'a[href]',
+  'area[href]',
+  'button:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+let scrollLockCount = 0;
+let scrollLockSnapshot = null;
+const inertElementState = new WeakMap();
+const activeModalTraps = [];
+
+function isVisibleFocusable(el) {
+  if (!(el instanceof HTMLElement)) return false;
+  if (el.disabled || el.getAttribute('aria-hidden') === 'true') return false;
+  const styles = window.getComputedStyle(el);
+  if (styles.display === 'none' || styles.visibility === 'hidden') return false;
+  return !!(el.offsetWidth || el.offsetHeight || el.getClientRects().length);
+}
+
+function focusableElementsIn(el) {
+  return Array.from(el.querySelectorAll(modalFocusableSelector)).filter(isVisibleFocusable);
+}
+
+function lockDocumentScroll() {
+  if (scrollLockCount === 0) {
+    scrollLockSnapshot = {
+      htmlOverflow: document.documentElement.style.overflow,
+      bodyOverflow: document.body.style.overflow,
+    };
+    document.documentElement.style.overflow = 'hidden';
+    document.body.style.overflow = 'hidden';
+  }
+
+  scrollLockCount += 1;
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    scrollLockCount = Math.max(0, scrollLockCount - 1);
+    if (scrollLockCount !== 0 || !scrollLockSnapshot) return;
+
+    document.documentElement.style.overflow = scrollLockSnapshot.htmlOverflow;
+    document.body.style.overflow = scrollLockSnapshot.bodyOverflow;
+    scrollLockSnapshot = null;
+  };
+}
+
+function inertElement(el) {
+  const existing = inertElementState.get(el);
+  if (existing) {
+    existing.count += 1;
+    return;
+  }
+
+  inertElementState.set(el, {
+    count: 1,
+    hadInert: el.hasAttribute('inert'),
+    inertValue: !!el.inert,
+    ariaHidden: el.getAttribute('aria-hidden'),
+  });
+  el.inert = true;
+  el.setAttribute('inert', '');
+  el.setAttribute('aria-hidden', 'true');
+}
+
+function releaseInertElement(el) {
+  const existing = inertElementState.get(el);
+  if (!existing) return;
+
+  existing.count -= 1;
+  if (existing.count > 0) return;
+
+  if (existing.hadInert) {
+    el.setAttribute('inert', '');
+  } else {
+    el.removeAttribute('inert');
+  }
+  el.inert = existing.inertValue;
+  if (existing.ariaHidden === null) {
+    el.removeAttribute('aria-hidden');
+  } else {
+    el.setAttribute('aria-hidden', existing.ariaHidden);
+  }
+  inertElementState.delete(el);
+}
+
+function inertModalBackground(el) {
+  const layer = el.closest('.modal-overlay') || el;
+  const inerted = [];
+  let branch = layer;
+
+  while (branch && branch.parentElement) {
+    const parent = branch.parentElement;
+    for (const child of parent.children) {
+      if (
+        child === branch
+        || child.tagName === 'SCRIPT'
+        || child.tagName === 'STYLE'
+        || child.contains(layer)
+        || layer.contains(child)
+      ) continue;
+      inertElement(child);
+      inerted.push(child);
+    }
+    if (parent === document.body) break;
+    branch = parent;
+  }
+
+  return () => {
+    inerted.forEach(releaseInertElement);
+  };
+}
+
+function registerModalTrapDirective(Alpine) {
+  Alpine.directive('trap', (el, { expression, modifiers }, { evaluateLater, effect, cleanup }) => {
+    const evaluateOpen = evaluateLater(expression || 'false');
+    const trap = {};
+    let active = false;
+    let previouslyFocused = null;
+    let releaseScroll = null;
+    let releaseInert = null;
+    let addedTabindex = false;
+    let focusTimer = null;
+
+    const clearFocusTimer = () => {
+      if (focusTimer === null) return;
+      window.clearTimeout(focusTimer);
+      focusTimer = null;
+    };
+
+    const focusFirst = () => {
+      const target = focusableElementsIn(el)[0] || el;
+      if (target instanceof HTMLElement) target.focus({ preventScroll: true });
+    };
+
+    const isTopTrap = () => activeModalTraps[activeModalTraps.length - 1] === trap;
+
+    const onKeydown = (event) => {
+      if (!active || !isTopTrap() || event.key !== 'Tab') return;
+
+      const focusable = focusableElementsIn(el);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        el.focus({ preventScroll: true });
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const current = document.activeElement;
+
+      if (event.shiftKey && (current === first || !el.contains(current))) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      } else if (!event.shiftKey && (current === last || !el.contains(current))) {
+        event.preventDefault();
+        first.focus({ preventScroll: true });
+      }
+    };
+
+    const onFocusIn = (event) => {
+      if (!active || !isTopTrap() || el.contains(event.target)) return;
+      focusFirst();
+    };
+
+    const activate = () => {
+      if (active) return;
+      active = true;
+      activeModalTraps.push(trap);
+      previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+      if (!el.hasAttribute('tabindex')) {
+        el.setAttribute('tabindex', '-1');
+        addedTabindex = true;
+      }
+      if (modifiers.includes('noscroll')) releaseScroll = lockDocumentScroll();
+      if (modifiers.includes('inert')) releaseInert = inertModalBackground(el);
+
+      document.addEventListener('keydown', onKeydown, true);
+      document.addEventListener('focusin', onFocusIn, true);
+      focusTimer = window.setTimeout(() => {
+        focusTimer = null;
+        if (active && el.isConnected && !el.contains(document.activeElement)) focusFirst();
+      }, 0);
+    };
+
+    const deactivate = () => {
+      if (!active) return;
+      active = false;
+      const stackIndex = activeModalTraps.lastIndexOf(trap);
+      if (stackIndex !== -1) activeModalTraps.splice(stackIndex, 1);
+      clearFocusTimer();
+      document.removeEventListener('keydown', onKeydown, true);
+      document.removeEventListener('focusin', onFocusIn, true);
+      if (releaseInert) releaseInert();
+      if (releaseScroll) releaseScroll();
+      releaseInert = null;
+      releaseScroll = null;
+      if (addedTabindex) {
+        el.removeAttribute('tabindex');
+        addedTabindex = false;
+      }
+      if (previouslyFocused && previouslyFocused.isConnected && document.body.contains(previouslyFocused)) {
+        previouslyFocused.focus({ preventScroll: true });
+      }
+      previouslyFocused = null;
+    };
+
+    effect(() => {
+      evaluateOpen((open) => {
+        if (open) activate();
+        else deactivate();
+      });
+    });
+
+    cleanup(deactivate);
+  });
+}
+
 export function clonarr() {
   return applyFeatureModules({
     ...baseState(),
@@ -422,6 +650,7 @@ Object.assign(window, {
 //     already loaded — we just register directly.
 function registerClonarr() {
   window.Alpine.data('clonarr', clonarr);
+  registerModalTrapDirective(window.Alpine);
   // x-tt="'tooltip text'" — viewport-aware custom tooltip directive.
   // Replaces native title="" for elements where the OS tooltip would overflow
   // the viewport (right-edge buttons, long messages). Wires mouseenter/leave

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -52,6 +52,10 @@ function applyFeatureModules(target) {
   return target;
 }
 
+// Local modal focus trap used by the modal partials. It provides the subset of
+// Alpine Focus we need without another plugin: tab containment, focus restore,
+// optional scroll lock, and optional inert background content. Scroll/inert
+// state is reference-counted so stacked prompts unwind cleanly.
 const modalFocusableSelector = [
   'a[href]',
   'area[href]',
@@ -408,8 +412,8 @@ export function clonarr() {
       });
 
       // Profiles → History loads sync history for every instance of the
-      // active app type. Triggers on tab change OR app-type change while the
-      // History tab is active.
+      // active app type. Triggers on profileTabs state change OR app-type
+      // change while the History tab is active.
       const ensureHistory = () => {
         if (this.currentSection === 'profiles' && this.getProfileTab(this.activeAppType) === 'history') {
           this.instancesOfType(this.activeAppType).forEach(i => this.loadSyncHistory(i.id));
@@ -523,7 +527,7 @@ export function clonarr() {
         this.loadInstanceQS(type, inst.id);
         this.loadInstanceNaming(type);
       }
-      // Maintenance: auto-select based on current tab type
+      // Maintenance: auto-select based on current app type
       const currentType = this.activeAppType;
       const maintInsts = this.instances.filter(i => i.type === currentType);
       if (maintInsts.length === 1) {
@@ -642,7 +646,7 @@ Object.assign(window, {
 // Register the clonarr() data factory with Alpine.
 //
 // Belt-and-suspenders ordering:
-//   - Belt: index.html loads this module BEFORE the Alpine CDN <script>
+//   - Belt: index.html loads this module BEFORE the Alpine script
 //     so document-order rules guarantee main.js runs first and the
 //     alpine:init listener is registered before Alpine.start() fires it.
 //   - Suspenders: if a future HTML edit reorders the tags, the
@@ -653,8 +657,8 @@ function registerClonarr() {
   registerModalTrapDirective(window.Alpine);
   // x-tt="'tooltip text'" — viewport-aware custom tooltip directive.
   // Replaces native title="" for elements where the OS tooltip would overflow
-  // the viewport (right-edge buttons, long messages). Wires mouseenter/leave
-  // listeners that call showTooltip / hideTooltip on the root clonarr scope.
+  // the viewport (right-edge buttons, long messages). Wires hover, focus, and
+  // Escape handlers to showTooltip / hideTooltip on the root clonarr scope.
   // Static text:   x-tt="'Reset all overrides'"
   // Dynamic text:  x-tt="someDynamicExpr"
   window.Alpine.directive('tt', (el, { expression }, { evaluateLater, cleanup }) => {
@@ -666,6 +670,8 @@ function registerClonarr() {
     }
     el.setAttribute('aria-describedby', 'global-tooltip');
 
+    // evaluateLater resolves on a microtask; track the current trigger so a
+    // dynamic tooltip cannot appear after pointer/focus already left.
     let currentEl = null;
     const onEnter = (e) => {
       currentEl = e.currentTarget;

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -2,16 +2,16 @@
   <!-- Top Navigation -->
   <div class="topnav">
     <div class="logo"><img src="icons/clonarr.png" alt="" style="width:28px;height:28px;border-radius:6px;vertical-align:middle;margin-right:8px">Clonarr</div>
-    <div class="tabs">
-      <div class="tab" :class="{ active: currentSection === 'profiles' }" @click="switchSection('profiles')">Profiles</div>
-      <div class="tab" :class="{ active: currentSection === 'custom-formats' }" @click="switchSection('custom-formats')">Custom Formats</div>
-      <div class="tab" :class="{ active: currentSection === 'quality-size' }" @click="switchSection('quality-size')">Quality Definitions</div>
-      <div class="tab" :class="{ active: currentSection === 'naming' }" @click="switchSection('naming')">File Naming</div>
-      <div class="tab" :class="{ active: currentSection === 'maintenance' }" @click="switchSection('maintenance')">Maintenance</div>
-      <div class="tab" x-show="config.devMode" :class="{ active: currentSection === 'advanced' }" @click="switchSection('advanced')">Advanced</div>
-      <div class="tab" :class="{ active: currentSection === 'settings' }" @click="switchSection('settings')">Settings</div>
-      <div class="tab" :class="{ active: currentSection === 'about' }" @click="switchSection('about')">About</div>
-    </div>
+    <nav class="tabs" aria-label="Main">
+      <a class="tab" :class="{ active: currentSection === 'profiles' }" :href="navHref('profiles')" :aria-current="currentSection === 'profiles' ? 'page' : null">Profiles</a>
+      <a class="tab" :class="{ active: currentSection === 'custom-formats' }" :href="navHref('custom-formats')" :aria-current="currentSection === 'custom-formats' ? 'page' : null">Custom Formats</a>
+      <a class="tab" :class="{ active: currentSection === 'quality-size' }" :href="navHref('quality-size')" :aria-current="currentSection === 'quality-size' ? 'page' : null">Quality Definitions</a>
+      <a class="tab" :class="{ active: currentSection === 'naming' }" :href="navHref('naming')" :aria-current="currentSection === 'naming' ? 'page' : null">File Naming</a>
+      <a class="tab" :class="{ active: currentSection === 'maintenance' }" :href="navHref('maintenance')" :aria-current="currentSection === 'maintenance' ? 'page' : null">Maintenance</a>
+      <a class="tab" x-show="config.devMode" :class="{ active: currentSection === 'advanced' }" :href="navHref('advanced')" :aria-current="currentSection === 'advanced' ? 'page' : null">Advanced</a>
+      <a class="tab" :class="{ active: currentSection === 'settings' }" :href="navHref('settings')" :aria-current="currentSection === 'settings' ? 'page' : null">Settings</a>
+      <a class="tab" :class="{ active: currentSection === 'about' }" :href="navHref('about')" :aria-current="currentSection === 'about' ? 'page' : null">About</a>
+    </nav>
     <div class="spacer"></div>
     <div class="sync-status" style="position:relative">
       <span class="dot" :class="{ stale: !trashStatus.cloned, none: !trashStatus.commitHash }"></span>

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -13,10 +13,12 @@
       <a class="tab" :class="{ active: currentSection === 'about' }" :href="navHref('about')" :aria-current="currentSection === 'about' ? 'page' : null">About</a>
     </nav>
     <div class="spacer"></div>
-    <div class="sync-status" style="position:relative">
+    <div class="sync-status" style="position:relative"
+         @keydown.escape.window="if (showChangelog) { showChangelog = false; $nextTick(() => $refs.trashChangelogButton?.focus()) }">
       <span class="dot" :class="{ stale: !trashStatus.cloned, none: !trashStatus.commitHash }"></span>
       <template x-if="trashStatus.cloned">
         <button type="button" class="inline-action" @click="showChangelog = !showChangelog"
+                x-ref="trashChangelogButton"
                 :aria-expanded="showChangelog"
                 aria-controls="trash-changelog-dropdown"
                 style="color:inherit" x-tt="'Click for changelog'">

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -16,7 +16,10 @@
     <div class="sync-status" style="position:relative">
       <span class="dot" :class="{ stale: !trashStatus.cloned, none: !trashStatus.commitHash }"></span>
       <template x-if="trashStatus.cloned">
-        <span @click="showChangelog = !showChangelog" style="cursor:pointer" x-tt="'Click for changelog'">
+        <button type="button" class="inline-action" @click="showChangelog = !showChangelog"
+                :aria-expanded="showChangelog"
+                aria-controls="trash-changelog-dropdown"
+                style="color:inherit" x-tt="'Click for changelog'">
           <span class="sync-label">TRaSH synced</span> <span x-text="formatSyncTime(trashStatus.lastPull)"></span>
           <span class="sync-commit" x-show="trashStatus.commitHash" style="color:var(--text-muted);font-size:12px;margin-left:4px" x-text="trashStatus.commitHash"></span>
           <span class="sync-next" x-show="config.pullInterval && config.pullInterval !== 'off' && trashStatus.lastPull"
@@ -24,7 +27,7 @@
                 x-text="'· next ' + nextPullTime()"></span>
           <span style="color:var(--text-muted);font-size:12px;margin-left:2px;transition:transform 0.2s;display:inline-block"
                 :style="showChangelog ? 'transform:rotate(180deg)' : ''">&#9662;</span>
-        </span>
+        </button>
       </template>
       <template x-if="!trashStatus.cloned">
         <span>TRaSH not synced</span>
@@ -35,7 +38,7 @@
       </button>
 
       <!-- Changelog dropdown -->
-      <div x-show="showChangelog" @click.outside="showChangelog = false" x-cloak class="changelog-dropdown">
+      <div id="trash-changelog-dropdown" x-show="showChangelog" @click.outside="showChangelog = false" x-cloak class="changelog-dropdown">
 
         <!-- Last pull diff -->
         <template x-if="trashStatus.lastDiff">

--- a/ui/static/partials/modals/backup-instance.html
+++ b/ui/static/partials/modals/backup-instance.html
@@ -1,8 +1,8 @@
 {{define "modals/backup-instance"}}
   <!-- Backup modal -->
-  <div class="modal-overlay" x-show="showBackupModal" @click.self="showBackupModal = false" x-cloak>
-    <div class="modal" style="max-width:600px">
-      <div class="modal-title">Backup Instance</div>
+  <div class="modal-overlay" x-show="showBackupModal" @click.self="showBackupModal = false" @keydown.escape.window="showBackupModal = false" x-cloak>
+    <div class="modal" style="max-width:600px" role="dialog" aria-modal="true" aria-labelledby="modal-title-backup-instance" x-trap.noscroll.inert="showBackupModal">
+      <h2 id="modal-title-backup-instance" class="modal-title">Backup Instance</h2>
       <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px" x-text="backupInstance?.name || ''"></div>
 
       <template x-if="backupLoading && backupProfiles.length === 0 && backupCFs.length === 0">

--- a/ui/static/partials/modals/cf-editor.html
+++ b/ui/static/partials/modals/cf-editor.html
@@ -201,10 +201,13 @@
 
       <!-- JSON Preview (collapsible) -->
       <div style="margin-bottom:16px">
-        <div style="font-size:12px;color:var(--accent-blue);cursor:pointer;user-select:none" @click="cfEditorShowPreview = !cfEditorShowPreview">
+        <button type="button" class="collapse-toggle" style="font-size:12px;color:var(--accent-blue);user-select:none"
+                @click="cfEditorShowPreview = !cfEditorShowPreview"
+                :aria-expanded="cfEditorShowPreview"
+                aria-controls="cf-editor-preview">
           <span x-text="cfEditorShowPreview ? '▼' : '▶'"></span> JSON Preview
-        </div>
-        <div x-show="cfEditorShowPreview" style="margin-top:4px">
+        </button>
+        <div id="cf-editor-preview" x-show="cfEditorShowPreview" style="margin-top:4px">
           <pre style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:8px 12px;font-size:13px;color:var(--text-muted);max-height:200px;overflow:auto;white-space:pre-wrap" x-text="getCFEditorPreviewJSON()"></pre>
         </div>
       </div>

--- a/ui/static/partials/modals/cf-editor.html
+++ b/ui/static/partials/modals/cf-editor.html
@@ -1,9 +1,9 @@
 {{define "modals/cf-editor"}}
   <!-- CF Editor Modal (Create/Edit) -->
   <template x-if="showCFEditor">
-  <div class="modal-overlay" @click.self="showCFEditor = false">
-    <div class="modal" style="max-width:720px;max-height:90vh;overflow-y:auto">
-      <div class="modal-title" x-text="cfEditorMode === 'edit' ? 'Edit Custom Format' : 'Create Custom Format'"></div>
+  <div class="modal-overlay" @click.self="showCFEditor = false" @keydown.escape.window="showCFEditor = false">
+    <div class="modal" style="max-width:720px;max-height:90vh;overflow-y:auto" role="dialog" aria-modal="true" aria-labelledby="modal-title-cf-editor" x-trap.noscroll.inert="showCFEditor">
+      <h2 id="modal-title-cf-editor" class="modal-title" x-text="cfEditorMode === 'edit' ? 'Edit Custom Format' : 'Create Custom Format'"></h2>
 
       <!-- Header fields -->
       <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:16px">

--- a/ui/static/partials/modals/cf-export.html
+++ b/ui/static/partials/modals/cf-export.html
@@ -1,8 +1,8 @@
 {{define "modals/cf-export"}}
   <!-- Export TRaSH JSON Modal -->
-  <div class="modal-overlay" x-show="cfExportContent" @click.self="cfExportContent = ''" x-cloak>
-    <div class="modal" style="max-width:700px">
-      <div class="modal-title">Export TRaSH JSON</div>
+  <div class="modal-overlay" x-show="cfExportContent" @click.self="cfExportContent = ''" @keydown.escape.window="cfExportContent = ''" x-cloak>
+    <div class="modal" style="max-width:700px" role="dialog" aria-modal="true" aria-labelledby="modal-title-cf-export" x-trap.noscroll.inert="cfExportContent">
+      <h2 id="modal-title-cf-export" class="modal-title">Export TRaSH JSON</h2>
       <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
         TRaSH Guides format — use this to share custom formats or contribute to the guides.
       </div>

--- a/ui/static/partials/modals/cleanup-result.html
+++ b/ui/static/partials/modals/cleanup-result.html
@@ -1,11 +1,11 @@
 {{define "modals/cleanup-result"}}
   <!-- Cleanup results modal (shared across tabs) -->
   <template x-if="cleanupResult">
-    <div class="modal-overlay" @click.self="cleanupResult = null">
-      <div class="modal" style="max-width:700px">
+    <div class="modal-overlay" @click.self="cleanupResult = null" @keydown.escape.window="cleanupResult = null">
+      <div class="modal" style="max-width:700px" role="dialog" aria-modal="true" aria-labelledby="modal-title-cleanup-result" x-trap.noscroll.inert="cleanupResult">
         <div class="modal-header">
-          <div class="modal-title" x-text="cleanupActionLabel(cleanupResult.action) + ' — ' + cleanupResult.instance"></div>
-          <button class="modal-close" @click="cleanupResult = null">&times;</button>
+          <h2 id="modal-title-cleanup-result" class="modal-title" x-text="cleanupActionLabel(cleanupResult.action) + ' — ' + cleanupResult.instance"></h2>
+          <button class="modal-close" aria-label="Close cleanup result" @click="cleanupResult = null">&times;</button>
         </div>
         <div class="modal-body" style="max-height:500px;overflow-y:auto">
           <!-- Apply result -->

--- a/ui/static/partials/modals/cleanup-result.html
+++ b/ui/static/partials/modals/cleanup-result.html
@@ -1,5 +1,5 @@
 {{define "modals/cleanup-result"}}
-  <!-- Cleanup results modal (shared across tabs) -->
+  <!-- Cleanup results modal shared by every cleanup action. -->
   <template x-if="cleanupResult">
     <div class="modal-overlay" @click.self="cleanupResult = null" @keydown.escape.window="cleanupResult = null">
       <div class="modal" style="max-width:700px" role="dialog" aria-modal="true" aria-labelledby="modal-title-cleanup-result" x-trap.noscroll.inert="cleanupResult">

--- a/ui/static/partials/modals/compare-quick-sync.html
+++ b/ui/static/partials/modals/compare-quick-sync.html
@@ -1,5 +1,4 @@
 {{define "modals/compare-quick-sync"}}
-  <!-- Confirm modal -->
   <!-- Per-card Quick Sync modal — simplified confirm with Sync/Dry Run/Cancel, no dropdowns. -->
   <div class="modal-overlay" x-show="compareQuickSync.show" @click.self="if (!compareQuickSync.running) compareQuickSync = { show: false }" @keydown.escape.window="if (!compareQuickSync.running) compareQuickSync = { show: false }" x-cloak>
     <div class="modal" style="max-width:440px" role="dialog" aria-modal="true" aria-labelledby="modal-title-compare-quick-sync" x-trap.noscroll.inert="compareQuickSync.show" @click.stop>

--- a/ui/static/partials/modals/compare-quick-sync.html
+++ b/ui/static/partials/modals/compare-quick-sync.html
@@ -1,10 +1,10 @@
 {{define "modals/compare-quick-sync"}}
   <!-- Confirm modal -->
   <!-- Per-card Quick Sync modal — simplified confirm with Sync/Dry Run/Cancel, no dropdowns. -->
-  <div class="modal-overlay" x-show="compareQuickSync.show" @click.self="if (!compareQuickSync.running) compareQuickSync = { show: false }" x-cloak>
-    <div class="modal" style="max-width:440px" @click.stop>
+  <div class="modal-overlay" x-show="compareQuickSync.show" @click.self="if (!compareQuickSync.running) compareQuickSync = { show: false }" @keydown.escape.window="if (!compareQuickSync.running) compareQuickSync = { show: false }" x-cloak>
+    <div class="modal" style="max-width:440px" role="dialog" aria-modal="true" aria-labelledby="modal-title-compare-quick-sync" x-trap.noscroll.inert="compareQuickSync.show" @click.stop>
       <div class="modal-header">
-        <div style="font-size:15px;font-weight:600" x-text="compareQuickSync.title"></div>
+        <h2 id="modal-title-compare-quick-sync" class="modal-title" style="font-size:15px;font-weight:600" x-text="compareQuickSync.title"></h2>
       </div>
       <div class="modal-body" style="font-size:13px;line-height:1.55">
         <div style="margin-bottom:10px">

--- a/ui/static/partials/modals/confirm-dialog.html
+++ b/ui/static/partials/modals/confirm-dialog.html
@@ -1,9 +1,9 @@
 {{define "modals/confirm-dialog"}}
   <!-- z-index:2000 so confirm prompts always sit above any custom modal
        (e.g. Quality Items editor at z-index:1000). -->
-  <div class="modal-overlay" style="z-index:2000" x-show="confirmModal.show" @click.self="confirmModal.show = false; if(confirmModal.onCancel) confirmModal.onCancel()" x-cloak>
-    <div class="modal" style="max-width:420px">
-      <div class="modal-title" x-text="confirmModal.title"></div>
+  <div class="modal-overlay" style="z-index:2000" x-show="confirmModal.show" @click.self="confirmModal.show = false; if(confirmModal.onCancel) confirmModal.onCancel()" @keydown.escape.window="confirmModal.show = false; if(confirmModal.onCancel) confirmModal.onCancel()" x-cloak>
+    <div class="modal" style="max-width:420px" role="dialog" aria-modal="true" aria-labelledby="modal-title-confirm-dialog" x-trap.noscroll.inert="confirmModal.show">
+      <h2 id="modal-title-confirm-dialog" class="modal-title" x-text="confirmModal.title"></h2>
       <div style="font-size:13px;color:var(--text-muted);white-space:pre-line;line-height:1.6" x-show="!confirmModal.html" x-text="confirmModal.message"></div>
       <div style="font-size:13px;color:var(--text-muted);line-height:1.6" x-show="confirmModal.html" x-html="confirmModal.message"></div>
       <div class="modal-actions">

--- a/ui/static/partials/modals/disable-auth.html
+++ b/ui/static/partials/modals/disable-auth.html
@@ -21,8 +21,10 @@
       </label>
       <input type="password" class="input" x-model="disableAuthPassword" autocomplete="current-password" placeholder="current password"
              @keydown.enter="disableAuthPassword && (disableAuthModalOpen = false, saveSecurityConfig(true))"
-             style="width:100%;margin-bottom:8px">
-      <div x-show="disableAuthError" x-text="disableAuthError" style="color:var(--accent-red-soft);font-size:12px;margin:0 0 10px"></div>
+             style="width:100%;margin-bottom:8px"
+             :aria-invalid="!!disableAuthError"
+             :aria-describedby="disableAuthError ? 'disable-auth-error' : null">
+      <div id="disable-auth-error" class="field-error" x-show="disableAuthError" x-text="disableAuthError"></div>
       <div style="display:flex;gap:8px;justify-content:flex-end">
         <button class="btn btn-secondary"
                 @click="disableAuthModalOpen = false; disableAuthError = ''; disableAuthPassword = ''; config.authentication = authStatus.authentication || 'forms'">Cancel</button>

--- a/ui/static/partials/modals/disable-auth.html
+++ b/ui/static/partials/modals/disable-auth.html
@@ -4,8 +4,9 @@
        style="position:fixed;top:0;right:0;bottom:0;left:0;width:100vw;height:100vh;background:var(--alpha-overlay);display:flex;align-items:center;justify-content:center;z-index:10000;padding:20px;box-sizing:border-box"
        @keydown.escape.window="disableAuthModalOpen = false; disableAuthError = ''">
     <div @click.outside="disableAuthModalOpen = false; disableAuthError = ''"
-         style="background:var(--bg-card);border:2px solid var(--banner-warn-border);border-radius:10px;padding:24px 28px;width:min(520px,100%);max-height:90vh;overflow-y:auto;box-shadow:0 12px 40px var(--alpha-shadow)">
-      <h2 style="margin:0 0 10px;font-size:20px;color:var(--accent-red-soft)">⚠️ Disable authentication?</h2>
+         style="background:var(--bg-card);border:2px solid var(--banner-warn-border);border-radius:10px;padding:24px 28px;width:min(520px,100%);max-height:90vh;overflow-y:auto;box-shadow:0 12px 40px var(--alpha-shadow)"
+         role="dialog" aria-modal="true" aria-labelledby="modal-title-disable-auth" x-trap.noscroll.inert="disableAuthModalOpen">
+      <h2 id="modal-title-disable-auth" style="margin:0 0 10px;font-size:20px;color:var(--accent-red-soft)">⚠️ Disable authentication?</h2>
       <p style="font-size:13px;line-height:1.5;color:var(--text-body);margin:10px 0 8px">
         You are about to turn off login for <strong>Clonarr</strong>. After this change, anyone who reaches this UI will be admin — they can modify your Radarr/Sonarr/Prowlarr API keys, change Discord webhooks to their own server, and read every notification token.
       </p>

--- a/ui/static/partials/modals/export-profile.html
+++ b/ui/static/partials/modals/export-profile.html
@@ -1,9 +1,9 @@
 {{define "modals/export-profile"}}
   <!-- ==================== IMPORT MODAL ==================== -->
   <!-- ==================== EXPORT MODAL ==================== -->
-  <div class="modal-overlay" x-show="showExportModal" @click.self="closeExportModal()" x-cloak>
-    <div class="modal" style="max-width:700px">
-      <div class="modal-title">Export Profile</div>
+  <div class="modal-overlay" x-show="showExportModal" @click.self="closeExportModal()" @keydown.escape.window="closeExportModal()" x-cloak>
+    <div class="modal" style="max-width:700px" role="dialog" aria-modal="true" aria-labelledby="modal-title-export-profile" x-trap.noscroll.inert="showExportModal">
+      <h2 id="modal-title-export-profile" class="modal-title">Export Profile</h2>
       <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
         Copy this profile configuration to use in other tools or share with others.
       </div>

--- a/ui/static/partials/modals/export-profile.html
+++ b/ui/static/partials/modals/export-profile.html
@@ -1,5 +1,4 @@
 {{define "modals/export-profile"}}
-  <!-- ==================== IMPORT MODAL ==================== -->
   <!-- ==================== EXPORT MODAL ==================== -->
   <div class="modal-overlay" x-show="showExportModal" @click.self="closeExportModal()" @keydown.escape.window="closeExportModal()" x-cloak>
     <div class="modal" style="max-width:700px" role="dialog" aria-modal="true" aria-labelledby="modal-title-export-profile" x-trap.noscroll.inert="showExportModal">

--- a/ui/static/partials/modals/import-cf.html
+++ b/ui/static/partials/modals/import-cf.html
@@ -1,8 +1,8 @@
 {{define "modals/import-cf"}}
   <!-- Import Custom CFs Modal -->
-  <div class="modal-overlay" x-show="showImportCFModal" @click.self="showImportCFModal = false" x-cloak>
-    <div class="modal" style="max-width:600px">
-      <div class="modal-title">Import Custom Formats</div>
+  <div class="modal-overlay" x-show="showImportCFModal" @click.self="showImportCFModal = false" @keydown.escape.window="showImportCFModal = false" x-cloak>
+    <div class="modal" style="max-width:600px" role="dialog" aria-modal="true" aria-labelledby="modal-title-import-cf" x-trap.noscroll.inert="showImportCFModal">
+      <h2 id="modal-title-import-cf" class="modal-title">Import Custom Formats</h2>
       <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
         Import custom formats from an Arr instance or JSON. Imported CFs appear in the CF browser and are available in the profile builder.
       </div>

--- a/ui/static/partials/modals/import-profile.html
+++ b/ui/static/partials/modals/import-profile.html
@@ -1,7 +1,7 @@
 {{define "modals/import-profile"}}
-  <div class="modal-overlay" x-show="showImportModal !== false" @click.self="showImportModal = false" x-cloak>
-    <div class="modal" style="max-width:600px">
-      <div class="modal-title">Import Profile</div>
+  <div class="modal-overlay" x-show="showImportModal !== false" @click.self="showImportModal = false" @keydown.escape.window="showImportModal = false" x-cloak>
+    <div class="modal" style="max-width:600px" role="dialog" aria-modal="true" aria-labelledby="modal-title-import-profile" x-trap.noscroll.inert="showImportModal !== false">
+      <h2 id="modal-title-import-profile" class="modal-title">Import Profile</h2>
       <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
         Paste or upload a profile configuration. Supports Recyclarr YAML, TRaSH JSON, and Clonarr JSON. Multiple profiles and both Radarr and Sonarr are detected automatically.
       </div>

--- a/ui/static/partials/modals/input-dialog.html
+++ b/ui/static/partials/modals/input-dialog.html
@@ -2,15 +2,15 @@
   <!-- Input modal (single text field). z-index above any custom modal (e.g. the
        Quality Items editor at z-index:1000) so input prompts triggered from inside
        another modal aren't hidden behind it. -->
-  <div class="modal-overlay" style="z-index:2000" x-show="inputModal.show" @click.self="inputModal.show = false; if(inputModal.onCancel) inputModal.onCancel()" x-cloak>
-    <div class="modal" style="max-width:420px">
-      <div class="modal-title" x-text="inputModal.title"></div>
+  <div class="modal-overlay" style="z-index:2000" x-show="inputModal.show" @click.self="inputModal.show = false; if(inputModal.onCancel) inputModal.onCancel()" @keydown.escape.window="inputModal.show = false; if(inputModal.onCancel) inputModal.onCancel()" x-cloak>
+    <div class="modal" style="max-width:420px" role="dialog" aria-modal="true" aria-labelledby="modal-title-input-dialog" x-trap.noscroll.inert="inputModal.show">
+      <h2 id="modal-title-input-dialog" class="modal-title" x-text="inputModal.title"></h2>
       <div x-show="inputModal.message" style="font-size:13px;color:var(--text-muted);white-space:pre-line;line-height:1.6;margin-bottom:8px" x-text="inputModal.message"></div>
       <input type="text" class="input" style="width:100%;font-size:13px;padding:6px 10px"
              x-model="inputModal.value"
              :placeholder="inputModal.placeholder || ''"
              @keyup.enter="if (!inputModal.value || !inputModal.value.trim()) return; inputModal.show = false; if(inputModal.onConfirm) inputModal.onConfirm(inputModal.value)"
-             @keyup.escape="inputModal.show = false; if(inputModal.onCancel) inputModal.onCancel()"
+             @keydown.escape.stop="inputModal.show = false; if(inputModal.onCancel) inputModal.onCancel()"
              x-init="$watch('inputModal.show', v => { if (v) $nextTick(() => $el.focus()) })">
       <div class="modal-actions">
         <button class="btn" @click="inputModal.show = false; if(inputModal.onCancel) inputModal.onCancel()">Cancel</button>

--- a/ui/static/partials/modals/instance.html
+++ b/ui/static/partials/modals/instance.html
@@ -1,8 +1,8 @@
 {{define "modals/instance"}}
   <!-- ==================== INSTANCE MODAL ==================== -->
-  <div class="modal-overlay" x-show="showInstanceModal" @click.self="showInstanceModal = false" x-cloak>
-    <div class="modal">
-      <div class="modal-title" x-text="editingInstance ? 'Edit Instance' : 'Add Instance'"></div>
+  <div class="modal-overlay" x-show="showInstanceModal" @click.self="showInstanceModal = false" @keydown.escape.window="showInstanceModal = false" x-cloak>
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title-instance" x-trap.noscroll.inert="showInstanceModal">
+      <h2 id="modal-title-instance" class="modal-title" x-text="editingInstance ? 'Edit Instance' : 'Add Instance'"></h2>
       <div class="form-group">
         <label>Name</label>
         <input class="input" x-model="instanceForm.name" placeholder="e.g. Radarr HD">

--- a/ui/static/partials/modals/instance.html
+++ b/ui/static/partials/modals/instance.html
@@ -5,7 +5,10 @@
       <h2 id="modal-title-instance" class="modal-title" x-text="editingInstance ? 'Edit Instance' : 'Add Instance'"></h2>
       <div class="form-group">
         <label>Name</label>
-        <input class="input" x-model="instanceForm.name" placeholder="e.g. Radarr HD">
+        <input class="input" x-model="instanceForm.name" placeholder="e.g. Radarr HD"
+               :aria-invalid="!!instanceFormErrors.name"
+               :aria-describedby="instanceFormErrors.name ? 'instance-name-error' : null">
+        <div id="instance-name-error" class="field-error" x-show="instanceFormErrors.name" x-text="instanceFormErrors.name"></div>
       </div>
       <div class="form-group">
         <label>Type</label>
@@ -16,11 +19,17 @@
       </div>
       <div class="form-group">
         <label>URL</label>
-        <input class="input" x-model="instanceForm.url" placeholder="http://192.168.86.22:7878" autocomplete="one-time-code">
+        <input class="input" x-model="instanceForm.url" placeholder="http://192.168.86.22:7878" autocomplete="one-time-code"
+               :aria-invalid="!!instanceFormErrors.url"
+               :aria-describedby="instanceFormErrors.url ? 'instance-url-error' : null">
+        <div id="instance-url-error" class="field-error" x-show="instanceFormErrors.url" x-text="instanceFormErrors.url"></div>
       </div>
       <div class="form-group">
         <label>API Key</label>
-        <input class="input" x-model="instanceForm.apiKey" :placeholder="editingInstance ? 'Leave empty to keep current key' : 'Radarr/Sonarr API key'" :type="editingInstance && !instanceForm.apiKey ? 'text' : 'password'" autocomplete="one-time-code">
+        <input class="input" x-model="instanceForm.apiKey" :placeholder="editingInstance ? 'Leave empty to keep current key' : 'Radarr/Sonarr API key'" :type="editingInstance && !instanceForm.apiKey ? 'text' : 'password'" autocomplete="one-time-code"
+               :aria-invalid="!!instanceFormErrors.apiKey"
+               :aria-describedby="instanceFormErrors.apiKey ? 'instance-apikey-error' : null">
+        <div id="instance-apikey-error" class="field-error" x-show="instanceFormErrors.apiKey" x-text="instanceFormErrors.apiKey"></div>
         <div x-show="editingInstance && !instanceForm.apiKey" style="font-size:13px;color:var(--text-muted);margin-top:4px">API key is saved — leave empty to keep it, or enter a new one to replace it.</div>
       </div>
       <!-- Test result -->

--- a/ui/static/partials/modals/instance.html
+++ b/ui/static/partials/modals/instance.html
@@ -45,7 +45,7 @@
         </template>
       </div>
       <div class="modal-actions">
-        <button class="btn" @click="testConnectionInModal()" :disabled="!instanceForm.url || !instanceForm.apiKey || modalTestResult === 'testing'">Test</button>
+        <button class="btn" @click="testConnectionInModal()" :disabled="!(instanceForm.url || '').trim() || (!editingInstance && !(instanceForm.apiKey || '').trim()) || modalTestResult === 'testing'">Test</button>
         <div style="flex:1"></div>
         <button class="btn" @click="showInstanceModal = false">Cancel</button>
         <button class="btn btn-primary" @click="saveInstance()">

--- a/ui/static/partials/modals/notification-agent.html
+++ b/ui/static/partials/modals/notification-agent.html
@@ -9,9 +9,9 @@
       - kind="field"     → one input row (Field) bound to agentModal.config[name]
       - kind="priority"  → 3 priority levels with checkbox + number input
   -->
-  <div class="modal-overlay" x-show="agentModal.show" @click.self="agentModal.show = false" x-cloak>
-    <div class="modal" style="min-width:480px;max-width:560px">
-      <div class="modal-title" x-text="agentModal.editId ? 'Edit Notification Agent' : 'Add Notification Agent'"></div>
+  <div class="modal-overlay" x-show="agentModal.show" @click.self="agentModal.show = false" @keydown.escape.window="agentModal.show = false" x-cloak>
+    <div class="modal" style="min-width:480px;max-width:560px" role="dialog" aria-modal="true" aria-labelledby="modal-title-notification-agent" x-trap.noscroll.inert="agentModal.show">
+      <h2 id="modal-title-notification-agent" class="modal-title" x-text="agentModal.editId ? 'Edit Notification Agent' : 'Add Notification Agent'"></h2>
 
       <!-- Name -->
       <div class="form-group">

--- a/ui/static/partials/modals/restore-instance.html
+++ b/ui/static/partials/modals/restore-instance.html
@@ -1,8 +1,8 @@
 {{define "modals/restore-instance"}}
   <!-- Restore modal -->
-  <div class="modal-overlay" x-show="showRestoreModal" @click.self="showRestoreModal = false" x-cloak>
-    <div class="modal" style="max-width:600px">
-      <div class="modal-title">Restore to Instance</div>
+  <div class="modal-overlay" x-show="showRestoreModal" @click.self="showRestoreModal = false" @keydown.escape.window="showRestoreModal = false" x-cloak>
+    <div class="modal" style="max-width:600px" role="dialog" aria-modal="true" aria-labelledby="modal-title-restore-instance" x-trap.noscroll.inert="showRestoreModal">
+      <h2 id="modal-title-restore-instance" class="modal-title">Restore to Instance</h2>
       <div style="font-size:12px;color:var(--text-muted);margin-bottom:12px" x-text="restoreInstance?.name || ''"></div>
 
       <!-- Step 1: Upload file -->

--- a/ui/static/partials/modals/sandbox-cf-browser.html
+++ b/ui/static/partials/modals/sandbox-cf-browser.html
@@ -16,11 +16,13 @@
           <div style="margin-bottom:4px">
             <!-- Category header -->
             <div :class="getCategoryClass(cat.category)" style="margin:0 8px">
-              <div class="pb-cat-header" @click="sandboxCFBrowser.expanded[cat.category] = !sandboxCFBrowser.expanded[cat.category]">
+              <button type="button" class="pb-cat-header"
+                      @click="sandboxCFBrowser.expanded[cat.category] = !sandboxCFBrowser.expanded[cat.category]"
+                      :aria-expanded="sandboxCFBrowser.expanded[cat.category]">
                 <span class="profile-group-chevron" :class="{ open: sandboxCFBrowser.expanded[cat.category] }">&#9654;</span>
                 <span style="font-size:13px;font-weight:500" x-text="cat.category"></span>
                 <span class="pb-cat-count" x-text="sandboxCFBrowserCatCount(cat)"></span>
-              </div>
+              </button>
             </div>
 
             <!-- CFs in category -->
@@ -55,11 +57,13 @@
         <!-- Custom CFs section -->
         <template x-if="(sandboxCFBrowser.customCFs || []).length > 0">
           <div style="margin:4px 8px 0">
-            <div class="pb-cat-header" style="border-left:3px solid var(--accent-orange)" @click="sandboxCFBrowser.expanded['Custom'] = !sandboxCFBrowser.expanded['Custom']">
+            <button type="button" class="pb-cat-header" style="border-left:3px solid var(--accent-orange)"
+                    @click="sandboxCFBrowser.expanded['Custom'] = !sandboxCFBrowser.expanded['Custom']"
+                    :aria-expanded="sandboxCFBrowser.expanded['Custom']">
               <span class="profile-group-chevron" :class="{ open: sandboxCFBrowser.expanded['Custom'] }">&#9654;</span>
               <span style="font-size:13px;font-weight:500;color:var(--accent-orange)">Custom CFs</span>
               <span class="pb-cat-count" x-text="(sandboxCFBrowser.customCFs || []).length"></span>
-            </div>
+            </button>
             <div x-show="sandboxCFBrowser.expanded['Custom']">
               <template x-for="cf in sandboxCFBrowser.customCFs || []" :key="cf.id">
                 <div x-show="!sandboxCFBrowser.filter || cf.name.toLowerCase().includes(sandboxCFBrowser.filter.toLowerCase())"

--- a/ui/static/partials/modals/sandbox-cf-browser.html
+++ b/ui/static/partials/modals/sandbox-cf-browser.html
@@ -1,10 +1,10 @@
 {{define "modals/sandbox-cf-browser"}}
   <!-- ==================== SANDBOX CF BROWSER MODAL ==================== -->
-  <div class="modal-overlay" x-show="sandboxCFBrowser.open" @click.self="closeSandboxCFBrowser()" x-cloak>
-    <div style="background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:12px;width:700px;max-width:90vw;max-height:80vh;display:flex;flex-direction:column">
+  <div class="modal-overlay" x-show="sandboxCFBrowser.open" @click.self="closeSandboxCFBrowser()" @keydown.escape.window="closeSandboxCFBrowser()" x-cloak>
+    <div style="background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:12px;width:700px;max-width:90vw;max-height:80vh;display:flex;flex-direction:column" role="dialog" aria-modal="true" aria-labelledby="modal-title-sandbox-cf-browser" x-trap.noscroll.inert="sandboxCFBrowser.open">
       <!-- Header -->
       <div style="padding:16px 20px;border-bottom:1px solid var(--border-subtle);display:flex;align-items:center;gap:12px">
-        <div style="font-size:15px;font-weight:600">Add Custom Formats</div>
+        <h2 id="modal-title-sandbox-cf-browser" style="font-size:15px;font-weight:600">Add Custom Formats</h2>
         <input type="text" class="pb-input" placeholder="Filter..." style="width:200px;font-size:13px;margin-left:auto"
                x-model="sandboxCFBrowser.filter">
         <button class="btn btn-sm" @click="closeSandboxCFBrowser()">Done</button>

--- a/ui/static/partials/modals/sandbox-copy.html
+++ b/ui/static/partials/modals/sandbox-copy.html
@@ -2,11 +2,11 @@
   <!-- Sandbox Copy modal — per-row "share these release details" popup. Plain-text block
        inside a <pre> so the user can highlight portions manually, plus a one-click Copy. -->
   <div class="modal-overlay" x-show="sandboxCopyModal.show" @keydown.escape.window="sandboxCopyModal.show = false" x-cloak>
-    <div class="modal" style="max-width:720px;width:90vw">
-      <div class="modal-title" style="display:flex;align-items:center;gap:8px">
+    <div class="modal" style="max-width:720px;width:90vw" role="dialog" aria-modal="true" aria-labelledby="modal-title-sandbox-copy" x-trap.noscroll.inert="sandboxCopyModal.show">
+      <h2 id="modal-title-sandbox-copy" class="modal-title" style="display:flex;align-items:center;gap:8px">
         <span>Release Details</span>
         <span style="font-size:11px;color:var(--text-secondary);font-weight:400">(selectable · copy for sharing)</span>
-      </div>
+      </h2>
       <pre style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px 14px;margin:0;max-height:60vh;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.55;color:var(--text-body);white-space:pre-wrap;user-select:text" x-text="sandboxCopyModal.text"></pre>
       <div class="modal-actions">
         <button class="btn" @click="sandboxCopyModal.show = false">Close</button>

--- a/ui/static/partials/modals/sync-profile.html
+++ b/ui/static/partials/modals/sync-profile.html
@@ -4,10 +4,10 @@
        and Cancel close it, to prevent accidental loss of a half-edited sync
        form. Esc is bound on the wrapper via @keyup.escape.window. -->
   <div class="modal-overlay" x-show="showSyncModal" @keyup.escape.window="showSyncModal = false" x-cloak>
-    <div class="modal" style="width:560px">
+    <div class="modal" style="width:560px" role="dialog" aria-modal="true" aria-labelledby="modal-title-sync-profile" x-trap.noscroll.inert="showSyncModal">
       <!-- Scrollable content region so many diffs don't push Cancel/Dry Run/Apply off-screen -->
       <div style="flex:1 1 auto;overflow-y:auto;min-height:0;padding:24px">
-      <div class="modal-title">Sync Profile</div>
+      <h2 id="modal-title-sync-profile" class="modal-title">Sync Profile</h2>
       <div style="font-size:13px;color:var(--text-muted);margin-bottom:12px">
         Deploy <strong x-text="syncForm.profileName" style="color:var(--text-primary)"></strong> to an instance
       </div>

--- a/ui/static/partials/modals/tooltip.html
+++ b/ui/static/partials/modals/tooltip.html
@@ -7,7 +7,7 @@
        x-tt directive (registered in main.js) on any element:
          x-tt="'static text'"      static label
          x-tt="someExpr"           dynamic expression -->
-  <div x-show="tt.show" x-cloak
-       :style="`position:fixed;left:${tt.x}px;top:${tt.y + (tt.flip ? 8 : -8)}px;transform:translate(-50%, ${tt.flip ? '0' : '-100%'});pointer-events:none;background:#0d1117;border:1px solid #30363d;border-radius:5px;padding:6px 10px;font-size:12px;color:#e1e4e8;line-height:1.4;max-width:320px;width:max-content;white-space:normal;text-align:center;box-shadow:0 4px 12px rgba(0,0,0,0.6);z-index:10000;`"
+  <div id="global-tooltip" role="tooltip" x-show="tt.show" x-cloak
+       :style="`position:fixed;left:${tt.x}px;top:${tt.y + (tt.flip ? 8 : -8)}px;transform:translate(-50%, ${tt.flip ? '0' : '-100%'});background:#0d1117;border:1px solid #30363d;border-radius:5px;padding:6px 10px;font-size:12px;color:#e1e4e8;line-height:1.4;max-width:320px;width:max-content;white-space:normal;text-align:center;box-shadow:0 4px 12px rgba(0,0,0,0.6);z-index:10000;pointer-events:none;`"
        x-text="tt.text"></div>
 {{end}}

--- a/ui/static/partials/overlays/profile-builder.html
+++ b/ui/static/partials/overlays/profile-builder.html
@@ -29,12 +29,14 @@
 
       <!-- Settings Card -->
       <div class="card" style="overflow:visible;margin-top:16px">
-        <div class="profile-group-header" @click="pbSettingsOpen = !pbSettingsOpen">
+        <button type="button" class="profile-group-header" @click="pbSettingsOpen = !pbSettingsOpen"
+                :aria-expanded="pbSettingsOpen"
+                aria-controls="pb-settings-body">
           <span class="profile-group-chevron" :class="{ open: pbSettingsOpen }">&#9654;</span>
           <span>Profile Settings</span>
           <span style="font-size:12px;color:var(--text-muted);margin-left:auto" x-text="pbSelectedCount() + ' CFs selected'"></span>
-        </div>
-        <div x-show="pbSettingsOpen">
+        </button>
+        <div id="pb-settings-body" x-show="pbSettingsOpen">
           <div style="padding:14px 20px;display:flex;flex-direction:column;gap:14px">
             <!-- Profile Name -->
             <div class="pb-header" style="margin-bottom:0">
@@ -347,12 +349,15 @@
             <!-- TRaSH schema fields — collapsible, grey stripe. Gated by CLONARR_DEV_FEATURES env + trashSchemaFields toggle. -->
             <template x-if="config.devFeatures && config.trashSchemaFields">
               <div class="pd-card" style="border-left:3px solid var(--text-muted-secondary);padding:10px 18px">
-                <div @click="pbAdvancedOpen = !pbAdvancedOpen" style="cursor:pointer;display:flex;align-items:center;gap:8px">
+                <button type="button" class="collapse-toggle" @click="pbAdvancedOpen = !pbAdvancedOpen"
+                        :aria-expanded="pbAdvancedOpen"
+                        aria-controls="pb-advanced-body"
+                        style="display:flex;align-items:center;gap:8px">
                   <span style="color:var(--text-secondary)" x-text="pbAdvancedOpen ? '▾' : '▸'"></span>
                   <span style="font-size:12px;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;font-weight:700">Advanced Mode</span>
                   <span style="font-size:11px;color:var(--text-secondary)">TRaSH ID, Group number, HTML description</span>
-                </div>
-                <div x-show="pbAdvancedOpen" style="margin-top:12px">
+                </button>
+                <div id="pb-advanced-body" x-show="pbAdvancedOpen" style="margin-top:12px">
                 <div class="pb-dev-fields">
                   <div style="font-size:12px;color:var(--accent-orange);margin-bottom:6px">Advanced fields</div>
                 <div class="pb-wide-row" style="margin-bottom:6px">
@@ -390,11 +395,13 @@
       <template x-if="!pbLoading && pbCategories.length > 0">
         <div>
           <div class="card" style="margin-bottom:12px">
-            <div class="pb-cat-header" @click="pbExpandedCats['__formatItems__'] = !(pbExpandedCats['__formatItems__'] ?? true)">
+            <button type="button" class="pb-cat-header"
+                    @click="pbExpandedCats['__formatItems__'] = !(pbExpandedCats['__formatItems__'] ?? true)"
+                    :aria-expanded="pbExpandedCats['__formatItems__'] ?? true">
               <span class="profile-group-chevron" :class="{ open: pbExpandedCats['__formatItems__'] ?? true }">&#9654;</span>
               <span style="font-size:13px;font-weight:500">Required CFs</span>
               <span class="pb-cat-count" x-text="pbFormatItemCount() + ' in formatItems'"></span>
-            </div>
+            </button>
             <div x-show="pbExpandedCats['__formatItems__'] ?? true">
               <div style="padding:8px 16px;font-size:12px;color:var(--text-muted);border-bottom:1px solid var(--bg-card);line-height:1.5">
                 These CFs are added to the profile's <code style="background:var(--bg-muted);padding:1px 4px;border-radius:2px;color:var(--text-body);font-size:13px">formatItems</code> — they are mandatory and always synced. End users cannot disable them.
@@ -430,9 +437,10 @@
               </div>
               <!-- Add more CFs (collapsed, with search) -->
               <div style="padding:6px 16px;border-top:1px solid var(--bg-card);display:flex;align-items:center;gap:12px">
-                <span style="font-size:13px;color:var(--accent-blue);cursor:pointer;flex-shrink:0"
-                      @click="pbAddMoreOpen = !pbAddMoreOpen; pbFormatItemSearch = ''"
-                      x-text="pbAddMoreOpen ? '▾ Hide available CFs' : '▸ Add more CFs...'"></span>
+                <button type="button" class="inline-action" style="font-size:13px;color:var(--accent-blue);flex-shrink:0"
+                        @click="pbAddMoreOpen = !pbAddMoreOpen; pbFormatItemSearch = ''"
+                        :aria-expanded="pbAddMoreOpen"
+                        x-text="pbAddMoreOpen ? '▾ Hide available CFs' : '▸ Add more CFs...'"></button>
                 <template x-if="pbAddMoreOpen">
                   <input type="text" class="pb-input" x-model="pbFormatItemSearch"
                          placeholder="Search CFs..."
@@ -474,24 +482,29 @@
 
           <template x-for="group in pbSortedGroups()" :key="'grp-'+group.groupTrashId">
             <div class="card" :class="getCategoryClass(group._category || '')" style="margin-bottom:8px">
-              <div class="pb-cat-header" @click="pbExpandedGroups[group.groupTrashId] = !(pbExpandedGroups[group.groupTrashId] ?? false)">
-                <span class="profile-group-chevron" :class="{ open: pbExpandedGroups[group.groupTrashId] }">&#9654;</span>
-                <span style="font-size:13px;font-weight:500" x-text="group.name"></span>
-                <span x-show="group.exclusive" class="group-badge badge-exclusive">pick one</span>
-                <span x-show="group.defaultEnabled" class="group-badge badge-default">default</span>
-                <span class="pb-cat-count" x-text="group.cfs.length + ' CFs'"></span>
+              <div class="pb-cat-header">
+                <button type="button" class="collapse-toggle"
+                        style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                        @click="pbExpandedGroups[group.groupTrashId] = !(pbExpandedGroups[group.groupTrashId] ?? false)"
+                        :aria-expanded="pbExpandedGroups[group.groupTrashId] ?? false">
+                  <span class="profile-group-chevron" :class="{ open: pbExpandedGroups[group.groupTrashId] }">&#9654;</span>
+                  <span style="font-size:13px;font-weight:500" x-text="group.name"></span>
+                  <span x-show="group.exclusive" class="group-badge badge-exclusive">pick one</span>
+                  <span x-show="group.defaultEnabled" class="group-badge badge-default">default</span>
+                  <span class="pb-cat-count" x-text="group.cfs.length + ' CFs'"></span>
+                </button>
                 <!-- Group-level state pills -->
-                <div style="display:flex;gap:4px;margin-left:auto" @click.stop>
+                <div style="display:flex;gap:4px;margin-left:auto">
                   <span class="pb-state-pill" :class="{ 'active-req': true }" x-show="false"></span>
-                  <span class="pb-state-pill"
-                        :class="{ 'active-req': !pbGroupHasAnyState(group, 'optional') && !pbGroupHasAnyState(group, 'formatItems') }"
-                        @click="pbSetGroupState(group, 'required')" x-tt="'Set all CFs to Required'">Req</span>
-                  <span class="pb-state-pill"
-                        :class="{ 'active-opt': pbGroupHasAllState(group, 'optional') }"
-                        @click="pbSetGroupState(group, 'optional')" x-tt="'Set all CFs to Optional'">Opt</span>
-                  <span class="pb-state-pill"
-                        :class="{ 'active-fmt': pbGroupHasAllState(group, 'formatItems') }"
-                        @click="pbSetGroupState(group, 'formatItems')" x-tt="'Move all CFs to formatItems'">Fmt</span>
+                  <button type="button" class="pb-state-pill"
+                          :class="{ 'active-req': !pbGroupHasAnyState(group, 'optional') && !pbGroupHasAnyState(group, 'formatItems') }"
+                          @click="pbSetGroupState(group, 'required')" x-tt="'Set all CFs to Required'">Req</button>
+                  <button type="button" class="pb-state-pill"
+                          :class="{ 'active-opt': pbGroupHasAllState(group, 'optional') }"
+                          @click="pbSetGroupState(group, 'optional')" x-tt="'Set all CFs to Optional'">Opt</button>
+                  <button type="button" class="pb-state-pill"
+                          :class="{ 'active-fmt': pbGroupHasAllState(group, 'formatItems') }"
+                          @click="pbSetGroupState(group, 'formatItems')" x-tt="'Move all CFs to formatItems'">Fmt</button>
                 </div>
                 <label class="toggle toggle-sm" @click.stop>
                   <input type="checkbox" :checked="pbIsGroupEnabled(group)"
@@ -535,15 +548,15 @@
                     </div>
                     <!-- Three-state pills: Req / Opt / Fmt -->
                     <div style="display:flex;gap:4px;flex-shrink:0">
-                      <span class="pb-state-pill" :class="{ 'active-req': pbGetCFState(cf) === 'required' }"
-                            @click="pbSetCFState(cf.trashId, 'required')"
-                            x-tt="'Required — mandatory when group is active'">Req</span>
-                      <span class="pb-state-pill" :class="{ 'active-opt': pbGetCFState(cf) === 'optional' }"
-                            @click="pbSetCFState(cf.trashId, 'optional')"
-                            x-tt="'Optional — user chooses within group'">Opt</span>
-                      <span class="pb-state-pill" :class="{ 'active-fmt': pbGetCFState(cf) === 'formatItems' }"
-                            @click="pbSetCFState(cf.trashId, 'formatItems')"
-                            x-tt="'formatItems — always mandatory in profile'">Fmt</span>
+                      <button type="button" class="pb-state-pill" :class="{ 'active-req': pbGetCFState(cf) === 'required' }"
+                              @click="pbSetCFState(cf.trashId, 'required')"
+                              x-tt="'Required — mandatory when group is active'">Req</button>
+                      <button type="button" class="pb-state-pill" :class="{ 'active-opt': pbGetCFState(cf) === 'optional' }"
+                              @click="pbSetCFState(cf.trashId, 'optional')"
+                              x-tt="'Optional — user chooses within group'">Opt</button>
+                      <button type="button" class="pb-state-pill" :class="{ 'active-fmt': pbGetCFState(cf) === 'formatItems' }"
+                              @click="pbSetCFState(cf.trashId, 'formatItems')"
+                              x-tt="'formatItems — always mandatory in profile'">Fmt</button>
                     </div>
                     <input type="number" class="pb-score-input"
                            x-show="pbIsGroupEnabled(group) || pb.formatItemCFs[cf.trashId]"

--- a/ui/static/partials/overlays/profile-detail.html
+++ b/ui/static/partials/overlays/profile-detail.html
@@ -110,9 +110,12 @@
                 </template>
               </div>
               <template x-if="profileDetail?.detail?.profile?.trash_description">
-                <div @click="showProfileInfo = !showProfileInfo" style="margin-top:8px;cursor:pointer;font-size:12px;color:var(--accent-blue);user-select:none;display:inline-block">
+                <button type="button" class="inline-action" @click="showProfileInfo = !showProfileInfo"
+                        :aria-expanded="showProfileInfo"
+                        aria-controls="profile-info-panel"
+                        style="margin-top:8px;font-size:12px;color:var(--accent-blue);user-select:none;display:inline-block">
                   <span x-text="showProfileInfo ? '▾' : '▸'"></span> Profile info
-                </div>
+                </button>
               </template>
             </div>
             <div style="display:flex;gap:8px;flex-shrink:0" x-show="profileDetail?.detail?.imported">
@@ -128,7 +131,7 @@
           </div>
           <!-- Profile info panel (full-width below flex row, so expanding it doesn't push buttons) -->
           <template x-if="profileDetail?.detail?.profile?.trash_description">
-            <div x-show="showProfileInfo" x-cloak style="margin-top:10px;padding:12px;background:var(--bg-page);border:1px solid var(--bg-muted);border-radius:6px;font-size:12px;color:var(--text-muted);line-height:1.5">
+            <div id="profile-info-panel" x-show="showProfileInfo" x-cloak style="margin-top:10px;padding:12px;background:var(--bg-page);border:1px solid var(--bg-muted);border-radius:6px;font-size:12px;color:var(--text-muted);line-height:1.5">
               <span x-html="sanitizeHTML(profileDetail.detail.profile.trash_description)"></span>
               <template x-if="profileDetail.detail.profile.trash_url">
                 <a :href="profileDetail.detail.profile.trash_url" target="_blank" rel="noopener" style="display:block;margin-top:6px;color:var(--accent-blue);font-size:13px;text-decoration:none">View on TRaSH Guides &rarr;</a>
@@ -203,17 +206,22 @@
                  (label | TRaSH-default+↺ | input) so the input column always sits at the
                  same X-coordinate across rows regardless of override state. -->
             <div class="pd-card pd-card-general">
-              <div @click="pdGeneralCollapsed = !pdGeneralCollapsed"
-                   style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px">
-                <span class="detail-section-chevron" :class="{ open: !pdGeneralCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
-                <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">General</span>
-                <template x-if="pdGeneralChangeCount() > 0">
-                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="pdGeneralChangeCount() + (pdGeneralChangeCount() === 1 ? ' override' : ' overrides')"></span>
-                </template>
-                <template x-if="pdGeneralChangeCount() === 0">
-                  <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
-                </template>
-                <span style="margin-left:auto" @click.stop>
+              <div style="display:flex;align-items:center;gap:8px;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px">
+                <button type="button" class="collapse-toggle"
+                        style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                        @click="pdGeneralCollapsed = !pdGeneralCollapsed"
+                        :aria-expanded="!pdGeneralCollapsed"
+                        aria-controls="pd-general-body">
+                  <span class="detail-section-chevron" :class="{ open: !pdGeneralCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+                  <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">General</span>
+                  <template x-if="pdGeneralChangeCount() > 0">
+                    <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="pdGeneralChangeCount() + (pdGeneralChangeCount() === 1 ? ' override' : ' overrides')"></span>
+                  </template>
+                  <template x-if="pdGeneralChangeCount() === 0">
+                    <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
+                  </template>
+                </button>
+                <span>
                   <button class="btn" x-show="pdGeneralChangeCount() > 0"
                           style="font-size:11px;padding:1px 8px;border-color:var(--accent-red);color:var(--accent-red)"
                           x-tt="'Reset all General values to Profile defaults'"
@@ -225,7 +233,7 @@
                    TRaSH/↺ sit immediately to the left of input (no empty middle gap), and
                    input sits at the right edge with width:150px (overrides pd-input's
                    max-width:50% which would otherwise shrink it inside the cluster). -->
-              <div x-show="!pdGeneralCollapsed" style="display:flex;flex-direction:column;gap:4px">
+              <div id="pd-general-body" x-show="!pdGeneralCollapsed" style="display:flex;flex-direction:column;gap:4px">
                 <!-- Language (Radarr only — Sonarr removed language from profiles in v4).
                      ON: Default + ↺ + select. OFF: plain value text (read-only). -->
                 <div class="pd-row" x-show="activeAppType === 'radarr'">
@@ -351,24 +359,29 @@
                  it to a modal so the card never grows to full width). Card still spans full
                  width when the editor is open — that part goes away in Step 2. -->
             <div class="pd-card pd-card-quality">
-              <div @click="pdQualityCollapsed = !pdQualityCollapsed"
-                   style="display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px">
-                <span class="detail-section-chevron" :class="{ open: !pdQualityCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
-                <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality</span>
-                <template x-if="pdQualityChangeCount() + pdQualityItemsChangeCount() > 0">
-                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="(pdQualityChangeCount() + pdQualityItemsChangeCount()) + ' change' + (pdQualityChangeCount() + pdQualityItemsChangeCount() === 1 ? '' : 's')"></span>
-                </template>
-                <template x-if="pdQualityChangeCount() + pdQualityItemsChangeCount() === 0">
-                  <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
-                </template>
-                <span style="margin-left:auto" @click.stop>
+              <div style="display:flex;align-items:center;gap:8px;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px">
+                <button type="button" class="collapse-toggle"
+                        style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                        @click="pdQualityCollapsed = !pdQualityCollapsed"
+                        :aria-expanded="!pdQualityCollapsed"
+                        aria-controls="pd-quality-body">
+                  <span class="detail-section-chevron" :class="{ open: !pdQualityCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+                  <span style="font-size:13px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;font-weight:600">Quality</span>
+                  <template x-if="pdQualityChangeCount() + pdQualityItemsChangeCount() > 0">
+                    <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="(pdQualityChangeCount() + pdQualityItemsChangeCount()) + ' change' + (pdQualityChangeCount() + pdQualityItemsChangeCount() === 1 ? '' : 's')"></span>
+                  </template>
+                  <template x-if="pdQualityChangeCount() + pdQualityItemsChangeCount() === 0">
+                    <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
+                  </template>
+                </button>
+                <span>
                   <button class="btn" x-show="pdQualityChangeCount() + pdQualityItemsChangeCount() > 0"
                           style="font-size:11px;padding:1px 8px;border-color:var(--accent-red);color:var(--accent-red)"
                           x-tt="'Reset Quality cutoff and items to Profile defaults'"
                           @click="pdResetQuality(); qsResetAll()">&#8634; Reset Quality</button>
                 </span>
               </div>
-              <div x-show="!pdQualityCollapsed">
+              <div id="pd-quality-body" x-show="!pdQualityCollapsed">
                 <div style="display:flex;flex-direction:column;gap:4px">
                   <!-- Cutoff row. ON: Default + ↺ + select. OFF: plain value text. -->
                   <div class="pd-row">
@@ -600,25 +613,30 @@
                has been changed from the profile default. Edits to Required/Group CF
                score inputs (gated on pdOverridesEnabled) populate this list. -->
           <div class="pd-card pd-card-cfscores" style="margin-top:18px;padding:10px 14px">
-            <div @click="pdCFScoresCollapsed = !pdCFScoresCollapsed"
-                 :style="pdCFScoresCollapsed ? 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none' : 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px'">
-              <span class="detail-section-chevron" :class="{ open: !pdCFScoresCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
-              <span style="font-size:13px;color:var(--text-primary);font-weight:600">Overridden Scores</span>
-              <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 0">
-                <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px"
-                      x-text="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length + ' override' + (Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length === 1 ? '' : 's')"></span>
-              </template>
-              <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length === 0">
-                <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
-              </template>
-              <span style="margin-left:auto" @click.stop>
+            <div :style="pdCFScoresCollapsed ? 'display:flex;align-items:center;gap:8px' : 'display:flex;align-items:center;gap:8px;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px'">
+              <button type="button" class="collapse-toggle"
+                      style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                      @click="pdCFScoresCollapsed = !pdCFScoresCollapsed"
+                      :aria-expanded="!pdCFScoresCollapsed"
+                      aria-controls="pd-cf-scores-body">
+                <span class="detail-section-chevron" :class="{ open: !pdCFScoresCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+                <span style="font-size:13px;color:var(--text-primary);font-weight:600">Overridden Scores</span>
+                <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 0">
+                  <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px"
+                        x-text="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length + ' override' + (Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length === 1 ? '' : 's')"></span>
+                </template>
+                <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length === 0">
+                  <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">Profile default</span>
+                </template>
+              </button>
+              <span>
                 <button class="btn" x-show="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 0"
                         style="font-size:11px;padding:1px 8px;border-color:var(--accent-red);color:var(--accent-red)"
                         x-tt="'Reset all CF score overrides to Profile defaults'"
                         @click="cfScoreOverrides = {}">&#8634; Reset Overridden</button>
               </span>
             </div>
-            <div x-show="!pdCFScoresCollapsed">
+            <div id="pd-cf-scores-body" x-show="!pdCFScoresCollapsed">
               <template x-if="Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 0">
                 <div :style="'column-count:' + (Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).length > 8 ? 2 : 1) + ';column-gap:24px'">
                   <template x-for="tid in Object.keys(cfScoreOverrides).filter(tid => { const d = resolveCFDefaultScore(tid); return d === '?' || cfScoreOverrides[tid] !== d; }).sort((a,b) => (resolveCFName(a)).localeCompare(resolveCFName(b)))" :key="'so-'+tid">
@@ -629,8 +647,8 @@
                       <input type="number" class="pb-score-input overridden" style="width:65px;flex-shrink:0"
                              :value="cfScoreOverrides[tid]"
                              @change="const v = parseInt($event.target.value) || 0; const def = resolveCFDefaultScore(tid); if (v === def) { const {[tid]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [tid]: v}; }">
-                      <span @click="const {[tid]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                            style="color:var(--accent-red);font-size:12px;cursor:pointer;flex-shrink:0;margin-left:2px" x-tt="'Reset to Profile default'">&#8634;</span>
+                      <button type="button" class="inline-action" @click="const {[tid]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
+                              style="color:var(--accent-red);font-size:12px;flex-shrink:0;margin-left:2px" x-tt="'Reset to Profile default'" aria-label="Reset to profile default">&#8634;</button>
                     </div>
                   </template>
                 </div>
@@ -646,17 +664,22 @@
                a full yellow border. Lazy-load picker on first expand. -->
           <div class="pd-card pd-card-extracfs" style="margin-top:18px;padding:10px 14px"
                x-effect="if (!pdExtraCFsCollapsed && extraCFAllCFs.length === 0 && profileDetail?.instance?.type) loadExtraCFList()">
-          <div @click="pdExtraCFsCollapsed = !pdExtraCFsCollapsed"
-               :style="pdExtraCFsCollapsed ? 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none' : 'display:flex;align-items:center;gap:8px;cursor:pointer;user-select:none;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px'">
-            <span class="detail-section-chevron" :class="{ open: !pdExtraCFsCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
-            <span style="font-size:13px;color:var(--text-primary);font-weight:600">Additional Custom Formats</span>
-            <template x-if="Object.keys(extraCFs).length > 0">
-              <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="Object.keys(extraCFs).length + ' added'"></span>
-            </template>
-            <template x-if="Object.keys(extraCFs).length === 0">
-              <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">None</span>
-            </template>
-            <span style="margin-left:auto" @click.stop>
+          <div :style="pdExtraCFsCollapsed ? 'display:flex;align-items:center;gap:8px' : 'display:flex;align-items:center;gap:8px;padding-bottom:8px;border-bottom:1px solid var(--bg-muted);margin-bottom:10px'">
+            <button type="button" class="collapse-toggle"
+                    style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                    @click="pdExtraCFsCollapsed = !pdExtraCFsCollapsed"
+                    :aria-expanded="!pdExtraCFsCollapsed"
+                    aria-controls="pd-extra-cfs-body">
+              <span class="detail-section-chevron" :class="{ open: !pdExtraCFsCollapsed }" style="color:var(--text-muted);font-size:11px">&#9654;</span>
+              <span style="font-size:13px;color:var(--text-primary);font-weight:600">Additional Custom Formats</span>
+              <template x-if="Object.keys(extraCFs).length > 0">
+                <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 7px;border-radius:10px" x-text="Object.keys(extraCFs).length + ' added'"></span>
+              </template>
+              <template x-if="Object.keys(extraCFs).length === 0">
+                <span style="font-size:11px;color:var(--text-muted-secondary);background:rgba(110,118,129,0.15);padding:1px 7px;border-radius:10px">None</span>
+              </template>
+            </button>
+            <span>
               <input x-show="!pdExtraCFsCollapsed" type="text" class="input" x-model="extraCFSearch" placeholder="Search..." style="font-size:12px;width:140px;padding:2px 8px;margin-right:6px">
               <button class="btn" x-show="Object.keys(extraCFs).length > 0"
                       style="font-size:11px;padding:1px 8px;border-color:var(--accent-red);color:var(--accent-red)"
@@ -664,7 +687,7 @@
                       @click="extraCFs = {}">&#8634; Reset Additional</button>
             </span>
           </div>
-          <div x-show="!pdExtraCFsCollapsed">
+          <div id="pd-extra-cfs-body" x-show="!pdExtraCFsCollapsed">
             <div style="font-size:13px;color:var(--accent-red);font-weight:600;margin-bottom:10px">&#9888; Non-standard for this profile — use at your own risk</div>
             <template x-if="extraCFAllCFs.length === 0">
               <div style="font-size:12px;color:var(--text-secondary);font-style:italic;padding:4px 0">Loading custom formats...</div>
@@ -680,13 +703,15 @@
                 <template x-for="group in extraCFGroups" :key="'ag-'+group.name">
                   <template x-if="group.cfs.some(cf => extraCFs[cf.trashId] !== undefined)">
                     <div class="detail-section" :class="getCategoryClass(group.category)">
-                      <div class="detail-section-header" @click="detailSections['added_'+group.name] = !detailSections['added_'+group.name]">
+                      <button type="button" class="detail-section-header"
+                              @click="detailSections['added_'+group.name] = !detailSections['added_'+group.name]"
+                              :aria-expanded="detailSections['added_'+group.name]">
                         <span class="detail-section-chevron" :class="{ open: detailSections['added_'+group.name] }">&#9654;</span>
-                        <div style="font-size:13px;font-weight:500" x-text="group.name"></div>
-                        <div style="font-size:12px;color:var(--accent-orange);margin-left:8px"
-                             x-text="group.cfs.filter(cf => extraCFs[cf.trashId] !== undefined).length + ' added'"></div>
+                        <span style="font-size:13px;font-weight:500" x-text="group.name"></span>
+                        <span style="font-size:12px;color:var(--accent-orange);margin-left:8px"
+                              x-text="group.cfs.filter(cf => extraCFs[cf.trashId] !== undefined).length + ' added'"></span>
                         <span style="margin-right:auto"></span>
-                      </div>
+                      </button>
                       <div x-show="detailSections['added_'+group.name]">
                         <template x-for="cf in group.cfs.filter(cf => extraCFs[cf.trashId] !== undefined)" :key="'as-'+cf.trashId">
                           <div class="cf-row">
@@ -719,11 +744,16 @@
               <div class="detail-section" :class="getCategoryClass(group.category)"
                    x-show="group.cfs.some(cf => !_extraInProfile(cf.trashId) && (!extraCFSearch || cf.name.toLowerCase().includes(extraCFSearch.toLowerCase())))"
                    style="margin-bottom:4px">
-                <div class="detail-section-header" @click="detailSections['extra_'+group.name] = !detailSections['extra_'+group.name]">
-                  <span class="detail-section-chevron" :class="{ open: detailSections['extra_'+group.name] }">&#9654;</span>
-                  <div style="font-size:13px;font-weight:500" x-text="group.name"></div>
-                  <div x-text="(() => { const total = group.cfs.filter(cf => !_extraInProfile(cf.trashId)).length; const added = group.cfs.filter(cf => !_extraInProfile(cf.trashId) && extraCFs[cf.trashId] !== undefined).length; return added + '/' + total + (added > 0 ? ' added' : ''); })()"
-                       :style="'font-size:12px;margin-left:8px;color:' + (group.cfs.some(cf => !_extraInProfile(cf.trashId) && extraCFs[cf.trashId] !== undefined) ? 'var(--accent-orange)' : 'var(--text-muted)')"></div>
+                <div class="detail-section-header">
+                  <button type="button" class="collapse-toggle"
+                          style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                          @click="detailSections['extra_'+group.name] = !detailSections['extra_'+group.name]"
+                          :aria-expanded="detailSections['extra_'+group.name]">
+                    <span class="detail-section-chevron" :class="{ open: detailSections['extra_'+group.name] }">&#9654;</span>
+                    <span style="font-size:13px;font-weight:500" x-text="group.name"></span>
+                    <span x-text="(() => { const total = group.cfs.filter(cf => !_extraInProfile(cf.trashId)).length; const added = group.cfs.filter(cf => !_extraInProfile(cf.trashId) && extraCFs[cf.trashId] !== undefined).length; return added + '/' + total + (added > 0 ? ' added' : ''); })()"
+                          :style="'font-size:12px;margin-left:8px;color:' + (group.cfs.some(cf => !_extraInProfile(cf.trashId) && extraCFs[cf.trashId] !== undefined) ? 'var(--accent-orange)' : 'var(--text-muted)')"></span>
+                  </button>
                   <span style="margin-right:auto"></span>
                   <label class="toggle toggle-sm" @click.stop x-tt="'Add or remove every selectable CF in this group'">
                     <input type="checkbox"
@@ -761,22 +791,24 @@
         <template x-if="profileDetail?.detail?.imported && profileDetail?.detail?.importedRequiredCategories?.length > 0">
           <div>
             <div class="detail-section cat-required-core" style="margin-bottom:8px">
-              <div class="detail-section-header" @click="toggleDetailSection('importedReq')">
+              <button type="button" class="detail-section-header" @click="toggleDetailSection('importedReq')"
+                      :aria-expanded="detailSections.importedReq">
                 <span class="detail-section-chevron" :class="{ open: detailSections.importedReq }">&#9654;</span>
-                <div style="font-size:13px;font-weight:600">Required Custom Formats</div>
-                <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="profileDetail.detail.importedRequiredCategories.reduce((n,c) => n + c.cfs.length, 0) + ' CFs'"></div>
-              </div>
+                <span style="font-size:13px;font-weight:600">Required Custom Formats</span>
+                <span style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="profileDetail.detail.importedRequiredCategories.reduce((n,c) => n + c.cfs.length, 0) + ' CFs'"></span>
+              </button>
               <div class="section-desc" x-show="detailSections.importedReq">
                 Required for this profile. Always included when syncing.
               </div>
               <div x-show="detailSections.importedReq">
                 <template x-for="cat in profileDetail.detail.importedRequiredCategories" :key="'req-'+cat.category">
                   <div class="detail-section" :class="getCategoryClass(cat.category)" style="margin-bottom:2px">
-                    <div class="detail-section-header" @click="toggleGroupExpanded('req', cat.category)">
+                    <button type="button" class="detail-section-header" @click="toggleGroupExpanded('req', cat.category)"
+                            :aria-expanded="groupExpanded['req/' + cat.category]">
                       <span class="detail-section-chevron" :class="{ open: groupExpanded['req/' + cat.category] }">&#9654;</span>
-                      <div style="font-size:13px;font-weight:600" x-text="cat.category"></div>
-                      <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="cat.cfs.length + '/' + cat.cfs.length"></div>
-                    </div>
+                      <span style="font-size:13px;font-weight:600" x-text="cat.category"></span>
+                      <span style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="cat.cfs.length + '/' + cat.cfs.length"></span>
+                    </button>
                     <div x-show="groupExpanded['req/' + cat.category]">
                       <template x-for="cf in cat.cfs" :key="cf.trashId">
                         <div class="cf-row">
@@ -787,8 +819,8 @@
                                      :value="cfScoreOverrides[cf.trashId] ?? cf.score ?? 0"
                                      @change="const v = parseInt($event.target.value) || 0; if (v === (cf.score ?? 0)) { const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [cf.trashId]: v}; }"
                                      style="width:65px">
-                              <span x-show="cfScoreOverrides[cf.trashId] !== undefined" @click="const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                                    style="color:var(--accent-red);font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
+                              <button type="button" class="inline-action" x-show="cfScoreOverrides[cf.trashId] !== undefined" @click="const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
+                                      style="color:var(--accent-red);font-size:12px;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'" aria-label="Reset to profile default">&#8634;</button>
                             </div>
                           </template>
                           <template x-if="!pdOverridesEnabled">
@@ -810,12 +842,13 @@
         <!-- Imported profile: Golden Rule (pick one — required but with choice) -->
         <template x-if="profileDetail?.detail?.imported && profileDetail?.detail?.importedGoldenRule?.length > 0">
           <div class="detail-section cat-golden-rule" style="margin-bottom:8px">
-            <div class="detail-section-header" @click="toggleDetailSection('goldenRule')">
+            <button type="button" class="detail-section-header" @click="toggleDetailSection('goldenRule')"
+                    :aria-expanded="detailSections.goldenRule">
               <span class="detail-section-chevron" :class="{ open: detailSections.goldenRule }">&#9654;</span>
-              <div style="font-size:13px;font-weight:600">Golden Rule</div>
+              <span style="font-size:13px;font-weight:600">Golden Rule</span>
               <span style="font-size:11px;color:var(--accent-blue);background:var(--fill-blue-soft);padding:1px 5px;border-radius:3px">pick one</span>
               <span style="margin-right:auto"></span>
-            </div>
+            </button>
             <div x-show="detailSections.goldenRule">
               <div style="padding:6px 16px;font-size:13px;color:var(--accent-blue)">Please ensure you only score or enable one of them in your Quality Profile!</div>
               <template x-for="cf in profileDetail.detail.importedGoldenRule" :key="cf.trashId">
@@ -840,10 +873,15 @@
           <div>
             <template x-for="cat in profileDetail.detail.importedCategories" :key="cat.category">
               <div class="detail-section" :class="getCategoryClass(cat.category)" style="margin-bottom:8px">
-                <div class="detail-section-header" @click="toggleDetailSection(cat.category)">
-                  <span class="detail-section-chevron" :class="{ open: detailSections[cat.category] }">&#9654;</span>
-                  <div style="font-size:13px;font-weight:600" x-text="cat.category"></div>
-                  <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="cat.cfs.filter(cf => selectedOptionalCFs[cf.trashId]).length + '/' + cat.cfs.length"></div>
+                <div class="detail-section-header">
+                  <button type="button" class="collapse-toggle"
+                          style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                          @click="toggleDetailSection(cat.category)"
+                          :aria-expanded="detailSections[cat.category]">
+                    <span class="detail-section-chevron" :class="{ open: detailSections[cat.category] }">&#9654;</span>
+                    <span style="font-size:13px;font-weight:600" x-text="cat.category"></span>
+                    <span style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="cat.cfs.filter(cf => selectedOptionalCFs[cf.trashId]).length + '/' + cat.cfs.length"></span>
+                  </button>
                   <label class="toggle toggle-sm" @click.stop>
                     <input type="checkbox"
                            :checked="cat.cfs.every(cf => selectedOptionalCFs[cf.trashId])"
@@ -872,10 +910,11 @@
             <!-- Quality items -->
             <template x-if="profileDetail?.detail?.profile?.items?.length > 0">
               <div class="detail-section">
-                <div class="detail-section-header" @click="toggleGroupExpanded('imported', 'qualities')">
-                  <div class="detail-section-label">Quality Settings</div>
+                <button type="button" class="detail-section-header" @click="toggleGroupExpanded('imported', 'qualities')"
+                        :aria-expanded="groupExpanded['imported/qualities']">
+                  <span class="detail-section-label">Quality Settings</span>
                   <span class="detail-section-chevron" :class="{ open: groupExpanded['imported/qualities'] }">&#9654;</span>
-                </div>
+                </button>
                 <div x-show="groupExpanded['imported/qualities']" style="padding:12px 16px;font-size:12px;color:var(--text-body)">
                   <template x-for="q in profileDetail.detail.profile.items" :key="q.name">
                     <div style="padding:4px 0;display:flex;gap:8px;align-items:center">
@@ -899,11 +938,12 @@
             <!-- Profile section: formatItems not in any group -->
             <template x-if="(profileDetail.detail.formatItemNames || []).length > 0">
               <div class="detail-section cat-required-core">
-                <div class="detail-section-header" @click="toggleDetailSection('core')">
+                <button type="button" class="detail-section-header" @click="toggleDetailSection('core')"
+                        :aria-expanded="detailSections.core">
                   <span class="detail-section-chevron" :class="{ open: detailSections.core }">&#9654;</span>
-                  <div style="font-size:13px;font-weight:600">Required CFs</div>
-                  <div style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="profileDetail.detail.formatItemNames.length + ' custom formats'"></div>
-                </div>
+                  <span style="font-size:13px;font-weight:600">Required CFs</span>
+                  <span style="font-size:13px;color:var(--text-muted);margin-right:auto" x-text="profileDetail.detail.formatItemNames.length + ' custom formats'"></span>
+                </button>
                 <div class="section-desc" x-show="detailSections.core">
                   Required for this profile. Always included when syncing.
                 </div>
@@ -918,8 +958,8 @@
                                  :value="cfScoreOverrides[fi.trashId] ?? fi.score ?? 0"
                                  @change="const v = parseInt($event.target.value) || 0; if (v === (fi.score ?? 0)) { const {[fi.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [fi.trashId]: v}; }"
                                  style="width:65px">
-                          <span x-show="cfScoreOverrides[fi.trashId] !== undefined" @click="const {[fi.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                                style="color:var(--accent-red);font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
+                          <button type="button" class="inline-action" x-show="cfScoreOverrides[fi.trashId] !== undefined" @click="const {[fi.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
+                                  style="color:var(--accent-red);font-size:12px;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'" aria-label="Reset to profile default">&#8634;</button>
                         </div>
                       </template>
                       <template x-if="!pdOverridesEnabled">
@@ -942,20 +982,25 @@
             <!-- Flat list of TRaSH CF groups -->
             <template x-for="group in (profileDetail.detail.trashGroups || [])" :key="group.name">
               <div class="detail-section" :class="getCategoryClass(group.category)" style="margin-bottom:4px">
-                <div class="detail-section-header" @click="toggleGroupExpanded('tg', group.name)">
-                  <span class="detail-section-chevron" :class="{ open: groupExpanded['tg/' + group.name] }">&#9654;</span>
-                  <div style="font-size:13px;font-weight:500" x-text="group.name"></div>
-                  <span x-show="group.exclusive" style="font-size:11px;color:var(--accent-blue);background:var(--fill-blue-soft);padding:1px 5px;border-radius:3px">pick one</span>
-                  <span x-show="group.defaultEnabled" style="font-size:11px;color:var(--accent-green);background:var(--fill-green-soft);padding:1px 5px;border-radius:3px">default</span>
-                  <div style="font-size:13px;color:var(--text-muted);margin-left:8px"
-                       x-text="(() => { const on = selectedOptionalCFs['__grp_' + group.name] !== undefined ? selectedOptionalCFs['__grp_' + group.name] : group.defaultEnabled; if (!on) return '0/' + group.cfs.length; return group.cfs.filter(cf => cf.required || selectedOptionalCFs[cf.trashId]).length + '/' + group.cfs.length; })()"></div>
-                  <template x-if="group.cfs.some(cf => cfScoreOverrides[cf.trashId] !== undefined)">
-                    <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 5px;border-radius:3px;margin-right:auto"
-                          x-text="group.cfs.filter(cf => cfScoreOverrides[cf.trashId] !== undefined).length + ' override' + (group.cfs.filter(cf => cfScoreOverrides[cf.trashId] !== undefined).length !== 1 ? 's' : '')"></span>
-                  </template>
-                  <template x-if="!group.cfs.some(cf => cfScoreOverrides[cf.trashId] !== undefined)">
-                    <span style="margin-right:auto"></span>
-                  </template>
+                <div class="detail-section-header">
+                  <button type="button" class="collapse-toggle"
+                          style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                          @click="toggleGroupExpanded('tg', group.name)"
+                          :aria-expanded="groupExpanded['tg/' + group.name]">
+                    <span class="detail-section-chevron" :class="{ open: groupExpanded['tg/' + group.name] }">&#9654;</span>
+                    <span style="font-size:13px;font-weight:500" x-text="group.name"></span>
+                    <span x-show="group.exclusive" style="font-size:11px;color:var(--accent-blue);background:var(--fill-blue-soft);padding:1px 5px;border-radius:3px">pick one</span>
+                    <span x-show="group.defaultEnabled" style="font-size:11px;color:var(--accent-green);background:var(--fill-green-soft);padding:1px 5px;border-radius:3px">default</span>
+                    <span style="font-size:13px;color:var(--text-muted);margin-left:8px"
+                          x-text="(() => { const on = selectedOptionalCFs['__grp_' + group.name] !== undefined ? selectedOptionalCFs['__grp_' + group.name] : group.defaultEnabled; if (!on) return '0/' + group.cfs.length; return group.cfs.filter(cf => cf.required || selectedOptionalCFs[cf.trashId]).length + '/' + group.cfs.length; })()"></span>
+                    <template x-if="group.cfs.some(cf => cfScoreOverrides[cf.trashId] !== undefined)">
+                      <span style="font-size:11px;color:var(--accent-orange);background:var(--accent-orange-bg);padding:1px 5px;border-radius:3px;margin-right:auto"
+                            x-text="group.cfs.filter(cf => cfScoreOverrides[cf.trashId] !== undefined).length + ' override' + (group.cfs.filter(cf => cfScoreOverrides[cf.trashId] !== undefined).length !== 1 ? 's' : '')"></span>
+                    </template>
+                    <template x-if="!group.cfs.some(cf => cfScoreOverrides[cf.trashId] !== undefined)">
+                      <span style="margin-right:auto"></span>
+                    </template>
+                  </button>
                   <!-- Group toggle — shown for every group, including exclusive pick-one groups
                        (Golden Rule). TRaSH's schema marks those CFs `required: false`, so the
                        group itself is optional; "exclusive" only describes picking at most one
@@ -1017,8 +1062,8 @@
                                  :value="cfScoreOverrides[cf.trashId] ?? cf.score ?? 0"
                                  @change="const v = parseInt($event.target.value) || 0; if (v === (cf.score ?? 0)) { const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest; } else { cfScoreOverrides = {...cfScoreOverrides, [cf.trashId]: v}; }"
                                  style="width:65px">
-                          <span x-show="cfScoreOverrides[cf.trashId] !== undefined" @click="const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
-                                style="color:var(--accent-red);font-size:12px;cursor:pointer;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'">&#8634;</span>
+                          <button type="button" class="inline-action" x-show="cfScoreOverrides[cf.trashId] !== undefined" @click="const {[cf.trashId]: _, ...rest} = cfScoreOverrides; cfScoreOverrides = rest"
+                                  style="color:var(--accent-red);font-size:12px;margin-left:2px;vertical-align:middle" x-tt="'Reset to Profile default'" aria-label="Reset to profile default">&#8634;</button>
                         </div>
                       </template>
                       <template x-if="!(pdOverridesEnabled && (cf.required ? (selectedOptionalCFs['__grp_' + group.name] !== undefined ? selectedOptionalCFs['__grp_' + group.name] : group.defaultEnabled) : selectedOptionalCFs[cf.trashId]))">

--- a/ui/static/partials/sections/advanced.html
+++ b/ui/static/partials/sections/advanced.html
@@ -355,10 +355,15 @@
             <div style="overflow-y:auto;flex:1;padding:8px;background:var(--bg-page)">
               <template x-for="grp in cfgbGroupedProfiles()" :key="grp.name">
                 <div class="card" :class="'grp-' + grp.name.toLowerCase().replace(/[^a-z]/g, '')" style="margin-bottom:6px">
-                  <div class="profile-group-header" @click="cfgbToggleProfileGroupCard(grp.name)">
-                    <span class="profile-group-chevron" :class="{ open: cfgbIsProfileGroupExpanded(grp.name) }">&#9654;</span>
-                    <span style="flex:1" x-text="grp.name"></span>
-                    <span class="profile-group-count" x-text="cfgbGroupSelectedCount(grp) + ' / ' + grp.profiles.length"></span>
+                  <div class="profile-group-header">
+                    <button type="button" class="collapse-toggle"
+                            style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                            @click="cfgbToggleProfileGroupCard(grp.name)"
+                            :aria-expanded="cfgbIsProfileGroupExpanded(grp.name)">
+                      <span class="profile-group-chevron" :class="{ open: cfgbIsProfileGroupExpanded(grp.name) }">&#9654;</span>
+                      <span style="flex:1" x-text="grp.name"></span>
+                      <span class="profile-group-count" x-text="cfgbGroupSelectedCount(grp) + ' / ' + grp.profiles.length"></span>
+                    </button>
                     <label style="display:flex;align-items:center;gap:4px;cursor:pointer;font-size:11px;color:var(--text-muted)" @click.stop x-tt="'Select all ' + grp.name + ' profiles'">
                       <input type="checkbox" :checked="cfgbGroupAllSelected(grp)" @change="cfgbToggleGroupAll(grp, $event.target.checked)">
                       all
@@ -404,11 +409,14 @@
 
         <!-- JSON preview (collapsible — Alpine pattern, matches other Clonarr collapsibles) -->
         <div style="margin-top:8px">
-          <div @click="cfgbPreviewOpen = !cfgbPreviewOpen" style="cursor:pointer;font-size:13px;color:var(--text-muted);padding:6px 0;display:flex;align-items:center;gap:6px;user-select:none">
+          <button type="button" class="collapse-toggle" @click="cfgbPreviewOpen = !cfgbPreviewOpen"
+                  :aria-expanded="cfgbPreviewOpen"
+                  aria-controls="cfgb-preview-body"
+                  style="font-size:13px;color:var(--text-muted);padding:6px 0;display:flex;align-items:center;gap:6px;user-select:none">
             <span class="detail-section-chevron" :class="{ open: cfgbPreviewOpen }">▶</span>
             <span>JSON preview</span>
-          </div>
-          <pre x-show="cfgbPreviewOpen" x-cloak style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px;overflow-x:auto;font-size:12px;color:var(--text-body);max-height:300px;overflow-y:auto" x-text="cfgbGenerateJSON()"></pre>
+          </button>
+          <pre id="cfgb-preview-body" x-show="cfgbPreviewOpen" x-cloak style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px;overflow-x:auto;font-size:12px;color:var(--text-body);max-height:300px;overflow-y:auto" x-text="cfgbGenerateJSON()"></pre>
         </div>
       </div>
     </div>

--- a/ui/static/partials/sections/app-pages.html
+++ b/ui/static/partials/sections/app-pages.html
@@ -1,8 +1,8 @@
 {{define "sections/app-pages"}}
-  <!-- ==================== APP PAGES (Radarr/Sonarr) ==================== -->
+  <!-- ==================== APP-SCOPED SECTIONS (Radarr/Sonarr) ==================== -->
   <template x-if="true">
     <div x-show="!['settings','about'].includes(currentSection) && !profileDetail && !profileBuilder">
-      <!-- App type + section sub-tabs (universal bar, matches page width) -->
+      <!-- App selector + section sub-tabs (universal bar, matches page width) -->
       <nav class="profile-tabs" aria-label="App and section" style="max-width:1100px;margin:0 auto;padding:0 24px;background:transparent;border-bottom:1px solid var(--bg-muted)">
         <template x-for="appType in availableAppTypes" :key="'global-'+appType">
           <a class="profile-tab" :class="{ active: activeAppType === appType }"
@@ -30,7 +30,7 @@
           </div>
         </template>
       </nav>
-      <!-- Sub-tabs (hidden, replaced by top nav) -->
+      <!-- Section bodies shown by currentSection / advancedTab state. -->
       {{template "sections/profiles" .}}
       {{template "sections/custom-formats" .}}
       {{template "sections/quality-size" .}}

--- a/ui/static/partials/sections/app-pages.html
+++ b/ui/static/partials/sections/app-pages.html
@@ -3,31 +3,33 @@
   <template x-if="true">
     <div x-show="!['settings','about'].includes(currentSection) && !profileDetail && !profileBuilder">
       <!-- App type + section sub-tabs (universal bar, matches page width) -->
-      <div class="profile-tabs" style="max-width:1100px;margin:0 auto;padding:0 24px;background:transparent;border-bottom:1px solid var(--bg-muted)">
+      <nav class="profile-tabs" aria-label="App and section" style="max-width:1100px;margin:0 auto;padding:0 24px;background:transparent;border-bottom:1px solid var(--bg-muted)">
         <template x-for="appType in availableAppTypes" :key="'global-'+appType">
-          <div class="profile-tab" :class="{ active: activeAppType === appType }"
-               @click="switchAppType(appType)">
+          <a class="profile-tab" :class="{ active: activeAppType === appType }"
+             :href="navHref(currentSection, { appType })"
+             :aria-current="activeAppType === appType ? 'page' : null"
+             @click="if (cfgbNeedsConfirm($event, appType)) $event.preventDefault()">
             <span x-text="appType.charAt(0).toUpperCase() + appType.slice(1)"></span>
             <span x-show="instancesOfType(appType).length > 0" style="background:var(--bg-muted);color:var(--text-muted);padding:0 6px;border-radius:8px;margin-left:4px;font-size:11px" x-text="instancesOfType(appType).length"></span>
-          </div>
+          </a>
         </template>
         <!-- Profiles sub-tabs -->
         <template x-if="currentSection === 'profiles'">
           <div style="display:flex;gap:0;margin-left:16px;border-left:1px solid var(--border-subtle);padding-left:8px">
-            <div class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'trash-sync' }" @click="setProfileTab(activeAppType, 'trash-sync'); pushNav()">TRaSH Sync</div>
-            <div class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'history' }" @click="setProfileTab(activeAppType, 'history'); pushNav(); instancesOfType(activeAppType).forEach(i => loadSyncHistory(i.id))">History</div>
-            <div class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'compare' }" @click="setProfileTab(activeAppType, 'compare'); pushNav()">Compare</div>
+            <a class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'trash-sync' }" :href="navHref('profiles', { profileTab: 'trash-sync' })" :aria-current="getProfileTab(activeAppType) === 'trash-sync' ? 'page' : null">TRaSH Sync</a>
+            <a class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'history' }" :href="navHref('profiles', { profileTab: 'history' })" :aria-current="getProfileTab(activeAppType) === 'history' ? 'page' : null">History</a>
+            <a class="profile-tab" :class="{ active: getProfileTab(activeAppType) === 'compare' }" :href="navHref('profiles', { profileTab: 'compare' })" :aria-current="getProfileTab(activeAppType) === 'compare' ? 'page' : null">Compare</a>
           </div>
         </template>
         <!-- Advanced sub-tabs -->
         <template x-if="currentSection === 'advanced'">
           <div style="display:flex;gap:0;margin-left:16px;border-left:1px solid var(--border-subtle);padding-left:8px">
-            <div class="profile-tab" :class="{ active: advancedTab === 'builder' }" @click="advancedTab = 'builder'; pushNav()">Profile Builder</div>
-            <div class="profile-tab" :class="{ active: advancedTab === 'scoring' }" @click="advancedTab = 'scoring'; loadSandbox(activeAppType); pushNav()">Scoring Sandbox</div>
-            <div class="profile-tab" :class="{ active: advancedTab === 'group-builder' }" @click="advancedTab = 'group-builder'; cfgbLoad(activeAppType); pushNav()">CF Group Builder</div>
+            <a class="profile-tab" :class="{ active: advancedTab === 'builder' }" :href="navHref('advanced', { advancedTab: 'builder' })" :aria-current="advancedTab === 'builder' ? 'page' : null">Profile Builder</a>
+            <a class="profile-tab" :class="{ active: advancedTab === 'scoring' }" :href="navHref('advanced', { advancedTab: 'scoring' })" :aria-current="advancedTab === 'scoring' ? 'page' : null">Scoring Sandbox</a>
+            <a class="profile-tab" :class="{ active: advancedTab === 'group-builder' }" :href="navHref('advanced', { advancedTab: 'group-builder' })" :aria-current="advancedTab === 'group-builder' ? 'page' : null">CF Group Builder</a>
           </div>
         </template>
-      </div>
+      </nav>
       <!-- Sub-tabs (hidden, replaced by top nav) -->
       {{template "sections/profiles" .}}
       {{template "sections/custom-formats" .}}

--- a/ui/static/partials/sections/custom-formats.html
+++ b/ui/static/partials/sections/custom-formats.html
@@ -1,5 +1,5 @@
 {{define "sections/custom-formats"}}
-      <!-- ===== Custom Formats sub-tab ===== -->
+      <!-- ===== Custom Formats section ===== -->
       <div class="page" x-show="currentSection === 'custom-formats'">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Custom Formats</div>
         <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">All Custom Formats from TRaSH Guides, organized by category. Use Create to build a custom format from scratch, or Import to add existing formats from an Arr instance or JSON.</div>

--- a/ui/static/partials/sections/custom-formats.html
+++ b/ui/static/partials/sections/custom-formats.html
@@ -17,12 +17,13 @@
             </div>
             <template x-for="cat in getCFBrowseGroups(activeAppType)" :key="cat.displayName">
               <div class="detail-section" :class="getCategoryClass(cat.category)" style="margin-bottom:8px">
-                <div class="detail-section-header" @click="toggleDetailSection('cfb_' + cat.displayName)" style="cursor:pointer"
-                     :style="cat.isCustom ? 'border-left:3px solid var(--accent-orange);background:var(--accent-orange-bg)' : ''">
-                  <div class="detail-section-label" :style="cat.isCustom ? 'color:var(--accent-orange)' : ''" x-text="cat.displayName"></div>
-                  <div class="detail-section-count" x-text="cat.totalCFs + ' CFs'"></div>
+                <button type="button" class="detail-section-header" @click="toggleDetailSection('cfb_' + cat.displayName)"
+                        :aria-expanded="detailSections['cfb_' + cat.displayName]"
+                        :style="cat.isCustom ? 'border-left:3px solid var(--accent-orange);background:var(--accent-orange-bg)' : ''">
+                  <span class="detail-section-label" :style="cat.isCustom ? 'color:var(--accent-orange)' : ''" x-text="cat.displayName"></span>
+                  <span class="detail-section-count" x-text="cat.totalCFs + ' CFs'"></span>
                   <span class="detail-section-chevron" :class="{ open: detailSections['cfb_' + cat.displayName] }">&#9654;</span>
-                </div>
+                </button>
                 <div x-show="detailSections['cfb_' + cat.displayName]">
                   <template x-for="group in cat.groups" :key="group.name">
                     <div class="cf-section">
@@ -41,8 +42,8 @@
                                   <span x-text="cf.name"></span>
                                   <span x-show="cf.isCustom" style="font-size:12px;color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:3px;padding:0 4px;margin-left:6px">Custom</span>
                                   <span class="cf-info" x-show="cf.description" @mouseenter="showCFTooltip($event, cf.description)" @mouseleave="hideCFTooltip()">ⓘ</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-blue);cursor:pointer;margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'">&#9998;</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-red);cursor:pointer;margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'">&#10005;</span>
+                                  <button type="button" class="inline-action" x-show="cf.isCustom" style="font-size:13px;color:var(--accent-blue);margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'" aria-label="Edit custom format">&#9998;</button>
+                                  <button type="button" class="inline-action" x-show="cf.isCustom" style="font-size:13px;color:var(--accent-red);margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'" aria-label="Delete custom format">&#10005;</button>
                                 </div>
                                 <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'"
                                      x-text="cf.score !== undefined ? ((cf.score > 0 ? '+' : '') + cf.score) : '—'"></div>
@@ -62,8 +63,8 @@
                                   <span x-text="cf.name"></span>
                                   <span x-show="cf.isCustom" style="font-size:12px;color:var(--accent-orange);border:1px solid var(--accent-orange);border-radius:3px;padding:0 4px;margin-left:6px">Custom</span>
                                   <span class="cf-info" x-show="cf.description" @mouseenter="showCFTooltip($event, cf.description)" @mouseleave="hideCFTooltip()">ⓘ</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-blue);cursor:pointer;margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'">&#9998;</span>
-                                  <span x-show="cf.isCustom" style="font-size:13px;color:var(--accent-red);cursor:pointer;margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'">&#10005;</span>
+                                  <button type="button" class="inline-action" x-show="cf.isCustom" style="font-size:13px;color:var(--accent-blue);margin-left:6px" @click="openCFEditor('edit', activeAppType, cf)" x-tt="'Edit'" aria-label="Edit custom format">&#9998;</button>
+                                  <button type="button" class="inline-action" x-show="cf.isCustom" style="font-size:13px;color:var(--accent-red);margin-left:4px" @click="deleteCustomCF(cf, activeAppType)" x-tt="'Delete'" aria-label="Delete custom format">&#10005;</button>
                                 </div>
                                 <div class="cf-score" :class="cf.score > 0 ? 'positive' : cf.score < 0 ? 'negative' : 'zero'"
                                      x-text="cf.score !== undefined ? ((cf.score > 0 ? '+' : '') + cf.score) : '—'"></div>
@@ -75,15 +76,16 @@
                       <!-- Multi-CF group: collapsible sub-headers -->
                       <template x-if="cat.groups.length > 1 && group.cfs.length > 1">
                         <div>
-                          <div class="cf-section-title" style="cursor:pointer;user-select:none"
-                               @click="toggleGroupExpanded('cfb_' + cat.displayName, group.shortName)">
-                            <div style="display:flex;align-items:center;gap:8px">
+                          <button type="button" class="cf-section-title"
+                                  @click="toggleGroupExpanded('cfb_' + cat.displayName, group.shortName)"
+                                  :aria-expanded="groupExpanded['cfb_' + cat.displayName + '/' + group.shortName]">
+                            <span style="display:flex;align-items:center;gap:8px">
                               <span class="detail-section-chevron" style="font-size:12px"
                                     :class="{ open: groupExpanded['cfb_' + cat.displayName + '/' + group.shortName] }">&#9654;</span>
                               <span x-text="group.shortName"></span>
                               <span style="font-size:13px;color:var(--text-muted)" x-text="group.cfs.length + ' CFs'"></span>
-                            </div>
-                          </div>
+                            </span>
+                          </button>
                           <div x-show="groupExpanded['cfb_' + cat.displayName + '/' + group.shortName]">
                             <!-- Group description from TRaSH (sourced from cat.trashDescription / group.trash_description JSON) -->
                             <div x-show="cat.trashDescription" class="group-desc-html"

--- a/ui/static/partials/sections/maintenance.html
+++ b/ui/static/partials/sections/maintenance.html
@@ -118,10 +118,10 @@
                               <div x-show="cleanupKeepFocused && cleanupKeepSuggestions.length > 0" @mousedown.prevent
                                    style="position:absolute;top:100%;left:0;right:0;z-index:50;background:var(--bg-card);border:1px solid var(--border-subtle);border-radius:0 0 6px 6px;max-height:200px;overflow-y:auto;box-shadow:0 4px 12px var(--alpha-shadow)">
                                 <template x-for="(suggestion, si) in cleanupKeepSuggestions" :key="si">
-                                  <div @click="addCleanupKeepName(suggestion)"
-                                       style="padding:6px 10px;font-size:12px;color:var(--text-body);cursor:pointer;border-bottom:1px solid var(--bg-muted)"
-                                       @mouseenter="$el.style.background='color-mix(in srgb, var(--accent-blue-strong) 20%, transparent)'" @mouseleave="$el.style.background='transparent'"
-                                       x-text="suggestion"></div>
+                                  <button type="button" @click="addCleanupKeepName(suggestion)"
+                                          style="display:block;width:100%;padding:6px 10px;font-size:12px;color:var(--text-body);cursor:pointer;border:0;border-bottom:1px solid var(--bg-muted);background:transparent;text-align:left;font:inherit"
+                                          @mouseenter="$el.style.background='color-mix(in srgb, var(--accent-blue-strong) 20%, transparent)'" @mouseleave="$el.style.background='transparent'"
+                                          x-text="suggestion"></button>
                                 </template>
                               </div>
                             </div>
@@ -144,7 +144,7 @@
                               <template x-for="(name, idx) in [...cleanupKeepList].sort((a,b) => a.localeCompare(b))" :key="'kl-'+idx">
                                 <div style="break-inside:avoid;display:flex;align-items:center;padding:1px 0;font-size:12px">
                                   <span style="color:var(--accent-blue);overflow:hidden;text-overflow:ellipsis;white-space:nowrap" x-text="name"></span>
-                                  <span style="color:var(--text-secondary);cursor:pointer;font-size:13px;flex-shrink:0;margin-left:4px" @click="removeCleanupKeep(cleanupKeepList.indexOf(name))" x-tt="'Remove'">&times;</span>
+                                  <button type="button" class="inline-action" style="color:var(--text-secondary);font-size:13px;flex-shrink:0;margin-left:4px" @click="removeCleanupKeep(cleanupKeepList.indexOf(name))" x-tt="'Remove'" aria-label="Remove from keep list">&times;</button>
                                 </div>
                               </template>
                             </div>

--- a/ui/static/partials/sections/maintenance.html
+++ b/ui/static/partials/sections/maintenance.html
@@ -1,5 +1,5 @@
 {{define "sections/maintenance"}}
-      <!-- ===== Maintenance sub-tab ===== -->
+      <!-- ===== Maintenance section ===== -->
       <div class="page" x-show="currentSection === 'maintenance'">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Backup &amp; Maintenance</div>
         <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">Backup and restore instance data, clean up custom formats and scores.</div>

--- a/ui/static/partials/sections/naming.html
+++ b/ui/static/partials/sections/naming.html
@@ -124,10 +124,10 @@
               </div>
               <!-- Media server tabs -->
               <div style="display:flex;align-items:center;border-bottom:1px solid var(--bg-muted);padding:0 16px">
-                <div class="subtab" :class="{ active: (namingMediaServer[activeAppType] || 'standard') === 'standard' }" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'standard'}">Standard</div>
-                <div class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'plex' }" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'plex'}">Plex</div>
-                <div class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'emby' }" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'emby'}">Emby</div>
-                <div class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'jellyfin' }" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'jellyfin'}">Jellyfin</div>
+                <button type="button" class="subtab" :class="{ active: (namingMediaServer[activeAppType] || 'standard') === 'standard' }" :aria-pressed="(namingMediaServer[activeAppType] || 'standard') === 'standard'" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'standard'}">Standard</button>
+                <button type="button" class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'plex' }" :aria-pressed="namingMediaServer[activeAppType] === 'plex'" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'plex'}">Plex</button>
+                <button type="button" class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'emby' }" :aria-pressed="namingMediaServer[activeAppType] === 'emby'" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'emby'}">Emby</button>
+                <button type="button" class="subtab" :class="{ active: namingMediaServer[activeAppType] === 'jellyfin' }" :aria-pressed="namingMediaServer[activeAppType] === 'jellyfin'" @click="namingMediaServer = {...namingMediaServer, [activeAppType]: 'jellyfin'}">Jellyfin</button>
               </div>
 
               <div style="padding:16px">
@@ -203,10 +203,10 @@
                         <span style="font-size:12px;font-weight:600;color:var(--text-body)" x-text="scheme.label"></span>
                         <span x-show="scheme.recommended" style="font-size:12px;background:var(--accent-green-strong);color:var(--text-on-accent);padding:1px 6px;border-radius:3px">Recommended</span>
                         <span style="margin-left:auto;display:flex;gap:8px;align-items:center">
-                          <span style="font-size:12px;color:var(--accent-blue);cursor:pointer" @click="copyToClipboard(scheme.pattern)">Copy</span>
+                          <button type="button" class="inline-action" style="font-size:12px;color:var(--accent-blue)" @click="copyToClipboard(scheme.pattern)">Copy</button>
                           <template x-if="namingSelectedInstance[activeAppType]">
-                            <span style="font-size:12px;color:var(--accent-orange);cursor:pointer"
-                              @click="$el.textContent='Syncing...'; $el.style.color='var(--text-secondary)'; applyNamingScheme(activeAppType, section.key, scheme).then(() => { $el.textContent='✓ Synced'; $el.style.color='var(--accent-green)'; setTimeout(() => { $el.textContent='Sync'; $el.style.color='var(--accent-orange)'; }, 2000); })">Sync</span>
+                            <button type="button" class="inline-action" style="font-size:12px;color:var(--accent-orange)"
+                              @click="$el.textContent='Syncing...'; $el.style.color='var(--text-secondary)'; applyNamingScheme(activeAppType, section.key, scheme).then(() => { $el.textContent='✓ Synced'; $el.style.color='var(--accent-green)'; setTimeout(() => { $el.textContent='Sync'; $el.style.color='var(--accent-orange)'; }, 2000); })">Sync</button>
                           </template>
                         </span>
                       </div>

--- a/ui/static/partials/sections/naming.html
+++ b/ui/static/partials/sections/naming.html
@@ -1,5 +1,5 @@
 {{define "sections/naming"}}
-      <!-- ===== File Naming sub-tab ===== -->
+      <!-- ===== File Naming section ===== -->
       <div class="page" x-show="currentSection === 'naming'">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">File Naming</div>
         <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">TRaSH recommended naming schemes for folders and files. Select a media server tab and an instance to compare and apply.</div>

--- a/ui/static/partials/sections/profiles.html
+++ b/ui/static/partials/sections/profiles.html
@@ -24,11 +24,17 @@
 
           <!-- Collapsible Sync Rules (always visible) -->
             <div class="card" style="margin-bottom:20px">
-              <div style="display:flex;align-items:center;padding:12px 16px;cursor:pointer;gap:8px;border-left:3px solid var(--text-primary)" @click="syncRulesExpanded = { ...syncRulesExpanded, [activeAppType]: !syncRulesExpanded[activeAppType] }">
-                <span class="profile-group-chevron" :class="{ open: syncRulesExpanded[activeAppType] }">&#9654;</span>
-                <span style="font-size:13px;font-weight:500">Sync Rules</span>
-                <span style="font-size:13px;color:var(--text-muted);margin-left:auto"
-                      x-text="(() => { let count = 0; for (const inst of instancesOfType(activeAppType)) count += sortedSyncRules(inst.id).length; return count > 0 ? count + ' synced profile' + (count !== 1 ? 's' : '') : 'No syncs yet'; })()"></span>
+              <div style="display:flex;align-items:center;padding:12px 16px;gap:8px;border-left:3px solid var(--text-primary)">
+                <button type="button" class="collapse-toggle"
+                        style="display:flex;align-items:center;gap:8px;flex:1;min-width:0"
+                        @click="syncRulesExpanded = { ...syncRulesExpanded, [activeAppType]: !syncRulesExpanded[activeAppType] }"
+                        :aria-expanded="syncRulesExpanded[activeAppType]"
+                        aria-controls="sync-rules-body">
+                  <span class="profile-group-chevron" :class="{ open: syncRulesExpanded[activeAppType] }">&#9654;</span>
+                  <span style="font-size:13px;font-weight:500">Sync Rules</span>
+                  <span style="font-size:13px;color:var(--text-muted);margin-left:auto"
+                        x-text="(() => { let count = 0; for (const inst of instancesOfType(activeAppType)) count += sortedSyncRules(inst.id).length; return count > 0 ? count + ' synced profile' + (count !== 1 ? 's' : '') : 'No syncs yet'; })()"></span>
+                </button>
                 <button class="btn btn-sm"
                         @click.stop="setAutoSyncPaused(!autoSyncSettings.paused)"
                         x-tt="autoSyncSettings.paused ? 'Resume auto-sync' : 'Pause auto-sync (scheduled + after-pull). Manual syncs unaffected.'"
@@ -37,7 +43,7 @@
                                 : 'font-size:12px;padding:2px 8px;border-color:var(--border-subtle);color:var(--text-secondary);margin-left:8px'"
                         x-text="autoSyncSettings.paused ? '▶ Resume Auto-Sync' : '⏸ Pause Auto-Sync'"></button>
               </div>
-              <div x-show="syncRulesExpanded[activeAppType]" style="border-top:1px solid var(--bg-muted)">
+              <div id="sync-rules-body" x-show="syncRulesExpanded[activeAppType]" style="border-top:1px solid var(--bg-muted)">
                 <template x-for="inst in instancesOfType(activeAppType)" :key="'sr-'+inst.id">
                   <template x-if="sortedSyncRules(inst.id).length > 0">
                     <div>
@@ -46,13 +52,17 @@
                         <button class="btn btn-sm" style="margin-left:auto;font-size:12px;padding:2px 8px;border-color:var(--accent-green-strong);color:var(--accent-green)" @click.stop="syncAllForInstance(inst)" x-tt="'Re-sync all profiles with auto-sync enabled on this instance'">Sync All</button>
                       </div>
                       <div style="display:flex;align-items:center;padding:4px 16px;gap:8px;font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid var(--bg-card);user-select:none">
-                        <span style="width:200px;flex-shrink:0;cursor:pointer;white-space:nowrap" @click="toggleSyncRulesSort('trash')">
+                        <button type="button" class="sort-header" style="width:200px;flex-shrink:0;white-space:nowrap;text-transform:inherit;letter-spacing:inherit"
+                                @click="toggleSyncRulesSort('trash')"
+                                :aria-sort="syncRulesSort.col === 'trash' ? (syncRulesSort.dir === 'asc' ? 'ascending' : 'descending') : 'none'">
                           TRaSH Profile <span x-show="syncRulesSort.col==='trash'" x-text="syncRulesSort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span>
-                        </span>
+                        </button>
                         <span style="width:20px;flex-shrink:0"></span>
-                        <span style="width:200px;flex-shrink:0;cursor:pointer;white-space:nowrap" @click="toggleSyncRulesSort('arr')">
+                        <button type="button" class="sort-header" style="width:200px;flex-shrink:0;white-space:nowrap;text-transform:inherit;letter-spacing:inherit"
+                                @click="toggleSyncRulesSort('arr')"
+                                :aria-sort="syncRulesSort.col === 'arr' ? (syncRulesSort.dir === 'asc' ? 'ascending' : 'descending') : 'none'">
                           Arr Profile <span x-show="syncRulesSort.col==='arr'" x-text="syncRulesSort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span>
-                        </span>
+                        </button>
                         <span style="width:100px;flex-shrink:0">Auto-Sync</span>
                         <span style="flex:1;text-align:center">Details</span>
                         <span style="width:180px;flex-shrink:0;text-align:center">Actions</span>
@@ -71,7 +81,7 @@
                             </template>
                             <template x-if="!sh.orphanedAt && !editing">
                               <span>
-                                <span style="color:var(--text-primary);cursor:pointer;border-bottom:1px dashed var(--border-subtle)" @click.stop="newName = sh.arrProfileName; editing = true" x-tt="'Click to rename in Arr'" x-text="sh.arrProfileName"></span>
+                                <button type="button" class="inline-action" style="color:var(--text-primary);border-bottom:1px dashed var(--border-subtle)" @click.stop="newName = sh.arrProfileName; editing = true" x-tt="'Click to rename in Arr'" x-text="sh.arrProfileName"></button>
                                 <span style="color:var(--text-muted);font-size:12px" x-text="'ID ' + sh.arrProfileId"></span>
                               </span>
                             </template>
@@ -153,11 +163,12 @@
           <div>
             <template x-for="group in groupedProfiles(activeAppType)" :key="group.name">
               <div class="card" :class="'grp-' + group.name.toLowerCase().replace(/[^a-z]/g, '')">
-                <div class="profile-group-header" @click="toggleProfileGroup(activeAppType, group.name)">
+                <button type="button" class="profile-group-header" @click="toggleProfileGroup(activeAppType, group.name)"
+                        :aria-expanded="isProfileGroupExpanded(activeAppType, group.name)">
                   <span class="profile-group-chevron" :class="{ open: isProfileGroupExpanded(activeAppType, group.name) }">&#9654;</span>
                   <span x-text="group.name"></span>
                   <span class="profile-group-count" x-text="group.profiles.length + (group.profiles.length === 1 ? ' profile' : ' profiles')"></span>
-                </div>
+                </button>
                 <div x-show="isProfileGroupExpanded(activeAppType, group.name)">
                   <template x-for="p in group.profiles" :key="p.trashId">
                     <div class="profile-row">
@@ -204,11 +215,19 @@
                 <!-- Table layout for proper column alignment -->
                 <!-- Column headers -->
                 <div style="display:flex;align-items:center;padding:4px 16px;font-size:12px;color:var(--text-muted);text-transform:uppercase;letter-spacing:0.5px;border-bottom:1px solid var(--bg-card);user-select:none">
-                  <div style="flex:none;width:240px;cursor:pointer" @click="toggleHistorySort('trash')">TRaSH Profile <span x-show="historySort.col==='trash'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></div>
+                  <button type="button" class="sort-header" style="flex:none;width:240px;text-transform:inherit;letter-spacing:inherit"
+                          @click="toggleHistorySort('trash')"
+                          :aria-sort="historySort.col === 'trash' ? (historySort.dir === 'asc' ? 'ascending' : 'descending') : 'none'">TRaSH Profile <span x-show="historySort.col==='trash'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></button>
                   <div style="flex:none;width:20px"></div>
-                  <div style="flex:none;width:240px;cursor:pointer" @click="toggleHistorySort('arr')">Arr Profile <span x-show="historySort.col==='arr'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></div>
-                  <div style="flex:none;width:100px;cursor:pointer" @click="toggleHistorySort('changed')">Last Changed <span x-show="historySort.col==='changed'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></div>
-                  <div style="flex:none;width:55px;text-align:center;cursor:pointer" @click="toggleHistorySort('events')">Events <span x-show="historySort.col==='events'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></div>
+                  <button type="button" class="sort-header" style="flex:none;width:240px;text-transform:inherit;letter-spacing:inherit"
+                          @click="toggleHistorySort('arr')"
+                          :aria-sort="historySort.col === 'arr' ? (historySort.dir === 'asc' ? 'ascending' : 'descending') : 'none'">Arr Profile <span x-show="historySort.col==='arr'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></button>
+                  <button type="button" class="sort-header" style="flex:none;width:100px;text-transform:inherit;letter-spacing:inherit"
+                          @click="toggleHistorySort('changed')"
+                          :aria-sort="historySort.col === 'changed' ? (historySort.dir === 'asc' ? 'ascending' : 'descending') : 'none'">Last Changed <span x-show="historySort.col==='changed'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></button>
+                  <button type="button" class="sort-header" style="flex:none;width:55px;text-align:center;text-transform:inherit;letter-spacing:inherit"
+                          @click="toggleHistorySort('events')"
+                          :aria-sort="historySort.col === 'events' ? (historySort.dir === 'asc' ? 'ascending' : 'descending') : 'none'">Events <span x-show="historySort.col==='events'" x-text="historySort.dir==='asc'?'▲':'▼'" style="font-size:10px"></span></button>
                   <div style="flex:1;text-align:right;padding-right:4px">Last Changes</div>
                 </div>
                 <!-- Data rows -->
@@ -619,12 +638,12 @@
                                         <!-- Filter chip bar — single source of truth for diff counts. -->
                                         <div style="display:flex;gap:6px;flex-wrap:wrap;align-items:center;margin-bottom:16px">
                                           <span style="font-size:11px;font-weight:600;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-right:6px">Filter</span>
-                                          <span class="compare-chip" :class="compareFilter === 'all' ? 'active' : ''" @click="compareFilter = 'all'" x-text="'All (' + compareAdjustedCounts(cr).all + ')'"></span>
-                                          <span class="compare-chip" :class="compareFilter === 'diff' ? 'active' : ''" @click="compareFilter = 'diff'" x-text="'Only diffs (' + compareAdjustedCounts(cr).diffs + ')'"></span>
-                                          <span class="compare-chip compare-chip-wrong" :class="compareFilter === 'wrong' ? 'active' : ''" @click="compareFilter = 'wrong'" x-text="'⚠ Wrong score (' + compareAdjustedCounts(cr).wrong + ')'"></span>
-                                          <span class="compare-chip compare-chip-missing" :class="compareFilter === 'missing' ? 'active' : ''" @click="compareFilter = 'missing'" x-tt="'Golden Rule groups count as 1 item — pick 1 of the available variants'" x-text="'✗ Missing (' + compareAdjustedCounts(cr).missing + ')'"></span>
-                                          <span class="compare-chip compare-chip-extra" :class="compareFilter === 'extra' ? 'active' : ''" @click="compareFilter = 'extra'" x-text="'+ Extra (' + compareAdjustedCounts(cr).extra + ')'"></span>
-                                          <span class="compare-chip compare-chip-match" :class="compareFilter === 'match' ? 'active' : ''" @click="compareFilter = 'match'" x-text="'✓ Matching (' + compareAdjustedCounts(cr).matching + ')'"></span>
+                                          <button type="button" class="compare-chip" :class="compareFilter === 'all' ? 'active' : ''" :aria-pressed="compareFilter === 'all'" @click="compareFilter = 'all'" x-text="'All (' + compareAdjustedCounts(cr).all + ')'"></button>
+                                          <button type="button" class="compare-chip" :class="compareFilter === 'diff' ? 'active' : ''" :aria-pressed="compareFilter === 'diff'" @click="compareFilter = 'diff'" x-text="'Only diffs (' + compareAdjustedCounts(cr).diffs + ')'"></button>
+                                          <button type="button" class="compare-chip compare-chip-wrong" :class="compareFilter === 'wrong' ? 'active' : ''" :aria-pressed="compareFilter === 'wrong'" @click="compareFilter = 'wrong'" x-text="'⚠ Wrong score (' + compareAdjustedCounts(cr).wrong + ')'"></button>
+                                          <button type="button" class="compare-chip compare-chip-missing" :class="compareFilter === 'missing' ? 'active' : ''" :aria-pressed="compareFilter === 'missing'" @click="compareFilter = 'missing'" x-tt="'Golden Rule groups count as 1 item — pick 1 of the available variants'" x-text="'✗ Missing (' + compareAdjustedCounts(cr).missing + ')'"></button>
+                                          <button type="button" class="compare-chip compare-chip-extra" :class="compareFilter === 'extra' ? 'active' : ''" :aria-pressed="compareFilter === 'extra'" @click="compareFilter = 'extra'" x-text="'+ Extra (' + compareAdjustedCounts(cr).extra + ')'"></button>
+                                          <button type="button" class="compare-chip compare-chip-match" :class="compareFilter === 'match' ? 'active' : ''" :aria-pressed="compareFilter === 'match'" @click="compareFilter = 'match'" x-text="'✓ Matching (' + compareAdjustedCounts(cr).matching + ')'"></button>
                                         </div>
 
                                         <!-- Profile Settings — one card with a 4-column table (Setting | Current | TRaSH | Sync) and sub-header rows for General / Quality / Quality Items. Rows filtered by compareFilter. Entire card hidden if filter yields 0 visible rows. Matches clonarr-compare-redesign-v3.html mockup. -->
@@ -644,9 +663,9 @@
                                                 </template>
                                               </span>
                                               <div style="flex:1"></div>
-                                              <span class="compare-section-toggle"
-                                                    x-show="(cr.settingsDiffs || []).some(s => !s.match) || (cr.qualityDiffs || []).some(q => !q.match)"
-                                                    @click.stop="toggleAllInCompareSection(iid, cr, 'settings')">toggle all</span>
+                                              <button type="button" class="compare-section-toggle"
+                                                      x-show="(cr.settingsDiffs || []).some(s => !s.match) || (cr.qualityDiffs || []).some(q => !q.match)"
+                                                      @click.stop="toggleAllInCompareSection(iid, cr, 'settings')">toggle all</button>
                                               <button class="btn btn-sm btn-primary" style="font-size:11px;padding:2px 10px;margin-left:8px"
                                                       x-show="(cr.settingsDiffs || []).some(s => !s.match) || (cr.qualityDiffs || []).some(q => !q.match)"
                                                       @click="compareQuickSyncOpen(inst, cr, 'settings')">Sync selected</button>
@@ -737,9 +756,9 @@
                                                 <span x-show="cr.formatItems.some(fi => !fi.exists)" style="color:var(--accent-red);background:var(--accent-red-bg);padding:1px 6px;border-radius:8px" x-text="cr.formatItems.filter(fi => !fi.exists).length + ' missing'"></span>
                                               </span>
                                               <div style="flex:1"></div>
-                                              <span class="compare-section-toggle"
-                                                    x-show="cr.formatItems.some(fi => !fi.exists || !fi.scoreMatch)"
-                                                    @click.stop="toggleAllInCompareSection(iid, cr, 'requiredCfs')">toggle all</span>
+                                              <button type="button" class="compare-section-toggle"
+                                                      x-show="cr.formatItems.some(fi => !fi.exists || !fi.scoreMatch)"
+                                                      @click.stop="toggleAllInCompareSection(iid, cr, 'requiredCfs')">toggle all</button>
                                               <button class="btn btn-sm btn-primary" style="font-size:11px;padding:2px 10px;margin-left:8px"
                                                       x-show="cr.formatItems.some(fi => !fi.exists || !fi.scoreMatch)"
                                                       @click="compareQuickSyncOpen(inst, cr, 'requiredCfs')">Sync selected</button>
@@ -808,9 +827,9 @@
                                                       x-text="cr.groups.reduce((n,g) => n + g.missing, 0) + ' missing'"></span>
                                               </span>
                                               <div style="flex:1"></div>
-                                              <span class="compare-section-toggle"
-                                                    x-show="cr.groups.some(g => g.wrongScore > 0 || g.missing > 0)"
-                                                    @click.stop="toggleAllInCompareSection(iid, cr, 'groups')">toggle all</span>
+                                              <button type="button" class="compare-section-toggle"
+                                                      x-show="cr.groups.some(g => g.wrongScore > 0 || g.missing > 0)"
+                                                      @click.stop="toggleAllInCompareSection(iid, cr, 'groups')">toggle all</button>
                                               <button class="btn btn-sm btn-primary" style="font-size:11px;padding:2px 10px;margin-left:8px"
                                                       x-show="cr.groups.some(g => g.wrongScore > 0 || g.missing > 0)"
                                                       @click="compareQuickSyncOpen(inst, cr, 'groups')">Sync selected</button>
@@ -914,7 +933,7 @@
                                               <span style="font-size:14px;font-weight:600;color:var(--text-body)">Extra in Arr</span>
                                               <span style="font-size:11px;color:var(--accent-blue);background:var(--fill-blue-soft);padding:1px 6px;border-radius:8px;margin-left:8px" x-text="cr.summary.extra + ' CFs'"></span>
                                               <div style="flex:1"></div>
-                                              <span class="compare-section-toggle" @click.stop="toggleAllInCompareSection(iid, cr, 'extras')">toggle all</span>
+                                              <button type="button" class="compare-section-toggle" @click.stop="toggleAllInCompareSection(iid, cr, 'extras')">toggle all</button>
                                               <button class="btn btn-sm btn-primary" style="font-size:11px;padding:2px 10px;margin-left:8px"
                                                       x-show="getRemoveSelectedCount(iid) > 0"
                                                       @click="compareQuickSyncOpen(inst, cr, 'extras')">Remove selected</button>

--- a/ui/static/partials/sections/profiles.html
+++ b/ui/static/partials/sections/profiles.html
@@ -1,5 +1,5 @@
 {{define "sections/profiles"}}
-      <!-- ===== Profiles sub-tab ===== -->
+      <!-- ===== Profiles section ===== -->
       <div x-show="currentSection === 'profiles'">
 
 

--- a/ui/static/partials/sections/scoring.html
+++ b/ui/static/partials/sections/scoring.html
@@ -1,5 +1,5 @@
 {{define "sections/scoring"}}
-      <!-- ===== Scoring Sandbox sub-tab ===== -->
+      <!-- ===== Scoring Sandbox section / Advanced sub-tab ===== -->
       <div class="page" x-show="currentSection === 'scoring' || (currentSection === 'advanced' && advancedTab === 'scoring')" style="max-width:none">
         <div style="font-size:18px;font-weight:600;margin-bottom:4px">Scoring Sandbox</div>
         <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">Test how releases score against your profiles. Paste a release name or search Prowlarr, then see which Custom Formats match and the total score.</div>

--- a/ui/static/partials/sections/scoring.html
+++ b/ui/static/partials/sections/scoring.html
@@ -330,21 +330,36 @@
                              @change="toggleSandboxSelectAll(activeAppType)">
                     </th>
                     <th style="width:22px;padding:5px 2px"></th>
-                    <th style="text-align:left;padding:5px 6px;font-weight:500;cursor:pointer;white-space:nowrap" @click="toggleSandboxSort(activeAppType, 'title')">
-                      Release <span x-show="sandbox[activeAppType].sortCol==='title'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                    <th style="text-align:left;padding:5px 6px;font-weight:500;white-space:nowrap"
+                        :aria-sort="sandbox[activeAppType].sortCol === 'title' ? (sandbox[activeAppType].sortDir === 'asc' ? 'ascending' : 'descending') : 'none'">
+                      <button type="button" class="sort-header" style="width:100%;text-align:left;text-transform:inherit;letter-spacing:inherit" @click="toggleSandboxSort(activeAppType, 'title')">
+                        Release <span x-show="sandbox[activeAppType].sortCol==='title'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                      </button>
                     </th>
                     <th style="text-align:left;padding:5px 4px;font-weight:500;white-space:nowrap">Matched CFs</th>
-                    <th style="text-align:center;padding:5px 4px;font-weight:500;width:80px;cursor:pointer;white-space:nowrap" @click="toggleSandboxSort(activeAppType, 'quality')">
-                      Quality <span x-show="sandbox[activeAppType].sortCol==='quality'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                    <th style="text-align:center;padding:5px 4px;font-weight:500;width:80px;white-space:nowrap"
+                        :aria-sort="sandbox[activeAppType].sortCol === 'quality' ? (sandbox[activeAppType].sortDir === 'asc' ? 'ascending' : 'descending') : 'none'">
+                      <button type="button" class="sort-header" style="width:100%;text-align:center;text-transform:inherit;letter-spacing:inherit" @click="toggleSandboxSort(activeAppType, 'quality')">
+                        Quality <span x-show="sandbox[activeAppType].sortCol==='quality'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                      </button>
                     </th>
-                    <th style="text-align:center;padding:5px 4px;font-weight:500;width:64px;cursor:pointer;white-space:nowrap" @click="toggleSandboxSort(activeAppType, 'group')">
-                      Group <span x-show="sandbox[activeAppType].sortCol==='group'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                    <th style="text-align:center;padding:5px 4px;font-weight:500;width:64px;white-space:nowrap"
+                        :aria-sort="sandbox[activeAppType].sortCol === 'group' ? (sandbox[activeAppType].sortDir === 'asc' ? 'ascending' : 'descending') : 'none'">
+                      <button type="button" class="sort-header" style="width:100%;text-align:center;text-transform:inherit;letter-spacing:inherit" @click="toggleSandboxSort(activeAppType, 'group')">
+                        Group <span x-show="sandbox[activeAppType].sortCol==='group'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                      </button>
                     </th>
-                    <th style="text-align:right;padding:5px 4px;font-weight:500;width:60px;cursor:pointer;white-space:nowrap" @click="toggleSandboxSort(activeAppType, 'score')">
-                      Score <span x-show="sandbox[activeAppType].sortCol==='score'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                    <th style="text-align:right;padding:5px 4px;font-weight:500;width:60px;white-space:nowrap"
+                        :aria-sort="sandbox[activeAppType].sortCol === 'score' ? (sandbox[activeAppType].sortDir === 'asc' ? 'ascending' : 'descending') : 'none'">
+                      <button type="button" class="sort-header" style="width:100%;text-align:right;text-transform:inherit;letter-spacing:inherit" @click="toggleSandboxSort(activeAppType, 'score')">
+                        Score <span x-show="sandbox[activeAppType].sortCol==='score'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                      </button>
                     </th>
-                    <th style="text-align:center;padding:5px 4px;font-weight:500;width:52px;cursor:pointer;white-space:nowrap" @click="toggleSandboxSort(activeAppType, 'status')">
-                      Status <span x-show="sandbox[activeAppType].sortCol==='status'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                    <th style="text-align:center;padding:5px 4px;font-weight:500;width:52px;white-space:nowrap"
+                        :aria-sort="sandbox[activeAppType].sortCol === 'status' ? (sandbox[activeAppType].sortDir === 'asc' ? 'ascending' : 'descending') : 'none'">
+                      <button type="button" class="sort-header" style="width:100%;text-align:center;text-transform:inherit;letter-spacing:inherit" @click="toggleSandboxSort(activeAppType, 'status')">
+                        Status <span x-show="sandbox[activeAppType].sortCol==='status'" x-text="sandbox[activeAppType].sortDir==='asc'?'▲':'▼'" style="font-size:10px"></span>
+                      </button>
                     </th>
                     <th style="width:24px;padding:5px 2px"></th>
                   </tr>

--- a/ui/static/partials/sections/settings.html
+++ b/ui/static/partials/sections/settings.html
@@ -6,15 +6,15 @@
 
     <div class="settings-layout">
       <!-- Sidebar nav -->
-      <div class="settings-sidebar">
-        <div class="settings-nav" :class="settingsSection === 'instances' && 'settings-nav-active'" @click="settingsSection = 'instances'; pushNav()">Instances</div>
-        <div class="settings-nav" :class="settingsSection === 'trash' && 'settings-nav-active'" @click="settingsSection = 'trash'; pushNav()">TRaSH Guides</div>
-        <div class="settings-nav" x-show="config.devMode" :class="settingsSection === 'prowlarr' && 'settings-nav-active'" @click="settingsSection = 'prowlarr'; pushNav()">Prowlarr</div>
-        <div class="settings-nav" :class="settingsSection === 'notifications' && 'settings-nav-active'" @click="settingsSection = 'notifications'; pushNav()">Notifications</div>
-        <div class="settings-nav" :class="settingsSection === 'display' && 'settings-nav-active'" @click="settingsSection = 'display'; pushNav()">Display</div>
-        <div class="settings-nav" :class="settingsSection === 'security' && 'settings-nav-active'" @click="settingsSection = 'security'; pushNav(); fetchApiKey()">Security</div>
-        <div class="settings-nav" :class="settingsSection === 'advanced' && 'settings-nav-active'" @click="settingsSection = 'advanced'; pushNav()">Advanced</div>
-      </div>
+      <nav class="settings-sidebar" aria-label="Settings">
+        <a class="settings-nav" :class="settingsSection === 'instances' && 'settings-nav-active'" :href="navHref('settings', { settingsSection: 'instances' })" :aria-current="settingsSection === 'instances' ? 'page' : null">Instances</a>
+        <a class="settings-nav" :class="settingsSection === 'trash' && 'settings-nav-active'" :href="navHref('settings', { settingsSection: 'trash' })" :aria-current="settingsSection === 'trash' ? 'page' : null">TRaSH Guides</a>
+        <a class="settings-nav" x-show="config.devMode" :class="settingsSection === 'prowlarr' && 'settings-nav-active'" :href="navHref('settings', { settingsSection: 'prowlarr' })" :aria-current="settingsSection === 'prowlarr' ? 'page' : null">Prowlarr</a>
+        <a class="settings-nav" :class="settingsSection === 'notifications' && 'settings-nav-active'" :href="navHref('settings', { settingsSection: 'notifications' })" :aria-current="settingsSection === 'notifications' ? 'page' : null">Notifications</a>
+        <a class="settings-nav" :class="settingsSection === 'display' && 'settings-nav-active'" :href="navHref('settings', { settingsSection: 'display' })" :aria-current="settingsSection === 'display' ? 'page' : null">Display</a>
+        <a class="settings-nav" :class="settingsSection === 'security' && 'settings-nav-active'" :href="navHref('settings', { settingsSection: 'security' })" :aria-current="settingsSection === 'security' ? 'page' : null">Security</a>
+        <a class="settings-nav" :class="settingsSection === 'advanced' && 'settings-nav-active'" :href="navHref('settings', { settingsSection: 'advanced' })" :aria-current="settingsSection === 'advanced' ? 'page' : null">Advanced</a>
+      </nav>
 
       <!-- Content panel -->
       <div class="settings-content">


### PR DESCRIPTION
## Context
Before this PR, Clonarr's UI was difficult or impossible for keyboard users and screen readers to navigate natively. A heavy reliance on `<div @click>` anti-patterns broke "Right-click -> Open in new tab", bypassed `Tab` layouts, allowed focus to escape open modals, and prevented native ARIA integrations. This PR comprehensively targets those deficiencies, making Clonarr massively more accessible.

## Actual Changes in this Branch

### 1. Native Hash Routing (`a[href]`)
- Replaced `<div @click>` based navigation with semantic `<a href="#route">` elements in the App Switcher, Profiles sub-tabs, Settings sidebars, and Top Navigation strips. 
- Refactored `navigation.js` and `main.js` to dispatch component data reloads automatically using reactive `$watch` listeners when the app URL hash changes.
- Right-click behavior ("Open in new tab") now works globally without executing active-tab side effects. 
- Added a "Skip to main content" mechanism for keyboard users.

### 2. Semantic Toggles & Controls
- Audited the entire application to convert non-navigation pseudo-buttons (like `.compare-chip`, sort headers, and collapsibles in the Profile menus) strictly into native `<button>` tags.
- Hooked up contextual `aria-expanded` and `aria-sort` data bindings so UI state mutations are properly announced to screen readers on click.

### 3. Modal Focus Traps
- Engineered a lightweight focus-trap implementation (`scrollLockSnapshot` & `inertElementState`) strictly within `main.js` to capture layout intent via custom Alpine logic.
- Implemented `x-trap.noscroll.inert` and `role="dialog"` attributes to functionally sandbox user input within open modals and revert focus to the correct element when closed via the `Escape` key.

### 4. Tooltips, Validation & Contrast
- Improved the `x-tt` tooltip directive to fire sequentially with `focusin` events, creating `aria-describedby` linking. Now, when navigating using `Tab`, tooltips display visually and read out successfully.
- Added structured ARIA form validation (`.field-error` pattern elements bounded via `aria-invalid`) to critical flows, such as Instance configuration and turning off global Auth logic.
- Conducted an accessibility sweep of `tokens.css`, correctly shifting `--text-muted` and `--text-secondary` token balances exclusively in the Light Theme to pass WCAG AA minimum 4.5:1 visibility thresholds.
- Fixed a URL routing bug preventing the "CF Group Builder" from resolving dynamically.