### PR TITLE
fix: reposition cleanup result modal outside of the main template

### DIFF
--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -53,10 +53,10 @@
   {{template "sections/advanced" .}}
   {{template "overlays/profile-builder" .}}
   {{template "overlays/profile-detail" .}}
-  {{template "modals/cleanup-result" .}}
   {{template "sections/settings" .}}
   {{template "sections/about" .}}
   </main>
+  {{template "modals/cleanup-result" .}}
   {{template "modals/instance" .}}
   {{template "modals/notification-agent" .}}
   {{template "modals/sandbox-cf-browser" .}}


### PR DESCRIPTION
Moves "modals/cleanup-result" outside of main in index.html for consistency with other modals.