### PR TITLE
Add scheduled TRaSH pull intervals

### DIFF
--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"strconv"
+	"os"
 	"strings"
 	"time"
 )
@@ -32,14 +32,52 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	for i, a := range cfg.AutoSync.NotificationAgents {
 		cfg.AutoSync.NotificationAgents[i].Config = maskAgentConfig(a.Type, a.Config)
 	}
+	timeInfo := serverTimeInfoAt(time.Now(), os.Getenv("TZ") != "")
+
 	// Wrap config with version + devFeatures for frontend.
 	// devFeatures is env-only (CLONARR_DEV_FEATURES), not persisted to clonarr.json,
 	// so it's exposed alongside the config rather than as part of it.
 	writeJSON(w, struct {
 		core.Config
-		Version     string `json:"version"`
-		DevFeatures bool   `json:"devFeatures"`
-	}{cfg, s.Core.Version, s.Core.DevFeatures})
+		Version                  string `json:"version"`
+		DevFeatures              bool   `json:"devFeatures"`
+		ServerTimeZone           string `json:"serverTimeZone"`
+		ServerTimeZoneOffset     int    `json:"serverTimeZoneOffset"`
+		ServerTimeZoneConfigured bool   `json:"serverTimeZoneConfigured"`
+		ServerNow                string `json:"serverNow"`
+	}{
+		Config:                   cfg,
+		Version:                  s.Core.Version,
+		DevFeatures:              s.Core.DevFeatures,
+		ServerTimeZone:           timeInfo.ServerTimeZone,
+		ServerTimeZoneOffset:     timeInfo.ServerTimeZoneOffset,
+		ServerTimeZoneConfigured: timeInfo.ServerTimeZoneConfigured,
+		ServerNow:                timeInfo.ServerNow,
+	})
+}
+
+func serverTimeZoneLabel(t time.Time) string {
+	return serverTimeInfoAt(t, false).ServerTimeZone
+}
+
+type serverTimeInfo struct {
+	ServerTimeZone           string
+	ServerTimeZoneOffset     int
+	ServerTimeZoneConfigured bool
+	ServerNow                string
+}
+
+func serverTimeInfoAt(t time.Time, configured bool) serverTimeInfo {
+	name, offset := t.Zone()
+	if name == "" {
+		name = "Local"
+	}
+	return serverTimeInfo{
+		ServerTimeZone:           name,
+		ServerTimeZoneOffset:     offset,
+		ServerTimeZoneConfigured: configured,
+		ServerNow:                t.Format(time.RFC3339),
+	}
 }
 
 func validatePullSchedule(sched core.PullSchedule) error {
@@ -48,7 +86,7 @@ func validatePullSchedule(sched core.PullSchedule) error {
 	if !core.IsValidEnumValue(core.PullScheduleModes, sched.Mode) {
 		return fmt.Errorf("pullSchedule.mode must be one of: %s", strings.Join(core.EnumValues(core.PullScheduleModes), ", "))
 	}
-	if !validScheduleClock(sched.Time) {
+	if _, _, ok := core.ParsePullScheduleClock(sched.Time); !ok {
 		return fmt.Errorf("pullSchedule.time must be HH:MM in 24-hour format")
 	}
 	if sched.Mode == "weekly" && (sched.DayOfWeek < 0 || sched.DayOfWeek > 6) {
@@ -58,21 +96,6 @@ func validatePullSchedule(sched core.PullSchedule) error {
 		return fmt.Errorf("pullSchedule.dayOfMonth must be 1..28")
 	}
 	return nil
-}
-
-func validScheduleClock(s string) bool {
-	if len(s) != 5 || s[2] != ':' {
-		return false
-	}
-	hour, err := strconv.Atoi(s[:2])
-	if err != nil {
-		return false
-	}
-	minute, err := strconv.Atoi(s[3:])
-	if err != nil {
-		return false
-	}
-	return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59
 }
 
 func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
@@ -282,6 +305,7 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	// Wake the scheduler after persistence. It re-reads ConfigStore so rapid
 	// partial saves cannot leave it running from stale request data.
 	if pullChanged || scheduleChanged {
+		s.Core.SetNextPullAt(nextPullAfterConfigSave(s.Core.Config.Get()))
 		select {
 		case s.Core.PullUpdateCh <- "":
 		default:

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -41,6 +42,39 @@ func (s *Server) handleGetConfig(w http.ResponseWriter, r *http.Request) {
 	}{cfg, s.Core.Version, s.Core.DevFeatures})
 }
 
+func validatePullSchedule(sched core.PullSchedule) error {
+	// Keep API validation in step with the scheduler. Bad saved schedules would
+	// otherwise turn into a disabled timer with only a log line as a clue.
+	if !core.IsValidEnumValue(core.PullScheduleModes, sched.Mode) {
+		return fmt.Errorf("pullSchedule.mode must be one of: %s", strings.Join(core.EnumValues(core.PullScheduleModes), ", "))
+	}
+	if !validScheduleClock(sched.Time) {
+		return fmt.Errorf("pullSchedule.time must be HH:MM in 24-hour format")
+	}
+	if sched.Mode == "weekly" && (sched.DayOfWeek < 0 || sched.DayOfWeek > 6) {
+		return fmt.Errorf("pullSchedule.dayOfWeek must be 0..6")
+	}
+	if sched.Mode == "monthly" && (sched.DayOfMonth < 1 || sched.DayOfMonth > 28) {
+		return fmt.Errorf("pullSchedule.dayOfMonth must be 1..28")
+	}
+	return nil
+}
+
+func validScheduleClock(s string) bool {
+	if len(s) != 5 || s[2] != ':' {
+		return false
+	}
+	hour, err := strconv.Atoi(s[:2])
+	if err != nil {
+		return false
+	}
+	minute, err := strconv.Atoi(s[3:])
+	if err != nil {
+		return false
+	}
+	return hour >= 0 && hour <= 23 && minute >= 0 && minute <= 59
+}
+
 func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	s.updateConfigMu.Lock()
 	defer s.updateConfigMu.Unlock()
@@ -56,6 +90,7 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		TrashRepo              *core.TrashRepo      `json:"trashRepo,omitempty"`
 		PullInterval           *string              `json:"pullInterval,omitempty"`
+		PullSchedule           *core.PullSchedule   `json:"pullSchedule,omitempty"`
 		DevMode                *bool                `json:"devMode,omitempty"`
 		TrashSchemaFields      *bool                `json:"trashSchemaFields,omitempty"`
 		DebugLogging           *bool                `json:"debugLogging"`
@@ -142,6 +177,29 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Validate the merged config, not just the fields in this request. Settings
+	// saves are partial, and a scheduled pull is only valid as interval+schedule pair.
+	existingCfg := s.Core.Config.Get()
+	effectiveInterval := existingCfg.PullInterval
+	if req.PullInterval != nil {
+		effectiveInterval = *req.PullInterval
+	}
+	effectiveSchedule := existingCfg.PullSchedule
+	if req.PullSchedule != nil {
+		sched := *req.PullSchedule
+		effectiveSchedule = &sched
+	}
+	if effectiveInterval == "specific" {
+		if effectiveSchedule == nil {
+			writeError(w, 400, "pullSchedule is required when pullInterval is specific")
+			return
+		}
+		if err := validatePullSchedule(*effectiveSchedule); err != nil {
+			writeError(w, 400, err.Error())
+			return
+		}
+	}
+
 	// Any save that sets authentication=none requires the current admin password.
 	if req.Authentication != nil && *req.Authentication == "none" && s.AuthStore != nil {
 		if confirm.ConfirmPassword == "" {
@@ -155,6 +213,7 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	pullChanged := false
+	scheduleChanged := false
 	authChanged := false
 	err := s.Core.Config.Update(func(cfg *core.Config) {
 		if req.TrashRepo != nil {
@@ -168,6 +227,11 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		if req.PullInterval != nil {
 			cfg.PullInterval = *req.PullInterval
 			pullChanged = true
+		}
+		if req.PullSchedule != nil && effectiveInterval == "specific" {
+			sched := *req.PullSchedule
+			cfg.PullSchedule = &sched
+			scheduleChanged = true
 		}
 		if req.DevMode != nil {
 			cfg.DevMode = *req.DevMode
@@ -215,11 +279,11 @@ func (s *Server) handleUpdateConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Notify pull goroutine of schedule change
-	if pullChanged {
-		cfg := s.Core.Config.Get()
+	// Wake the scheduler after persistence. It re-reads ConfigStore so rapid
+	// partial saves cannot leave it running from stale request data.
+	if pullChanged || scheduleChanged {
 		select {
-		case s.Core.PullUpdateCh <- cfg.PullInterval:
+		case s.Core.PullUpdateCh <- "":
 		default:
 		}
 	}

--- a/internal/api/config_schedule_test.go
+++ b/internal/api/config_schedule_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func setupConfigScheduleServer(t *testing.T, cfg *core.Config) (*Server, *core.App) {
@@ -22,11 +23,75 @@ func setupConfigScheduleServer(t *testing.T, cfg *core.Config) (*Server, *core.A
 	}
 	app := &core.App{
 		Config:       store,
+		Trash:        core.NewTrashStore(tempDir),
 		DebugLog:     core.NewDebugLogger(tempDir),
 		ActivityLog:  core.NewActivityLogger(tempDir),
 		PullUpdateCh: make(chan string, 1),
 	}
 	return &Server{Core: app}, app
+}
+
+func TestServerTimeInfoAt(t *testing.T) {
+	utc := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	info := serverTimeInfoAt(utc, false)
+	if info.ServerTimeZone != "UTC" {
+		t.Fatalf("ServerTimeZone = %q, want UTC", info.ServerTimeZone)
+	}
+	if label := serverTimeZoneLabel(utc); label != "UTC" {
+		t.Fatalf("serverTimeZoneLabel = %q, want UTC", label)
+	}
+	if info.ServerTimeZoneOffset != 0 {
+		t.Fatalf("ServerTimeZoneOffset = %d, want 0", info.ServerTimeZoneOffset)
+	}
+	if info.ServerTimeZoneConfigured {
+		t.Fatalf("ServerTimeZoneConfigured = true, want false")
+	}
+	if info.ServerNow != "2026-05-10T12:00:00Z" {
+		t.Fatalf("ServerNow = %q, want RFC3339 UTC time", info.ServerNow)
+	}
+
+	loc := time.FixedZone("CDT", -5*60*60)
+	local := time.Date(2026, time.May, 10, 9, 30, 0, 0, loc)
+	info = serverTimeInfoAt(local, true)
+	if info.ServerTimeZone != "CDT" {
+		t.Fatalf("ServerTimeZone = %q, want CDT", info.ServerTimeZone)
+	}
+	if info.ServerTimeZoneOffset != -5*60*60 {
+		t.Fatalf("ServerTimeZoneOffset = %d, want -18000", info.ServerTimeZoneOffset)
+	}
+	if !info.ServerTimeZoneConfigured {
+		t.Fatalf("ServerTimeZoneConfigured = false, want true")
+	}
+	if info.ServerNow != "2026-05-10T09:30:00-05:00" {
+		t.Fatalf("ServerNow = %q, want RFC3339 CDT time", info.ServerNow)
+	}
+}
+
+func TestTrashStatusIncludesServerTiming(t *testing.T) {
+	server, app := setupConfigScheduleServer(t, core.DefaultConfig())
+	next := time.Date(2026, time.May, 10, 12, 0, 0, 0, time.UTC)
+	app.SetNextPullAt(next)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/trash/status", nil)
+	w := httptest.NewRecorder()
+	server.handleTrashStatus(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var st core.TrashStatus
+	if err := json.NewDecoder(w.Body).Decode(&st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if st.ServerNow == "" {
+		t.Fatalf("ServerNow missing")
+	}
+	if st.NextPull == "" {
+		t.Fatalf("NextPull missing")
+	}
+	if st.NextPullClock != "12:00" {
+		t.Fatalf("NextPullClock = %q, want 12:00", st.NextPullClock)
+	}
 }
 
 func putConfigSchedule(t *testing.T, server *Server, body string) *httptest.ResponseRecorder {

--- a/internal/api/config_schedule_test.go
+++ b/internal/api/config_schedule_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"clonarr/internal/core"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func setupConfigScheduleServer(t *testing.T, cfg *core.Config) (*Server, *core.App) {
+	t.Helper()
+	tempDir := t.TempDir()
+	store := core.NewConfigStore(tempDir)
+	if cfg == nil {
+		cfg = core.DefaultConfig()
+	}
+	if err := store.Set(cfg); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	app := &core.App{
+		Config:       store,
+		DebugLog:     core.NewDebugLogger(tempDir),
+		ActivityLog:  core.NewActivityLogger(tempDir),
+		PullUpdateCh: make(chan string, 1),
+	}
+	return &Server{Core: app}, app
+}
+
+func putConfigSchedule(t *testing.T, server *Server, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPut, "/api/config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	server.handleUpdateConfig(w, req)
+	return w
+}
+
+func TestUpdateConfigSpecificPullScheduleValid(t *testing.T) {
+	server, app := setupConfigScheduleServer(t, core.DefaultConfig())
+
+	w := putConfigSchedule(t, server, `{"pullInterval":"specific","pullSchedule":{"mode":"daily","time":"03:00","dayOfWeek":0,"dayOfMonth":1}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	cfg := app.Config.Get()
+	if cfg.PullInterval != "specific" {
+		t.Fatalf("PullInterval = %q, want specific", cfg.PullInterval)
+	}
+	if cfg.PullSchedule == nil || cfg.PullSchedule.Mode != "daily" || cfg.PullSchedule.Time != "03:00" {
+		t.Fatalf("PullSchedule = %+v, want daily 03:00", cfg.PullSchedule)
+	}
+}
+
+func TestUpdateConfigSpecificRequiresSchedule(t *testing.T) {
+	server, _ := setupConfigScheduleServer(t, core.DefaultConfig())
+
+	w := putConfigSchedule(t, server, `{"pullInterval":"specific"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestUpdateConfigSpecificUsesExistingSchedule(t *testing.T) {
+	cfg := core.DefaultConfig()
+	cfg.PullSchedule = &core.PullSchedule{Mode: "weekly", Time: "04:00", DayOfWeek: 0, DayOfMonth: 1}
+	server, app := setupConfigScheduleServer(t, cfg)
+
+	w := putConfigSchedule(t, server, `{"pullInterval":"specific"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := app.Config.Get().PullSchedule; got == nil || got.DayOfWeek != 0 {
+		t.Fatalf("PullSchedule = %+v, want existing Sunday schedule", got)
+	}
+}
+
+func TestUpdateConfigScheduleWithoutIntervalWhenSpecific(t *testing.T) {
+	cfg := core.DefaultConfig()
+	cfg.PullInterval = "specific"
+	cfg.PullSchedule = &core.PullSchedule{Mode: "daily", Time: "03:00", DayOfWeek: 0, DayOfMonth: 1}
+	server, app := setupConfigScheduleServer(t, cfg)
+
+	w := putConfigSchedule(t, server, `{"pullSchedule":{"mode":"weekly","time":"04:00","dayOfWeek":0,"dayOfMonth":1}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	got := app.Config.Get().PullSchedule
+	if got == nil || got.Mode != "weekly" || got.DayOfWeek != 0 {
+		t.Fatalf("PullSchedule = %+v, want weekly Sunday", got)
+	}
+}
+
+func TestUpdateConfigScheduleIgnoredWhenIntervalIsNotSpecific(t *testing.T) {
+	server, app := setupConfigScheduleServer(t, core.DefaultConfig())
+
+	w := putConfigSchedule(t, server, `{"pullSchedule":{"mode":"weekly","time":"25:00","dayOfWeek":7,"dayOfMonth":31}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := app.Config.Get().PullSchedule; got != nil {
+		t.Fatalf("PullSchedule = %+v, want nil because fixed-interval schedule update is ignored", got)
+	}
+}
+
+func TestUpdateConfigSpecificPullScheduleInvalid(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "invalid time",
+			body: `{"pullInterval":"specific","pullSchedule":{"mode":"daily","time":"25:00","dayOfWeek":0,"dayOfMonth":1}}`,
+		},
+		{
+			name: "invalid weekday",
+			body: `{"pullInterval":"specific","pullSchedule":{"mode":"weekly","time":"03:00","dayOfWeek":7,"dayOfMonth":1}}`,
+		},
+		{
+			name: "invalid month day zero",
+			body: `{"pullInterval":"specific","pullSchedule":{"mode":"monthly","time":"03:00","dayOfWeek":0,"dayOfMonth":0}}`,
+		},
+		{
+			name: "invalid month day above max",
+			body: `{"pullInterval":"specific","pullSchedule":{"mode":"monthly","time":"03:00","dayOfWeek":0,"dayOfMonth":31}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, _ := setupConfigScheduleServer(t, core.DefaultConfig())
+			w := putConfigSchedule(t, server, tt.body)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+func TestPullScheduleSundayRoundTripsInConfigJSON(t *testing.T) {
+	server, _ := setupConfigScheduleServer(t, core.DefaultConfig())
+
+	w := putConfigSchedule(t, server, `{"pullInterval":"specific","pullSchedule":{"mode":"weekly","time":"03:00","dayOfWeek":0,"dayOfMonth":1}}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/config", nil)
+	getW := httptest.NewRecorder()
+	server.handleGetConfig(getW, req)
+	res := getW.Result()
+	defer res.Body.Close()
+	raw, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &root); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	var sched map[string]json.RawMessage
+	if err := json.Unmarshal(root["pullSchedule"], &sched); err != nil {
+		t.Fatalf("decode pullSchedule: %v", err)
+	}
+	v, ok := sched["dayOfWeek"]
+	if !ok {
+		t.Fatalf("dayOfWeek missing from pullSchedule JSON: %s", raw)
+	}
+	if string(v) != "0" {
+		t.Fatalf("dayOfWeek = %s, want 0", v)
+	}
+}

--- a/internal/api/trash.go
+++ b/internal/api/trash.go
@@ -6,12 +6,19 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"time"
 )
 
 // --- TRaSH ---
 
 func (s *Server) handleTrashStatus(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, s.Core.Trash.Status())
+	st := s.Core.Trash.Status()
+	// Keep countdown math on the server side so browser timezone settings do not
+	// drift from the container's TZ.
+	if next := s.Core.GetNextPullAt(); !next.IsZero() {
+		st.NextPull = next.Format(time.RFC3339)
+	}
+	writeJSON(w, st)
 }
 
 func (s *Server) handleTrashPull(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/trash.go
+++ b/internal/api/trash.go
@@ -13,12 +13,44 @@ import (
 
 func (s *Server) handleTrashStatus(w http.ResponseWriter, r *http.Request) {
 	st := s.Core.Trash.Status()
+	now := time.Now()
+	st.ServerNow = now.Format(time.RFC3339)
 	// Keep countdown math on the server side so browser timezone settings do not
 	// drift from the container's TZ.
-	if next := s.Core.GetNextPullAt(); !next.IsZero() {
+	if next := s.nextPullForStatus(); !next.IsZero() {
 		st.NextPull = next.Format(time.RFC3339)
+		st.NextPullClock = next.Format("15:04")
 	}
 	writeJSON(w, st)
+}
+
+func (s *Server) nextPullForStatus() time.Time {
+	cfg := s.Core.Config.Get()
+	if cfg.PullInterval == "specific" {
+		return nextSpecificPull(cfg)
+	}
+	if cfg.PullInterval == "0" {
+		return time.Time{}
+	}
+	return s.Core.GetNextPullAt()
+}
+
+func nextPullAfterConfigSave(cfg core.Config) time.Time {
+	if cfg.PullInterval == "specific" {
+		return nextSpecificPull(cfg)
+	}
+	interval := core.ParsePullInterval(cfg.PullInterval)
+	if interval <= 0 {
+		return time.Time{}
+	}
+	return time.Now().Add(interval)
+}
+
+func nextSpecificPull(cfg core.Config) time.Time {
+	if cfg.PullSchedule == nil {
+		return time.Time{}
+	}
+	return core.NextPullTime(*cfg.PullSchedule)
 }
 
 func (s *Server) handleTrashPull(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/ui_manifest.go
+++ b/internal/api/ui_manifest.go
@@ -22,17 +22,18 @@ import (
 // uses them to render <option> lists, set CSS custom properties for
 // category colors, and lay out the notification-agent modal generically.
 type UIManifest struct {
-	AppTypes              []core.EnumValue       `json:"appTypes"`
-	SyncBehaviorAddModes  []core.EnumValue       `json:"syncBehaviorAddModes"`
-	SyncBehaviorRemoveModes []core.EnumValue     `json:"syncBehaviorRemoveModes"`
-	SyncBehaviorResetModes []core.EnumValue      `json:"syncBehaviorResetModes"`
-	AuthModes             []core.EnumValue       `json:"authModes"`
-	AuthRequiredModes     []core.EnumValue       `json:"authRequiredModes"`
-	PullIntervalPresets   []core.EnumValue       `json:"pullIntervalPresets"`
-	SessionTTLBounds      core.IntBounds         `json:"sessionTtlBounds"`
-	CFCategories          []core.CategoryMeta    `json:"cfCategories"`
-	ProfileGroups         []core.CategoryMeta    `json:"profileGroups"`
-	NotificationAgents    []agents.AgentTypeMeta `json:"notificationAgents"`
+	AppTypes                []core.EnumValue       `json:"appTypes"`
+	SyncBehaviorAddModes    []core.EnumValue       `json:"syncBehaviorAddModes"`
+	SyncBehaviorRemoveModes []core.EnumValue       `json:"syncBehaviorRemoveModes"`
+	SyncBehaviorResetModes  []core.EnumValue       `json:"syncBehaviorResetModes"`
+	AuthModes               []core.EnumValue       `json:"authModes"`
+	AuthRequiredModes       []core.EnumValue       `json:"authRequiredModes"`
+	PullIntervalPresets     []core.EnumValue       `json:"pullIntervalPresets"`
+	PullScheduleModes       []core.EnumValue       `json:"pullScheduleModes"`
+	SessionTTLBounds        core.IntBounds         `json:"sessionTtlBounds"`
+	CFCategories            []core.CategoryMeta    `json:"cfCategories"`
+	ProfileGroups           []core.CategoryMeta    `json:"profileGroups"`
+	NotificationAgents      []agents.AgentTypeMeta `json:"notificationAgents"`
 }
 
 // handleGetUIManifest returns the static UI manifest.
@@ -51,6 +52,7 @@ func (s *Server) handleGetUIManifest(w http.ResponseWriter, r *http.Request) {
 		AuthModes:               core.AuthModes,
 		AuthRequiredModes:       core.AuthRequiredModes,
 		PullIntervalPresets:     core.PullIntervalPresets,
+		PullScheduleModes:       core.PullScheduleModes,
 		SessionTTLBounds:        core.SessionTTLBounds,
 		CFCategories:            core.CFCategories,
 		ProfileGroups:           core.ProfileGroups,

--- a/internal/api/ui_manifest_test.go
+++ b/internal/api/ui_manifest_test.go
@@ -42,6 +42,9 @@ func TestHandleGetUIManifest(t *testing.T) {
 	if len(m.AuthModes) != 3 {
 		t.Errorf("AuthModes: want 3, got %d", len(m.AuthModes))
 	}
+	if len(m.PullScheduleModes) != 3 {
+		t.Errorf("PullScheduleModes: want 3, got %d", len(m.PullScheduleModes))
+	}
 
 	// Bounds must be non-zero.
 	if m.SessionTTLBounds.Max <= m.SessionTTLBounds.Min {
@@ -84,5 +87,10 @@ func TestUIManifestEnumValuesValidate(t *testing.T) {
 	}
 	if !core.IsValidEnumValue(core.SyncBehaviorResetModes, d.ResetMode) {
 		t.Errorf("default ResetMode %q not in SyncBehaviorResetModes", d.ResetMode)
+	}
+	for _, mode := range []string{"daily", "weekly", "monthly"} {
+		if !core.IsValidEnumValue(core.PullScheduleModes, mode) {
+			t.Errorf("pull schedule mode %q not in PullScheduleModes", mode)
+		}
 	}
 }

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -98,7 +98,9 @@ func ParsePullInterval(s string) time.Duration {
 	return d
 }
 
-func parsePullScheduleClock(s string) (int, int, bool) {
+// ParsePullScheduleClock parses the persisted HH:MM schedule clock.
+// It is shared by API validation and scheduler math so they accept the same format.
+func ParsePullScheduleClock(s string) (int, int, bool) {
 	if len(s) != 5 || s[2] != ':' {
 		return 0, 0, false
 	}
@@ -120,7 +122,7 @@ func parsePullScheduleClock(s string) (int, int, bool) {
 // It always returns a time after now; exact equality rolls to the next period.
 // Invalid or empty schedules return the zero time.
 func nextPullTimeAt(sched PullSchedule, now time.Time) time.Time {
-	hour, minute, ok := parsePullScheduleClock(sched.Time)
+	hour, minute, ok := ParsePullScheduleClock(sched.Time)
 	if !ok {
 		return time.Time{}
 	}

--- a/internal/core/app.go
+++ b/internal/core/app.go
@@ -3,8 +3,10 @@ package core
 import (
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -45,21 +47,43 @@ type App struct {
 	HTTPClient     *http.Client // shared HTTP client for Arr/Prowlarr API calls
 	NotifyClient   *http.Client // shared HTTP client for Discord/Gotify notifications
 	SafeClient     *http.Client // shared HTTP client with SSRF blocklist (Pushover, Discord)
-	PullUpdateCh   chan string  // send new interval string to reschedule pull
+	PullUpdateCh   chan string  // wake the scheduler; payload is ignored so config stays authoritative
+	NextPullAt     atomic.Value // time.Time; zero means no automatic pull is armed
 	CleanupEvents  []CleanupEvent
 	CleanupMu      sync.Mutex
 	AutoSyncEvents []AutoSyncEvent
 	AutoSyncMu     sync.Mutex
 }
 
-// parsePullInterval parses a pull interval string. Supports Go duration (1h, 30m, 24h).
-// Returns 0 to disable. Defaults to 24h if empty.
+// SetNextPullAt records the next automatic TRaSH pull time for /api/trash/status.
+func (a *App) SetNextPullAt(t time.Time) {
+	if a == nil {
+		return
+	}
+	a.NextPullAt.Store(t)
+}
+
+// GetNextPullAt returns the next automatic TRaSH pull time, if one is armed.
+func (a *App) GetNextPullAt() time.Time {
+	if a == nil {
+		return time.Time{}
+	}
+	v := a.NextPullAt.Load()
+	if t, ok := v.(time.Time); ok {
+		return t
+	}
+	return time.Time{}
+}
+
+// ParsePullInterval parses fixed-duration pull intervals such as "1h" or "30m".
+// "0" and "specific" return 0; the scheduler handles wall-clock schedules separately.
+// Empty values keep the historical 24h default.
 func ParsePullInterval(s string) time.Duration {
 	s = strings.TrimSpace(s)
 	if s == "" {
 		return 24 * time.Hour
 	}
-	if s == "0" {
+	if s == "0" || s == "specific" {
 		return 0
 	}
 	d, err := time.ParseDuration(s)
@@ -72,4 +96,67 @@ func ParsePullInterval(s string) time.Duration {
 		return time.Minute
 	}
 	return d
+}
+
+func parsePullScheduleClock(s string) (int, int, bool) {
+	if len(s) != 5 || s[2] != ':' {
+		return 0, 0, false
+	}
+	hour, err := strconv.Atoi(s[:2])
+	if err != nil {
+		return 0, 0, false
+	}
+	minute, err := strconv.Atoi(s[3:])
+	if err != nil {
+		return 0, 0, false
+	}
+	if hour < 0 || hour > 23 || minute < 0 || minute > 59 {
+		return 0, 0, false
+	}
+	return hour, minute, true
+}
+
+// nextPullTimeAt computes the next wall-clock fire time in now's location.
+// It always returns a time after now; exact equality rolls to the next period.
+// Invalid or empty schedules return the zero time.
+func nextPullTimeAt(sched PullSchedule, now time.Time) time.Time {
+	hour, minute, ok := parsePullScheduleClock(sched.Time)
+	if !ok {
+		return time.Time{}
+	}
+
+	switch sched.Mode {
+	case "daily":
+		next := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location())
+		if !next.After(now) {
+			next = next.AddDate(0, 0, 1)
+		}
+		return next
+	case "weekly":
+		if sched.DayOfWeek < 0 || sched.DayOfWeek > 6 {
+			return time.Time{}
+		}
+		daysUntil := (sched.DayOfWeek - int(now.Weekday()) + 7) % 7
+		next := time.Date(now.Year(), now.Month(), now.Day(), hour, minute, 0, 0, now.Location()).AddDate(0, 0, daysUntil)
+		if !next.After(now) {
+			next = next.AddDate(0, 0, 7)
+		}
+		return next
+	case "monthly":
+		if sched.DayOfMonth < 1 || sched.DayOfMonth > 28 {
+			return time.Time{}
+		}
+		next := time.Date(now.Year(), now.Month(), sched.DayOfMonth, hour, minute, 0, 0, now.Location())
+		if !next.After(now) {
+			next = next.AddDate(0, 1, 0)
+		}
+		return next
+	default:
+		return time.Time{}
+	}
+}
+
+// NextPullTime returns the next wall-clock fire time using the process local timezone.
+func NextPullTime(sched PullSchedule) time.Time {
+	return nextPullTimeAt(sched, time.Now())
 }

--- a/internal/core/app_test.go
+++ b/internal/core/app_test.go
@@ -1,0 +1,101 @@
+package core
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextPullTimeAt(t *testing.T) {
+	loc := time.FixedZone("Test/Local", -5*60*60)
+
+	tests := []struct {
+		name  string
+		sched PullSchedule
+		now   time.Time
+		want  time.Time
+	}{
+		{
+			name:  "daily time already passed today",
+			sched: PullSchedule{Mode: "daily", Time: "14:00"},
+			now:   time.Date(2026, time.May, 4, 14, 30, 0, 0, loc),
+			want:  time.Date(2026, time.May, 5, 14, 0, 0, 0, loc),
+		},
+		{
+			name:  "daily time not yet reached",
+			sched: PullSchedule{Mode: "daily", Time: "14:00"},
+			now:   time.Date(2026, time.May, 4, 10, 0, 0, 0, loc),
+			want:  time.Date(2026, time.May, 4, 14, 0, 0, 0, loc),
+		},
+		{
+			name:  "weekly correct day not yet",
+			sched: PullSchedule{Mode: "weekly", Time: "09:00", DayOfWeek: int(time.Wednesday)},
+			now:   time.Date(2026, time.May, 4, 10, 0, 0, 0, loc),
+			want:  time.Date(2026, time.May, 6, 9, 0, 0, 0, loc),
+		},
+		{
+			name:  "weekly correct day passed",
+			sched: PullSchedule{Mode: "weekly", Time: "09:00", DayOfWeek: int(time.Monday)},
+			now:   time.Date(2026, time.May, 4, 10, 0, 0, 0, loc),
+			want:  time.Date(2026, time.May, 11, 9, 0, 0, 0, loc),
+		},
+		{
+			name:  "weekly Sunday",
+			sched: PullSchedule{Mode: "weekly", Time: "03:00", DayOfWeek: int(time.Sunday)},
+			now:   time.Date(2026, time.May, 9, 10, 0, 0, 0, loc),
+			want:  time.Date(2026, time.May, 10, 3, 0, 0, 0, loc),
+		},
+		{
+			name:  "monthly day not yet reached",
+			sched: PullSchedule{Mode: "monthly", Time: "02:00", DayOfMonth: 15},
+			now:   time.Date(2026, time.May, 10, 10, 0, 0, 0, loc),
+			want:  time.Date(2026, time.May, 15, 2, 0, 0, 0, loc),
+		},
+		{
+			name:  "monthly day already passed",
+			sched: PullSchedule{Mode: "monthly", Time: "02:00", DayOfMonth: 5},
+			now:   time.Date(2026, time.May, 10, 10, 0, 0, 0, loc),
+			want:  time.Date(2026, time.June, 5, 2, 0, 0, 0, loc),
+		},
+		{
+			name:  "monthly February wraps",
+			sched: PullSchedule{Mode: "monthly", Time: "12:00", DayOfMonth: 28},
+			now:   time.Date(2026, time.February, 28, 13, 0, 0, 0, loc),
+			want:  time.Date(2026, time.March, 28, 12, 0, 0, 0, loc),
+		},
+		{
+			name:  "exact equality is strictly after",
+			sched: PullSchedule{Mode: "daily", Time: "14:00"},
+			now:   time.Date(2026, time.May, 4, 14, 0, 0, 0, loc),
+			want:  time.Date(2026, time.May, 5, 14, 0, 0, 0, loc),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nextPullTimeAt(tt.sched, tt.now); !got.Equal(tt.want) {
+				t.Fatalf("nextPullTimeAt() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextPullTimeAtInvalidSchedules(t *testing.T) {
+	now := time.Date(2026, time.May, 4, 10, 0, 0, 0, time.UTC)
+	tests := []PullSchedule{
+		{Mode: "daily", Time: "25:99"},
+		{Mode: "", Time: "03:00"},
+		{Mode: "weekly", Time: "03:00", DayOfWeek: 7},
+		{Mode: "monthly", Time: "03:00", DayOfMonth: 29},
+	}
+	for _, sched := range tests {
+		if got := nextPullTimeAt(sched, now); !got.IsZero() {
+			t.Fatalf("nextPullTimeAt(%+v) = %s, want zero time", sched, got)
+		}
+	}
+}
+
+func TestParsePullIntervalSpecificDisablesTicker(t *testing.T) {
+	if got := ParsePullInterval("specific"); got != 0 {
+		t.Fatalf("ParsePullInterval(\"specific\") = %s, want 0", got)
+	}
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -15,7 +15,8 @@ import (
 type Config struct {
 	Instances            []Instance                       `json:"instances"`
 	TrashRepo            TrashRepo                        `json:"trashRepo"`
-	PullInterval         string                           `json:"pullInterval"`                   // Go duration (e.g. "24h", "1h", "0" to disable)
+	PullInterval         string                           `json:"pullInterval"`                   // Go duration (e.g. "24h", "1h"), "0" to disable, or "specific" for PullSchedule
+	PullSchedule         *PullSchedule                    `json:"pullSchedule,omitempty"`         // nil unless a wall-clock pull schedule has been saved
 	DevMode              bool                             `json:"devMode"`                        // Advanced Mode — enables Profile Builder, Scoring Sandbox, CF Group Builder and Prowlarr settings
 	TrashSchemaFields    bool                             `json:"trashSchemaFields"`              // Show TRaSH-schema fields (trash_id, trash_scores, group, description) in CF editor, Profile Builder, CF Group Builder
 	DebugLogging         bool                             `json:"debugLogging"`                   // Write detailed operations to /config/debug.log
@@ -34,6 +35,15 @@ type Config struct {
 	TrustedProxies         string `json:"trustedProxies,omitempty"`         // comma-separated IPs — reverse-proxy deployments
 	TrustedNetworks        string `json:"trustedNetworks,omitempty"`        // comma-separated IPs/CIDRs for local-bypass; empty = Radarr-parity default
 	SessionTTLDays         int    `json:"sessionTtlDays,omitempty"`         // default 30
+}
+
+// PullSchedule holds the wall-clock pull schedule used when PullInterval is "specific".
+// The scheduler interprets Time in the process local timezone (the container's TZ).
+type PullSchedule struct {
+	Mode       string `json:"mode"`       // "daily", "weekly", "monthly"
+	Time       string `json:"time"`       // "HH:MM" (24h format)
+	DayOfWeek  int    `json:"dayOfWeek"`  // 0=Sunday..6=Saturday (weekly)
+	DayOfMonth int    `json:"dayOfMonth"` // 1-28 (monthly)
 }
 
 // ProwlarrConfig holds Prowlarr connection settings for the Scoring Sandbox.
@@ -84,29 +94,29 @@ type NotificationConfig = agents.Config
 
 // AutoSyncRule defines one auto-sync binding (profile → instance).
 type AutoSyncRule struct {
-	ID                string          `json:"id"`
-	Enabled           bool            `json:"enabled"`
-	InstanceID        string          `json:"instanceId"`
-	ProfileSource     string          `json:"profileSource"` // "trash" or "imported"
-	TrashProfileID    string          `json:"trashProfileId,omitempty"`
-	ImportedProfileID string          `json:"importedProfileId,omitempty"`
-	ArrProfileID      int             `json:"arrProfileId"`               // target Arr profile to update
-	SelectedCFs       []string        `json:"selectedCFs,omitempty"`      // user's optional CF selections
+	ID                string   `json:"id"`
+	Enabled           bool     `json:"enabled"`
+	InstanceID        string   `json:"instanceId"`
+	ProfileSource     string   `json:"profileSource"` // "trash" or "imported"
+	TrashProfileID    string   `json:"trashProfileId,omitempty"`
+	ImportedProfileID string   `json:"importedProfileId,omitempty"`
+	ArrProfileID      int      `json:"arrProfileId"`          // target Arr profile to update
+	SelectedCFs       []string `json:"selectedCFs,omitempty"` // user's optional CF selections
 	// KeepArrCFIDs lists Arr CF IDs that must NOT be zeroed by ResetMode='reset_to_zero'.
 	// Populated by Compare-flow apply when the user opts to keep CFs in the "Extra in Arr"
 	// section (Arr-only customs not in any TRaSH cf-group, e.g. user-imported release-group
 	// CFs like FLUX / SiC). Without this, Sync All would zero them on every run.
 	// Empty for rules created via Save & Sync from profile-detail editor — that flow
 	// uses scoreOverrides/extraCFs (trash-id keyed) which doesn't apply to Arr-only CFs.
-	KeepArrCFIDs      []int           `json:"keepArrCFIDs,omitempty"`
-	ScoreOverrides    map[string]int  `json:"scoreOverrides,omitempty"`   // per-CF score overrides (trash_id → score)
-	QualityOverrides  map[string]bool `json:"qualityOverrides,omitempty"` // legacy flat quality override (name → allowed). Used when QualityStructure is empty.
-	QualityStructure  []QualityItem   `json:"qualityStructure,omitempty"` // full structure override (replaces TRaSH items). Trumps QualityOverrides when set.
-	Behavior          *SyncBehavior   `json:"behavior,omitempty"`         // sync behavior rules (nil = defaults)
-	Overrides         *SyncOverrides  `json:"overrides,omitempty"`        // user overrides (min score, language, cutoff, etc.)
-	LastSyncCommit    string          `json:"lastSyncCommit,omitempty"`
-	LastSyncTime      string          `json:"lastSyncTime,omitempty"`
-	LastSyncError     string          `json:"lastSyncError,omitempty"`
+	KeepArrCFIDs     []int           `json:"keepArrCFIDs,omitempty"`
+	ScoreOverrides   map[string]int  `json:"scoreOverrides,omitempty"`   // per-CF score overrides (trash_id → score)
+	QualityOverrides map[string]bool `json:"qualityOverrides,omitempty"` // legacy flat quality override (name → allowed). Used when QualityStructure is empty.
+	QualityStructure []QualityItem   `json:"qualityStructure,omitempty"` // full structure override (replaces TRaSH items). Trumps QualityOverrides when set.
+	Behavior         *SyncBehavior   `json:"behavior,omitempty"`         // sync behavior rules (nil = defaults)
+	Overrides        *SyncOverrides  `json:"overrides,omitempty"`        // user overrides (min score, language, cutoff, etc.)
+	LastSyncCommit   string          `json:"lastSyncCommit,omitempty"`
+	LastSyncTime     string          `json:"lastSyncTime,omitempty"`
+	LastSyncError    string          `json:"lastSyncError,omitempty"`
 	// PriorAvailableGroups is a snapshot of which cf-groups were available
 	// for this rule's profile at last successful sync. Map of
 	// group_trash_id → was_default_enabled_at_last_sync. Used to detect
@@ -213,10 +223,10 @@ type SyncHistoryEntry struct {
 	// Arr-only customs that were preserved on the original sync. Without
 	// this snapshot, sync-history rerun would fall back to nil and the
 	// reset_to_zero pass would wipe every pinned extra.
-	KeepArrCFIDs []int `json:"keepArrCFIDs,omitempty"`
-	CFsCreated        int             `json:"cfsCreated"`
-	CFsUpdated        int             `json:"cfsUpdated"`
-	ScoresUpdated     int             `json:"scoresUpdated"`
+	KeepArrCFIDs  []int `json:"keepArrCFIDs,omitempty"`
+	CFsCreated    int   `json:"cfsCreated"`
+	CFsUpdated    int   `json:"cfsUpdated"`
+	ScoresUpdated int   `json:"scoresUpdated"`
 	// LastSync bumps on every sync attempt for this profile (including no-op
 	// auto-syncs) so callers can show "last activity" per profile. UI surfaces
 	// it in the TRaSH Sync tab's per-profile row.
@@ -353,6 +363,10 @@ func (cs *ConfigStore) Get() Config {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	cfg := *cs.config
+	if cs.config.PullSchedule != nil {
+		ps := *cs.config.PullSchedule
+		cfg.PullSchedule = &ps
+	}
 	cfg.Instances = make([]Instance, len(cs.config.Instances))
 	copy(cfg.Instances, cs.config.Instances)
 	cfg.SyncHistory = make([]SyncHistoryEntry, len(cs.config.SyncHistory))

--- a/internal/core/enums.go
+++ b/internal/core/enums.go
@@ -107,6 +107,15 @@ var PullIntervalPresets = []EnumValue{
 	{Value: "6h", Label: "Every 6 hours"},
 	{Value: "12h", Label: "Every 12 hours"},
 	{Value: "24h", Label: "Every 24 hours"},
+	{Value: "specific", Label: "Scheduled"},
+}
+
+// PullScheduleModes lists the schedule choices shown after selecting the
+// "Scheduled" pull interval preset.
+var PullScheduleModes = []EnumValue{
+	{Value: "daily", Label: "Daily"},
+	{Value: "weekly", Label: "Weekly"},
+	{Value: "monthly", Label: "Monthly"},
 }
 
 // SessionTTLBounds is the accepted range for Authentication > Session TTL (days).

--- a/internal/core/trash.go
+++ b/internal/core/trash.go
@@ -429,21 +429,23 @@ type ChangelogSection struct {
 
 // Status returns repo status for the API.
 type TrashStatus struct {
-	LastPull     string             `json:"lastPull"`
-	NextPull     string             `json:"nextPull,omitempty"` // server-authoritative next automatic pull time
-	CommitHash   string             `json:"commitHash"`
-	CommitDate   string             `json:"commitDate,omitempty"`
-	LastDiff     *PullDiff          `json:"lastDiff,omitempty"`  // what changed in last pull
-	Changelog    []ChangelogSection `json:"changelog,omitempty"` // recent updates from updates.txt
-	RadarrCFs    int                `json:"radarrCFs"`
-	SonarrCFs    int                `json:"sonarrCFs"`
-	RadarrGroups int                `json:"radarrGroups"`
-	SonarrGroups int                `json:"sonarrGroups"`
-	RadarrProfs  int                `json:"radarrProfiles"`
-	SonarrProfs  int                `json:"sonarrProfiles"`
-	Cloned       bool               `json:"cloned"`
-	PullError    string             `json:"pullError,omitempty"`
-	Pulling      bool               `json:"pulling"`
+	LastPull      string             `json:"lastPull"`
+	NextPull      string             `json:"nextPull,omitempty"` // server-authoritative next automatic pull time
+	NextPullClock string             `json:"nextPullClock,omitempty"`
+	ServerNow     string             `json:"serverNow"`
+	CommitHash    string             `json:"commitHash"`
+	CommitDate    string             `json:"commitDate,omitempty"`
+	LastDiff      *PullDiff          `json:"lastDiff,omitempty"`  // what changed in last pull
+	Changelog     []ChangelogSection `json:"changelog,omitempty"` // recent updates from updates.txt
+	RadarrCFs     int                `json:"radarrCFs"`
+	SonarrCFs     int                `json:"sonarrCFs"`
+	RadarrGroups  int                `json:"radarrGroups"`
+	SonarrGroups  int                `json:"sonarrGroups"`
+	RadarrProfs   int                `json:"radarrProfiles"`
+	SonarrProfs   int                `json:"sonarrProfiles"`
+	Cloned        bool               `json:"cloned"`
+	PullError     string             `json:"pullError,omitempty"`
+	Pulling       bool               `json:"pulling"`
 }
 
 func (ts *TrashStore) Status() TrashStatus {

--- a/internal/core/trash.go
+++ b/internal/core/trash.go
@@ -41,10 +41,10 @@ type CFSpecification struct {
 
 // TrashCFGroup bundles related CFs for profiles.
 type TrashCFGroup struct {
-	Name             string         `json:"name"`
-	TrashID          string         `json:"trash_id"`
-	TrashDescription string         `json:"trash_description"`
-	Default          string         `json:"default"`
+	Name             string `json:"name"`
+	TrashID          string `json:"trash_id"`
+	TrashDescription string `json:"trash_description"`
+	Default          string `json:"default"`
 	// Group drives sort order across cf-group display sites. Lower value sorts
 	// earlier; ties break alphabetically. Pointer + omitempty so absent JSON
 	// stays absent on round-trip and zero is distinguishable from unset.
@@ -430,6 +430,7 @@ type ChangelogSection struct {
 // Status returns repo status for the API.
 type TrashStatus struct {
 	LastPull     string             `json:"lastPull"`
+	NextPull     string             `json:"nextPull,omitempty"` // server-authoritative next automatic pull time
 	CommitHash   string             `json:"commitHash"`
 	CommitDate   string             `json:"commitDate,omitempty"`
 	LastDiff     *PullDiff          `json:"lastDiff,omitempty"`  // what changed in last pull
@@ -1355,13 +1356,13 @@ type CategorizedCF struct {
 
 // CFPickerGroup is a CF group within a picker category, carrying group metadata + all score contexts.
 type CFPickerGroup struct {
-	Name             string          `json:"name"`
-	ShortName        string          `json:"shortName"`
-	GroupTrashID     string          `json:"groupTrashId"`
-	TrashDescription string          `json:"trashDescription,omitempty"`
-	DefaultEnabled   bool            `json:"defaultEnabled"`
-	Exclusive        bool            `json:"exclusive"`
-	IncludeProfiles  []string        `json:"includeProfiles,omitempty"`
+	Name             string   `json:"name"`
+	ShortName        string   `json:"shortName"`
+	GroupTrashID     string   `json:"groupTrashId"`
+	TrashDescription string   `json:"trashDescription,omitempty"`
+	DefaultEnabled   bool     `json:"defaultEnabled"`
+	Exclusive        bool     `json:"exclusive"`
+	IncludeProfiles  []string `json:"includeProfiles,omitempty"`
 	// Group drives sort order across cf-group display sites — see CompareCFGroups.
 	// Populated from the TRaSH cf-group JSON's `group` field (or user-authored CFGroup
 	// for custom groups). Pointer + omitempty so absent stays absent over JSON.
@@ -1741,9 +1742,9 @@ type ProfileCFGroupEntry struct {
 
 // ProfileCFGroup is a CF group linked to a profile via quality_profiles.include.
 type ProfileCFGroup struct {
-	Name             string                `json:"name"`
-	TrashDescription string                `json:"trashDescription"`
-	Required         bool                  `json:"required"` // true if all CFs in group have required=true
+	Name             string `json:"name"`
+	TrashDescription string `json:"trashDescription"`
+	Required         bool   `json:"required"` // true if all CFs in group have required=true
 	// Group drives sort order — see CompareCFGroups. Populated from the
 	// source cf-group JSON's `group` field (or absent if the source has none).
 	Group *int                  `json:"group,omitempty"`
@@ -1856,13 +1857,13 @@ func ProfileCFGroups(ad *AppData, profileTrashID string) (required []ProfileCFGr
 
 // CategoryCFGroup is a CF group with its category parsed from the name prefix.
 type CategoryCFGroup struct {
-	Name             string                `json:"name"`      // "[Audio] Audio Formats"
-	ShortName        string                `json:"shortName"` // "Audio Formats"
-	Category         string                `json:"category"`  // "Audio"
-	TrashID          string                `json:"trashId"`   // matches CFGroup.TrashID — used by frontend to look up rule.priorAvailableGroups for new-vs-existing classification
-	TrashDescription string                `json:"trashDescription"`
-	DefaultEnabled   bool                  `json:"defaultEnabled"` // group.Default == "true"
-	Exclusive        bool                  `json:"exclusive"`      // only one CF can be active (Golden Rule)
+	Name             string `json:"name"`      // "[Audio] Audio Formats"
+	ShortName        string `json:"shortName"` // "Audio Formats"
+	Category         string `json:"category"`  // "Audio"
+	TrashID          string `json:"trashId"`   // matches CFGroup.TrashID — used by frontend to look up rule.priorAvailableGroups for new-vs-existing classification
+	TrashDescription string `json:"trashDescription"`
+	DefaultEnabled   bool   `json:"defaultEnabled"` // group.Default == "true"
+	Exclusive        bool   `json:"exclusive"`      // only one CF can be active (Golden Rule)
 	// Group drives sort order — see CompareCFGroups. Populated from the source
 	// cf-group JSON's `group` field. Absent (nil) on cf-groups that don't carry
 	// the field (TRaSH groups pre-rollout, user-authored groups left empty).

--- a/main.go
+++ b/main.go
@@ -156,8 +156,8 @@ func main() {
 			repoCloned = true
 		}
 
-		if cfg.PullInterval == "0" && repoCloned {
-			log.Printf("Startup TRaSH pull skipped (interval disabled) — loading existing repo")
+		if (cfg.PullInterval == "0" || cfg.PullInterval == "specific") && repoCloned {
+			log.Printf("Startup TRaSH pull skipped (interval=%s) — loading existing repo", cfg.PullInterval)
 			if err := trashStore.LoadFromDisk(); err != nil {
 				log.Printf("Startup TRaSH load failed: %v", err)
 				return
@@ -175,54 +175,110 @@ func main() {
 		}
 	})
 
-	// Scheduled TRaSH pull
+	// Scheduled TRaSH pull. One goroutine owns either a fixed-interval ticker
+	// or a one-shot wall-clock timer; config changes wake it to rebuild from
+	// the saved config.
 	utils.SafeGo("trash-pull-scheduler", func() {
-		cfg := cfgStore.Get()
-		interval := core.ParsePullInterval(cfg.PullInterval)
 		var ticker *time.Ticker
 		var tickCh <-chan time.Time
+		var timer *time.Timer
+		var timerCh <-chan time.Time
+		var currentInterval time.Duration
 
-		setTicker := func(d time.Duration) {
+		stopSchedule := func() {
 			if ticker != nil {
 				ticker.Stop()
-			}
-			if d > 0 {
-				ticker = time.NewTicker(d)
-				tickCh = ticker.C
-				log.Printf("Scheduled TRaSH pull every %s", d)
-			} else {
 				ticker = nil
-				tickCh = nil
-				log.Printf("Scheduled TRaSH pull disabled")
 			}
+			tickCh = nil
+			if timer != nil {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer = nil
+			}
+			timerCh = nil
+			currentInterval = 0
+			app.SetNextPullAt(time.Time{})
 		}
-		setTicker(interval)
+
+		runScheduledPull := func() {
+			cfg := cfgStore.Get()
+			prevCommit := trashStore.CurrentCommit()
+			log.Printf("Scheduled TRaSH pull starting...")
+			if err := trashStore.CloneOrPull(cfg.TrashRepo.URL, cfg.TrashRepo.Branch); err != nil {
+				log.Printf("Scheduled TRaSH pull failed: %v", err)
+				return
+			}
+
+			newCommit := trashStore.CurrentCommit()
+			if prevCommit != "" && newCommit != prevCommit {
+				log.Printf("TRaSH repo updated: %s → %s", prevCommit, newCommit)
+				app.NotifyRepoUpdate(prevCommit, newCommit)
+			} else {
+				log.Printf("Scheduled TRaSH pull completed (no changes)")
+			}
+			server.AutoSyncQualitySizes()
+			app.AutoSyncAfterPull(core.SourceAutoPullInterval)
+		}
+
+		armFromConfig := func() {
+			stopSchedule()
+
+			cfg := cfgStore.Get()
+			if cfg.PullInterval == "specific" {
+				if cfg.PullSchedule == nil {
+					log.Printf("Scheduled TRaSH pull disabled (specific schedule missing)")
+					return
+				}
+				next := core.NextPullTime(*cfg.PullSchedule)
+				if next.IsZero() {
+					log.Printf("Scheduled TRaSH pull disabled (invalid specific schedule)")
+					return
+				}
+				delay := time.Until(next)
+				if delay <= 0 {
+					delay = time.Millisecond
+				}
+				timer = time.NewTimer(delay)
+				timerCh = timer.C
+				app.SetNextPullAt(next)
+				log.Printf("Scheduled TRaSH pull at %s", next.Format(time.RFC3339))
+				return
+			}
+
+			interval := core.ParsePullInterval(cfg.PullInterval)
+			if interval > 0 {
+				ticker = time.NewTicker(interval)
+				tickCh = ticker.C
+				currentInterval = interval
+				next := time.Now().Add(interval)
+				app.SetNextPullAt(next)
+				log.Printf("Scheduled TRaSH pull every %s (next at %s)", interval, next.Format(time.RFC3339))
+				return
+			}
+
+			log.Printf("Scheduled TRaSH pull disabled")
+		}
+		armFromConfig()
 
 		for {
 			select {
 			case <-tickCh:
-				cfg := cfgStore.Get()
-				prevCommit := trashStore.CurrentCommit()
-				log.Printf("Scheduled TRaSH pull starting...")
-				if err := trashStore.CloneOrPull(cfg.TrashRepo.URL, cfg.TrashRepo.Branch); err != nil {
-					log.Printf("Scheduled TRaSH pull failed: %v", err)
-				} else {
-					newCommit := trashStore.CurrentCommit()
-					if prevCommit != "" && newCommit != prevCommit {
-						log.Printf("TRaSH repo updated: %s → %s", prevCommit, newCommit)
-						app.NotifyRepoUpdate(prevCommit, newCommit)
-					} else {
-						log.Printf("Scheduled TRaSH pull completed (no changes)")
-					}
-					server.AutoSyncQualitySizes()
-					app.AutoSyncAfterPull(core.SourceAutoPullInterval)
+				runScheduledPull()
+				if currentInterval > 0 {
+					app.SetNextPullAt(time.Now().Add(currentInterval))
 				}
-			case newInterval := <-app.PullUpdateCh:
-				setTicker(core.ParsePullInterval(newInterval))
+			case <-timerCh:
+				runScheduledPull()
+				armFromConfig()
+			case <-app.PullUpdateCh:
+				armFromConfig()
 			case <-ctx.Done():
-				if ticker != nil {
-					ticker.Stop()
-				}
+				stopSchedule()
 				return
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -267,10 +267,11 @@ func main() {
 
 		for {
 			select {
-			case <-tickCh:
+			case tickAt := <-tickCh:
 				runScheduledPull()
 				if currentInterval > 0 {
-					app.SetNextPullAt(time.Now().Add(currentInterval))
+					// Ticker values are scheduled times, so this avoids drifting by the pull duration.
+					app.SetNextPullAt(tickAt.Add(currentInterval))
 				}
 			case <-timerCh:
 				runScheduledPull()

--- a/ui/static/js/features/manifest.js
+++ b/ui/static/js/features/manifest.js
@@ -17,6 +17,7 @@ const EMPTY_MANIFEST = {
   authModes: [],
   authRequiredModes: [],
   pullIntervalPresets: [],
+  pullScheduleModes: [],
   sessionTtlBounds: { min: 1, max: 365 },
   cfCategories: [],
   profileGroups: [],

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -3252,13 +3252,10 @@ export default {
     nextPullTime() {
       void this._nowTick;
       const interval = this.config.pullInterval;
-      const lastPull = this.trashStatus?.lastPull;
-      if (!interval || interval === 'off' || !lastPull) return '';
-      const match = interval.match(/^(\d+)(m|h)$/);
-      if (!match) return '';
-      const ms = parseInt(match[1]) * (match[2] === 'h' ? 3600000 : 60000);
-      const next = new Date(lastPull).getTime() + ms;
-      const diff = next - Date.now();
+      if (!interval || interval === '0') return '';
+      const nextPull = this.trashStatus?.nextPull;
+      if (!nextPull) return '';
+      const diff = new Date(nextPull).getTime() - Date.now();
       if (diff <= 0) return 'soon';
       const mins = Math.floor(diff / 60000);
       if (mins < 60) return mins + 'm';

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -3255,13 +3255,36 @@ export default {
       if (!interval || interval === '0') return '';
       const nextPull = this.trashStatus?.nextPull;
       if (!nextPull) return '';
-      const diff = new Date(nextPull).getTime() - Date.now();
+      const nextPullMs = new Date(nextPull).getTime();
+      const serverNowMs = new Date(this.trashStatus?.serverNow || '').getTime();
+      const fetchedAt = this._trashStatusFetchedAt || Date.now();
+      const elapsed = Math.max(0, Date.now() - fetchedAt);
+      const nowMs = Number.isFinite(serverNowMs) ? serverNowMs + elapsed : Date.now();
+      const diff = nextPullMs - nowMs;
       if (diff <= 0) return 'soon';
-      const mins = Math.floor(diff / 60000);
+      const mins = Math.ceil(diff / 60000);
       if (mins < 60) return mins + 'm';
       const hours = Math.floor(mins / 60);
       const remMins = mins % 60;
       return remMins > 0 ? hours + 'h ' + remMins + 'm' : hours + 'h';
+    },
+
+    nextPullClockLabel() {
+      const serverClock = this.formatScheduleClockValue(this.trashStatus?.nextPullClock);
+      if (!serverClock) return '';
+      const serverLabel = this.config.serverTimeZone || '';
+      const serverText = serverLabel ? serverClock + ' ' + serverLabel : serverClock;
+      if (!this.scheduleTimeZoneMismatch()) return serverText;
+      const localClock = this.formatLocalClock(this.trashStatus?.nextPull);
+      return localClock ? serverText + ' / ' + localClock + ' local' : serverText;
+    },
+
+    nextPullLabel() {
+      const remaining = this.nextPullTime();
+      if (!remaining) return '';
+      const clock = this.nextPullClockLabel();
+      const suffix = clock ? ' (' + clock + ')' : '';
+      return remaining === 'soon' ? 'next pull soon' + suffix : 'next pull in ' + remaining + suffix;
     },
 
     formatCommitDate(dateStr) {

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -614,6 +614,7 @@ export function clonarr() {
         const r = await fetch('/api/config');
         if (!r.ok) return;
         this.config = await r.json();
+        this.config.pullSchedule = Object.assign({ mode: 'daily', time: '03:00', dayOfWeek: 0, dayOfMonth: 1 }, this.config.pullSchedule || {});
         // Ensure prowlarr config object exists
         if (!this.config.prowlarr) this.config.prowlarr = { url: '', apiKey: '', enabled: false, radarrCategories: [], sonarrCategories: [] };
         // Back-fill missing arrays for configs saved before category overrides existed.
@@ -631,11 +632,112 @@ export function clonarr() {
       } catch (e) { console.error('loadConfig:', e); }
     },
 
+    // The API stores scheduled pull times as 24-hour HH:MM. These dropdowns
+    // follow the browser's hour cycle; the backend still schedules in container time.
+    pullScheduleTimeParts() {
+      const time = this.config?.pullSchedule?.time || '03:00';
+      const match = time.match(/^(\d{2}):(\d{2})$/);
+      if (!match) return { hour: 3, minute: 0 };
+      const hour = Math.max(0, Math.min(23, parseInt(match[1], 10)));
+      const minute = Math.max(0, Math.min(59, parseInt(match[2], 10)));
+      return { hour, minute };
+    },
+
+    pullScheduleUses12Hour() {
+      if (this._pullScheduleUses12Hour !== undefined) return this._pullScheduleUses12Hour;
+      const opts = new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).resolvedOptions();
+      this._pullScheduleUses12Hour = opts.hourCycle
+        ? opts.hourCycle === 'h11' || opts.hourCycle === 'h12'
+        : new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).formatToParts(new Date(2020, 0, 1, 13, 0)).some(p => p.type === 'dayPeriod');
+      return this._pullScheduleUses12Hour;
+    },
+
+    pullScheduleHourOptions() {
+      if (this.pullScheduleUses12Hour()) {
+        return Array.from({ length: 12 }, (_, i) => {
+          const value = i + 1;
+          return { value, label: String(value) };
+        });
+      }
+      return Array.from({ length: 24 }, (_, i) => ({ value: i, label: String(i).padStart(2, '0') }));
+    },
+
+    pullScheduleMinuteOptions() {
+      if (this._pullScheduleMinuteOptions) return this._pullScheduleMinuteOptions;
+      this._pullScheduleMinuteOptions = Array.from({ length: 60 }, (_, i) => ({ value: i, label: String(i).padStart(2, '0') }));
+      return this._pullScheduleMinuteOptions;
+    },
+
+    pullSchedulePeriodOptions() {
+      if (this._pullSchedulePeriodOptions) return this._pullSchedulePeriodOptions;
+      const labelFor = (hour, fallback) => {
+        const parts = new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).formatToParts(new Date(2020, 0, 1, hour, 0));
+        return parts.find(p => p.type === 'dayPeriod')?.value || fallback;
+      };
+      this._pullSchedulePeriodOptions = [
+        { value: 'AM', label: labelFor(9, 'AM') },
+        { value: 'PM', label: labelFor(21, 'PM') },
+      ];
+      return this._pullSchedulePeriodOptions;
+    },
+
+    pullScheduleHourValue() {
+      const { hour } = this.pullScheduleTimeParts();
+      if (!this.pullScheduleUses12Hour()) return hour;
+      const h = hour % 12;
+      return h === 0 ? 12 : h;
+    },
+
+    pullScheduleMinuteValue() {
+      return this.pullScheduleTimeParts().minute;
+    },
+
+    pullSchedulePeriodValue() {
+      return this.pullScheduleTimeParts().hour < 12 ? 'AM' : 'PM';
+    },
+
+    setPullScheduleTime(hour, minute) {
+      const h = Math.max(0, Math.min(23, Number(hour) || 0));
+      const m = Math.max(0, Math.min(59, Number(minute) || 0));
+      const next = String(h).padStart(2, '0') + ':' + String(m).padStart(2, '0');
+      const changed = this.config.pullSchedule.time !== next;
+      this.config.pullSchedule.time = next;
+      return changed;
+    },
+
+    setPullScheduleHour(value) {
+      const { hour, minute } = this.pullScheduleTimeParts();
+      let nextHour = Number(value);
+      if (this.pullScheduleUses12Hour()) {
+        const period = hour < 12 ? 'AM' : 'PM';
+        if (nextHour === 12) nextHour = 0;
+        if (period === 'PM') nextHour += 12;
+      }
+      return this.setPullScheduleTime(nextHour, minute);
+    },
+
+    setPullScheduleMinute(value) {
+      const { hour } = this.pullScheduleTimeParts();
+      return this.setPullScheduleTime(hour, Number(value));
+    },
+
+    setPullSchedulePeriod(value) {
+      const { hour, minute } = this.pullScheduleTimeParts();
+      const isPM = value === 'PM';
+      let nextHour = hour % 12;
+      if (isPM) nextHour += 12;
+      return this.setPullScheduleTime(nextHour, minute);
+    },
+
     async saveConfig(fields) {
       try {
         const body = {};
         if (!fields || fields.includes('trashRepo')) body.trashRepo = this.config.trashRepo;
-        if (fields && fields.includes('pullInterval')) body.pullInterval = this.config.pullInterval;
+        if (fields && fields.includes('pullInterval')) {
+          body.pullInterval = this.config.pullInterval;
+          if (this.config.pullInterval === 'specific') body.pullSchedule = this.config.pullSchedule;
+        }
+        if (fields && fields.includes('pullSchedule')) body.pullSchedule = this.config.pullSchedule;
         if (fields && fields.includes('devMode')) body.devMode = this.config.devMode;
         if (fields && fields.includes('trashSchemaFields')) body.trashSchemaFields = this.config.trashSchemaFields;
         if (fields && fields.includes('debugLogging')) body.debugLogging = this.config.debugLogging;

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -632,8 +632,8 @@ export function clonarr() {
       } catch (e) { console.error('loadConfig:', e); }
     },
 
-    // The API stores scheduled pull times as 24-hour HH:MM. These dropdowns
-    // follow the browser's hour cycle; the backend still schedules in container time.
+    // The API stores scheduled pull times as container-local HH:MM. The
+    // dropdown labels follow the browser's 12h/24h preference only for display.
     pullScheduleTimeParts() {
       const time = this.config?.pullSchedule?.time || '03:00';
       const match = time.match(/^(\d{2}):(\d{2})$/);
@@ -650,6 +650,33 @@ export function clonarr() {
         ? opts.hourCycle === 'h11' || opts.hourCycle === 'h12'
         : new Intl.DateTimeFormat(undefined, { hour: 'numeric' }).formatToParts(new Date(2020, 0, 1, 13, 0)).some(p => p.type === 'dayPeriod');
       return this._pullScheduleUses12Hour;
+    },
+
+    browserTimeZoneName() {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'local';
+    },
+
+    browserTimeZoneOffset() {
+      return -new Date().getTimezoneOffset() * 60;
+    },
+
+    serverTimeZoneDisplay() {
+      const zone = this.config?.serverTimeZone || 'container local time';
+      if (!this.config?.serverTimeZoneConfigured && zone === 'UTC') return 'UTC (default)';
+      return zone;
+    },
+
+    scheduleTimeZoneMismatch() {
+      return Number.isFinite(this.config?.serverTimeZoneOffset) &&
+        this.config.serverTimeZoneOffset !== this.browserTimeZoneOffset();
+    },
+
+    scheduleTimeZoneHelperText() {
+      const server = this.serverTimeZoneDisplay();
+      if (!this.scheduleTimeZoneMismatch()) return 'Schedules use container time: ' + server + '.';
+      const browser = this.browserTimeZoneName();
+      const setTZ = browser && browser !== 'local' ? ' Set TZ=' + browser + ' to schedule in your browser timezone.' : ' Set TZ to your local timezone to schedule in browser time.';
+      return 'Schedules use container time: ' + server + '. Your browser time is ' + browser + '.' + setTZ;
     },
 
     pullScheduleHourOptions() {
@@ -696,6 +723,25 @@ export function clonarr() {
       return this.pullScheduleTimeParts().hour < 12 ? 'AM' : 'PM';
     },
 
+    formatPullScheduleClock(hour, minute) {
+      return new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit' }).format(new Date(2020, 0, 1, hour, minute));
+    },
+
+    formatScheduleClockValue(value) {
+      const match = String(value || '').match(/^(\d{2}):(\d{2})$/);
+      if (!match) return '';
+      return this.formatPullScheduleClock(parseInt(match[1], 10), parseInt(match[2], 10));
+    },
+
+    formatLocalClock(isoString) {
+      if (!isoString) return '';
+      try {
+        return new Date(isoString).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+      } catch {
+        return '';
+      }
+    },
+
     setPullScheduleTime(hour, minute) {
       const h = Math.max(0, Math.min(23, Number(hour) || 0));
       const m = Math.max(0, Math.min(59, Number(minute) || 0));
@@ -732,6 +778,7 @@ export function clonarr() {
     async saveConfig(fields) {
       try {
         const body = {};
+        const pullScheduleChanged = fields && (fields.includes('pullInterval') || fields.includes('pullSchedule'));
         if (!fields || fields.includes('trashRepo')) body.trashRepo = this.config.trashRepo;
         if (fields && fields.includes('pullInterval')) {
           body.pullInterval = this.config.pullInterval;
@@ -743,11 +790,12 @@ export function clonarr() {
         if (fields && fields.includes('debugLogging')) body.debugLogging = this.config.debugLogging;
         if (fields && fields.includes('prowlarr')) body.prowlarr = this.config.prowlarr;
         // 401 handled centrally by the fetch wrapper.
-        await fetch('/api/config', {
+        const r = await fetch('/api/config', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(body)
         });
+        if (r.ok && pullScheduleChanged) await this.loadTrashStatus();
       } catch (e) { console.error('saveConfig:', e); }
     },
 
@@ -756,6 +804,7 @@ export function clonarr() {
         const r = await fetch('/api/trash/status');
         if (!r.ok) return;
         this.trashStatus = await r.json();
+        this._trashStatusFetchedAt = Date.now();
       } catch (e) { console.error('loadTrashStatus:', e); }
     },
 

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -79,7 +79,7 @@ export default function baseState() {
     cfgbSavingOk: false,                     // whether cfgbSavingMsg is success (green) or error (red)
     cfgbDeleting: false,                     // guard against double-fire on Delete → Confirm (modal's onConfirm could run twice under fast clicks)
     profileTab: 'trash-sync',    // NEW — simple variable replacing per-app profileTabs: 'trash-sync', 'compare'
-    config: { trashRepo: { url: '', branch: '' }, pullInterval: '24h', prowlarr: { url: '', apiKey: '', enabled: false, radarrCategories: [], sonarrCategories: [] }, authentication: 'forms', authenticationRequired: 'disabled_for_local_addresses', trustedNetworks: '', trustedProxies: '', sessionTtlDays: 30 },
+    config: { trashRepo: { url: '', branch: '' }, pullInterval: '24h', pullSchedule: { mode: 'daily', time: '03:00', dayOfWeek: 0, dayOfMonth: 1 }, prowlarr: { url: '', apiKey: '', enabled: false, radarrCategories: [], sonarrCategories: [] }, authentication: 'forms', authenticationRequired: 'disabled_for_local_addresses', trustedNetworks: '', trustedProxies: '', sessionTtlDays: 30 },
     trashStatus: {},
     _nowTick: Date.now(),
     trashProfiles: { radarr: [], sonarr: [] },

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -26,7 +26,7 @@
           <span class="sync-commit" x-show="trashStatus.commitHash" style="color:var(--text-muted);font-size:12px;margin-left:4px" x-text="trashStatus.commitHash"></span>
           <span class="sync-next" x-show="trashStatus.nextPull"
                 style="color:var(--text-muted);font-size:12px;margin-left:6px"
-                x-text="'· next ' + nextPullTime()"></span>
+                x-text="'· ' + nextPullLabel()"></span>
           <span style="color:var(--text-muted);font-size:12px;margin-left:2px;transition:transform 0.2s;display:inline-block"
                 :style="showChangelog ? 'transform:rotate(180deg)' : ''">&#9662;</span>
         </button>

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -24,7 +24,7 @@
                 style="color:inherit" x-tt="'Click for changelog'">
           <span class="sync-label">TRaSH synced</span> <span x-text="formatSyncTime(trashStatus.lastPull)"></span>
           <span class="sync-commit" x-show="trashStatus.commitHash" style="color:var(--text-muted);font-size:12px;margin-left:4px" x-text="trashStatus.commitHash"></span>
-          <span class="sync-next" x-show="config.pullInterval && config.pullInterval !== 'off' && trashStatus.lastPull"
+          <span class="sync-next" x-show="trashStatus.nextPull"
                 style="color:var(--text-muted);font-size:12px;margin-left:6px"
                 x-text="'· next ' + nextPullTime()"></span>
           <span style="color:var(--text-muted);font-size:12px;margin-left:2px;transition:transform 0.2s;display:inline-block"

--- a/ui/static/partials/sections/settings.html
+++ b/ui/static/partials/sections/settings.html
@@ -75,13 +75,73 @@
           </div>
           <div class="setting-row">
             <div class="setting-label">Pull Interval</div>
-            <div class="setting-value" style="display:flex;align-items:center;gap:10px">
+            <div class="setting-value" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
               <select class="input" style="width:180px" x-model="config.pullInterval" @change="saveConfig(['pullInterval'])">
                 <template x-for="opt in (manifest.pullIntervalPresets || [])" :key="opt.value">
                   <option :value="opt.value" x-text="opt.label"></option>
                 </template>
               </select>
-              <span style="font-size:12px;color:var(--text-muted)">Auto-pull TRaSH data at this interval</span>
+              <select class="input" style="width:130px"
+                      x-show="config.pullInterval === 'specific'"
+                      x-model="config.pullSchedule.mode"
+                      @change="saveConfig(['pullInterval'])">
+                <template x-for="opt in (manifest.pullScheduleModes || [])" :key="opt.value">
+                  <option :value="opt.value" x-text="opt.label"></option>
+                </template>
+              </select>
+              <select class="input" style="width:140px"
+                      x-show="config.pullInterval === 'specific' && config.pullSchedule.mode === 'weekly'"
+                      x-model.number="config.pullSchedule.dayOfWeek"
+                      @change="saveConfig(['pullInterval'])"
+                      aria-label="Scheduled pull day of week">
+                <template x-for="d in [{v:0,l:'Sunday'},{v:1,l:'Monday'},{v:2,l:'Tuesday'},{v:3,l:'Wednesday'},{v:4,l:'Thursday'},{v:5,l:'Friday'},{v:6,l:'Saturday'}]" :key="d.v">
+                  <option :value="d.v" x-text="d.l"></option>
+                </template>
+              </select>
+              <select class="input" style="width:100px"
+                      x-show="config.pullInterval === 'specific' && config.pullSchedule.mode === 'monthly'"
+                      x-model.number="config.pullSchedule.dayOfMonth"
+                      @change="saveConfig(['pullInterval'])"
+                      aria-label="Scheduled pull day of month">
+                <template x-for="d in Array.from({length:28},(_,i)=>i+1)" :key="d">
+                  <option :value="d" x-text="d"></option>
+                </template>
+              </select>
+              <span style="font-size:13px;color:var(--text-muted)"
+                    x-show="config.pullInterval === 'specific'">at</span>
+              <select class="input" style="width:72px"
+                      x-show="config.pullInterval === 'specific'"
+                      :value="pullScheduleHourValue()"
+                      @change="setPullScheduleHour($event.target.value); saveConfig(['pullInterval'])"
+                      aria-label="Scheduled pull hour">
+                <template x-for="h in pullScheduleHourOptions()" :key="h.value">
+                  <option :value="h.value" x-text="h.label"></option>
+                </template>
+              </select>
+              <span style="font-size:13px;color:var(--text-muted)"
+                    x-show="config.pullInterval === 'specific'">:</span>
+              <select class="input" style="width:70px"
+                      x-show="config.pullInterval === 'specific'"
+                      :value="pullScheduleMinuteValue()"
+                      @change="setPullScheduleMinute($event.target.value); saveConfig(['pullInterval'])"
+                      aria-label="Scheduled pull minute">
+                <template x-for="m in pullScheduleMinuteOptions()" :key="m.value">
+                  <option :value="m.value" x-text="m.label"></option>
+                </template>
+              </select>
+              <select class="input" style="width:76px"
+                      x-show="config.pullInterval === 'specific' && pullScheduleUses12Hour()"
+                      :value="pullSchedulePeriodValue()"
+                      @change="setPullSchedulePeriod($event.target.value); saveConfig(['pullInterval'])"
+                      aria-label="Scheduled pull period">
+                <template x-for="p in pullSchedulePeriodOptions()" :key="p.value">
+                  <option :value="p.value" x-text="p.label"></option>
+                </template>
+              </select>
+              <span x-show="config.pullInterval !== 'specific'"
+                    style="font-size:12px;color:var(--text-muted)">Auto-pull TRaSH data at this interval</span>
+              <span x-show="config.pullInterval === 'specific'"
+                    style="flex-basis:100%;font-size:12px;color:var(--text-secondary);font-style:italic">Next refresh starts on the next occurrence of this time</span>
             </div>
           </div>
           <div class="setting-row">

--- a/ui/static/partials/sections/settings.html
+++ b/ui/static/partials/sections/settings.html
@@ -84,7 +84,8 @@
               <select class="input" style="width:130px"
                       x-show="config.pullInterval === 'specific'"
                       x-model="config.pullSchedule.mode"
-                      @change="saveConfig(['pullInterval'])">
+                      @change="saveConfig(['pullInterval'])"
+                      aria-label="Scheduled pull mode">
                 <template x-for="opt in (manifest.pullScheduleModes || [])" :key="opt.value">
                   <option :value="opt.value" x-text="opt.label"></option>
                 </template>
@@ -141,7 +142,8 @@
               <span x-show="config.pullInterval !== 'specific'"
                     style="font-size:12px;color:var(--text-muted)">Auto-pull TRaSH data at this interval</span>
               <span x-show="config.pullInterval === 'specific'"
-                    style="flex-basis:100%;font-size:12px;color:var(--text-secondary);font-style:italic">Next refresh starts on the next occurrence of this time</span>
+                    style="flex-basis:100%;font-size:12px;color:var(--text-secondary);font-style:italic"
+                    x-text="scheduleTimeZoneHelperText()"></span>
             </div>
           </div>
           <div class="setting-row">


### PR DESCRIPTION
## Description

Adds a new **Scheduled** pull interval option for TRaSH updates. Users can now run automatic pulls at a fixed wall-clock time instead of only using fixed-duration intervals.

### Changes

- Add `PullSchedule` config support for daily, weekly, and monthly schedules
- Add `Scheduled` to the pull interval presets
- Expose schedule modes through the UI manifest
- Update the scheduler to support both interval tickers and wall-clock timers
- Expose backend-authoritative `nextPull`, `serverNow`, and `nextPullClock` in `/api/trash/status`
- Expose server timezone metadata in `/api/config`
- Add inline schedule controls to the Settings pull interval row
- Update the top-nav countdown to use server-relative timing
- Show container/browser timezone guidance when their timezones differ
- Add validation for scheduled pull settings
- Add unit/API coverage for schedule math, validation, Sunday persistence, manifest exposure, timezone metadata, and status timing fields

### Notes

- Monthly schedules use day-of-month `1-28`
- Schedule times use the container’s local timezone via `TZ`, defaulting to UTC
- The UI uses the browser’s hour-cycle preference for 12h/24h display, while saving `HH:MM`
- When the browser timezone differs from the container timezone, the UI shows both the container scheduled time and the local equivalent