### PR TITLE
Improve in-app toast UX

### DIFF
--- a/internal/core/autosync.go
+++ b/internal/core/autosync.go
@@ -539,15 +539,13 @@ func (app *App) runAutoSyncRule(rule AutoSyncRule, currentCommit string, parent 
 
 	// Push event to frontend toast queue (only when there are actual changes)
 	if result.CFsCreated > 0 || result.CFsUpdated > 0 || result.ScoresUpdated > 0 || result.QualityUpdated || len(result.SettingsDetails) > 0 {
-		// Collect details for toast (max 5 lines)
+		// Collect details for the frontend toast. The UI owns compacting and
+		// expansion, so keep the event payload complete.
 		var details []string
 		details = append(details, result.CFDetails...)
 		details = append(details, result.ScoreDetails...)
 		details = append(details, result.QualityDetails...)
 		details = append(details, result.SettingsDetails...)
-		if len(details) > 5 {
-			details = append(details[:4], fmt.Sprintf("...and %d more", len(details)-4))
-		}
 		app.AutoSyncMu.Lock()
 		app.AutoSyncEvents = append(app.AutoSyncEvents, AutoSyncEvent{
 			InstanceName:   inst.Name,

--- a/ui/static/css/components.css
+++ b/ui/static/css/components.css
@@ -137,6 +137,213 @@
   @keyframes fadeIn { from { opacity: 0; transform: translateY(-8px); } to { opacity: 1; transform: translateY(0); } }
   @keyframes toastProgress { from { width: 100%; } to { width: 0%; } }
 
+  /* Toast notifications */
+  .toast-stack {
+    position: fixed;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10000;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 7px;
+    width: min(460px, calc(100vw - 32px));
+    max-height: 80vh;
+    overflow-y: auto;
+    padding: 2px;
+    pointer-events: none;
+  }
+
+  .toast {
+    --toast-accent: var(--accent-blue);
+    --toast-border: var(--border-subtle);
+    --toast-bg: var(--bg-elevated);
+    position: relative;
+    overflow: hidden;
+    border-radius: 8px;
+    border: 1px solid var(--toast-border);
+    border-left: 3px solid var(--toast-accent);
+    background: var(--toast-bg);
+    color: var(--text-body);
+    box-shadow: 0 6px 18px var(--alpha-shadow);
+    animation: fadeIn 0.2s ease;
+    pointer-events: auto;
+    width: 100%;
+    min-height: 0;
+  }
+
+  .toast-compact {
+    width: fit-content;
+    min-width: min(300px, 100%);
+    max-width: min(420px, 100%);
+    min-height: 34px;
+    border-radius: 7px;
+  }
+
+  .toast-info,
+  .toast-success {
+    --toast-accent: var(--accent-green-strong);
+    --toast-border: var(--accent-green-strong);
+    --toast-bg: var(--accent-green-bg);
+  }
+
+  .toast-warning {
+    --toast-accent: var(--accent-orange);
+    --toast-border: var(--accent-orange);
+    --toast-bg: var(--accent-orange-bg);
+  }
+
+  .toast-error {
+    --toast-accent: var(--accent-red);
+    --toast-border: var(--accent-red);
+    --toast-bg: var(--accent-red-bg);
+  }
+
+  .toast-close {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    z-index: 1;
+    width: 22px;
+    height: 22px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--toast-accent);
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.78;
+  }
+
+  .toast-close:hover,
+  .toast-close:focus-visible {
+    background: var(--alpha-hover);
+    opacity: 1;
+    outline: none;
+  }
+
+  .toast-compact .toast-close {
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .toast-content {
+    padding: 9px 34px 10px 14px;
+    font-size: 12px;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+    white-space: pre-line;
+  }
+
+  .toast-compact .toast-content {
+    display: flex;
+    align-items: center;
+    min-height: 0;
+    padding: 8px 34px 9px 14px;
+    line-height: 1.3;
+  }
+
+  .toast-content-expandable {
+    cursor: pointer;
+  }
+
+  .toast-content-expandable:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: -3px;
+  }
+
+  .toast-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 2px;
+    padding-right: 2px;
+  }
+
+  .toast-title {
+    min-width: 0;
+    color: var(--text-primary);
+    font-size: 12px;
+    font-weight: 700;
+    overflow-wrap: anywhere;
+  }
+
+  .toast-repeat {
+    flex: 0 0 auto;
+    border: 1px solid currentColor;
+    border-radius: 999px;
+    padding: 0 6px;
+    font-size: 10px;
+    font-weight: 700;
+    opacity: 0.78;
+    color: var(--toast-accent);
+  }
+
+  .toast-message {
+    max-height: 7.2em;
+    overflow: hidden;
+    color: var(--text-body);
+  }
+
+  .toast-compact .toast-message {
+    max-height: none;
+    line-height: 1.25;
+  }
+
+  .toast-message-expanded {
+    max-height: min(60vh, 520px);
+    overflow-y: auto;
+    padding-right: 4px;
+  }
+
+  .toast-more {
+    margin-top: 4px;
+    font-size: 11px;
+    font-weight: 700;
+    opacity: 0.78;
+    color: var(--toast-accent);
+  }
+
+  .toast-progress {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 3px;
+    border-radius: 0 0 8px 8px;
+    background: var(--toast-accent);
+    opacity: 0.8;
+    animation-name: toastProgress;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
+  }
+
+  .toast-queue-footer {
+    align-self: center;
+    border: 1px solid var(--border-subtle);
+    border-radius: 999px;
+    background: var(--bg-elevated);
+    color: var(--text-muted);
+    box-shadow: 0 4px 12px var(--alpha-shadow);
+    padding: 4px 10px;
+    font-size: 11px;
+    line-height: 1.2;
+    pointer-events: auto;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toast {
+      animation: none;
+    }
+
+    .toast-progress {
+      animation: none;
+      display: none;
+    }
+  }
+
   /* Empty state */
   .empty-state { text-align: center; padding: 48px 20px; color: var(--text-muted); }
   .empty-state .icon { font-size: 32px; margin-bottom: 12px; }

--- a/ui/static/js/features/profile-builder.js
+++ b/ui/static/js/features/profile-builder.js
@@ -1135,7 +1135,14 @@ export default {
         this.pbScoreSetChanged();
         // Notify about unmapped CFs
         if (data.unmapped && data.unmapped.length > 0) {
-          this.showToast(`Profile loaded. ${data.unmapped.length} CF(s) could not be mapped to TRaSH IDs:\n\n${data.unmapped.join('\n')}`, 'error', 8000);
+          this.showToast({
+            title: 'Profile loaded with unmapped CFs',
+            message: `${data.unmapped.length} CF${data.unmapped.length === 1 ? '' : 's'} could not be mapped to TRaSH IDs.`,
+            details: data.unmapped,
+            type: 'error',
+            duration: 8000,
+            key: `profile-builder-unmapped:${data.unmapped.join('|')}`,
+          });
         }
       } catch (e) {
         this.showToast('Error loading profile: ' + e.message, 'error', 8000);

--- a/ui/static/js/features/profile-builder.js
+++ b/ui/static/js/features/profile-builder.js
@@ -1141,7 +1141,7 @@ export default {
             details: data.unmapped,
             type: 'error',
             duration: 8000,
-            key: `profile-builder-unmapped:${data.unmapped.join('|')}`,
+            key: this.toastKey('profile-builder-unmapped', data.unmapped.length, data.unmapped),
           });
         }
       } catch (e) {

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -271,12 +271,6 @@ export default {
       document.documentElement.setAttribute('data-theme', resolved);
     },
 
-    showToast(message, type = 'info', duration = 8000) {
-      const id = Date.now() + Math.random();
-      this.toasts = [...this.toasts, { id, message, type, duration }];
-      setTimeout(() => { this.toasts = this.toasts.filter(t => t.id !== id); }, duration);
-    },
-
     async checkCleanupEvents() {
       try {
         const r = await fetch('/api/cleanup-events');
@@ -284,20 +278,30 @@ export default {
         const events = await r.json();
         if (events.length === 0) return;
         // Coalesce per instance: bulk deletions in Arr would otherwise spawn
-        // one toast per affected profile, stacking 25+ deep with their own
-        // scrollbar. One toast per instance with first-three names + count
-        // is informative without being a wall of yellow.
+        // one toast per affected profile. The toast manager keeps the compact
+        // preview small and lets the full profile list expand inline.
         const byInstance = {};
         for (const ev of events) {
           (byInstance[ev.instanceName] = byInstance[ev.instanceName] || []).push(ev.profileName);
         }
         for (const [instanceName, names] of Object.entries(byInstance)) {
           if (names.length === 1) {
-            this.showToast(`"${names[0]}" — deleted in ${instanceName}, sync rule removed`, 'warning', 6000);
+            this.showToast({
+              title: `"${names[0]}" deleted`,
+              message: `Sync rule removed from ${instanceName}.`,
+              type: 'warning',
+              duration: 6000,
+              key: `cleanup:${instanceName}:${names[0]}`,
+            });
           } else {
-            const preview = names.slice(0, 3).map(n => `"${n}"`).join(', ');
-            const extra = names.length > 3 ? ` and ${names.length - 3} more` : '';
-            this.showToast(`${names.length} profiles deleted in ${instanceName}, sync rules removed:\n${preview}${extra}`, 'warning', 8000);
+            this.showToast({
+              title: `${names.length} profiles deleted in ${instanceName}`,
+              message: 'Sync rules removed.',
+              details: names.map(n => `"${n}"`),
+              type: 'warning',
+              duration: 8000,
+              key: `cleanup:${instanceName}:${names.join('|')}`,
+            });
           }
         }
       } catch (e) { /* ignore */ }
@@ -308,21 +312,59 @@ export default {
         const r = await fetch('/api/auto-sync/events');
         if (!r.ok) return;
         const events = await r.json();
-        for (let i = 0; i < events.length; i++) {
-          const ev = events[i];
-          setTimeout(() => {
-            if (ev.error) {
-              this.showToast(`Auto-sync failed: ${ev.instanceName} — ${ev.profileName}: ${ev.error}`, 'error', 8000);
+        const profileLabel = (ev) => ev.arrProfileName && ev.arrProfileName !== ev.profileName
+          ? `${ev.profileName} -> ${ev.arrProfileName}` : ev.profileName;
+        const groups = {};
+        for (const ev of events) {
+          const severity = ev.error ? 'error' : 'info';
+          const key = `${severity}:${ev.instanceName}`;
+          (groups[key] = groups[key] || { severity, instanceName: ev.instanceName, events: [] }).events.push(ev);
+        }
+        for (const group of Object.values(groups)) {
+          if (group.severity === 'error') {
+            if (group.events.length === 1) {
+              const ev = group.events[0];
+              this.showToast({
+                title: `Auto-sync failed: ${group.instanceName}`,
+                message: `${profileLabel(ev)}: ${ev.error}`,
+                type: 'error',
+                duration: 8000,
+                key: `autosync:error:${group.instanceName}:${ev.profileName}:${ev.timestamp || ev.error}`,
+              });
             } else {
-              const profileLabel = ev.arrProfileName && ev.arrProfileName !== ev.profileName
-                ? `${ev.profileName} → ${ev.arrProfileName}` : ev.profileName;
-              let msg = `Auto-sync: ${ev.instanceName} — "${profileLabel}"`;
-              if (ev.details?.length > 0) {
-                msg += '\n' + ev.details.join('\n');
-              }
-              this.showToast(msg, 'info', 8000);
+              this.showToast({
+                title: `Auto-sync failed: ${group.instanceName}`,
+                message: `${group.events.length} profiles failed.`,
+                details: group.events.map(ev => `${profileLabel(ev)}: ${ev.error}`),
+                type: 'error',
+                duration: 10000,
+                key: `autosync:error:${group.instanceName}:${group.events.map(ev => ev.timestamp || ev.profileName).join('|')}`,
+              });
             }
-          }, i * 3000);
+          } else if (group.events.length === 1) {
+            const ev = group.events[0];
+            this.showToast({
+              title: `Auto-sync: ${group.instanceName}`,
+              message: `"${profileLabel(ev)}"`,
+              details: ev.details || [],
+              type: 'info',
+              duration: 8000,
+              key: `autosync:info:${group.instanceName}:${ev.profileName}:${ev.timestamp || ''}`,
+            });
+          } else {
+            const details = group.events.flatMap(ev => [
+              `"${profileLabel(ev)}"`,
+              ...((ev.details || []).map(detail => `  ${detail}`)),
+            ]);
+            this.showToast({
+              title: `Auto-sync: ${group.instanceName}`,
+              message: `${group.events.length} profiles updated.`,
+              details,
+              type: 'info',
+              duration: 10000,
+              key: `autosync:info:${group.instanceName}:${group.events.map(ev => ev.timestamp || ev.profileName).join('|')}`,
+            });
+          }
         }
         // Reload sync history if any events came through
         if (events.length > 0) {
@@ -1546,14 +1588,14 @@ export default {
               ...(result.qualityDetails || []),
               ...(result.settingsDetails || [])
             ];
-            let msg = `"${this.syncForm.profileName}" synced`;
-            if (details.length > 0) {
-              const shown = details.length > 5 ? [...details.slice(0, 4), `...and ${details.length - 4} more`] : details;
-              msg += '\n' + shown.join('\n');
-            } else {
-              msg += ' — no changes';
-            }
-            this.showToast(msg, 'info', details.length > 0 ? 8000 : 4000);
+            this.showToast({
+              title: `"${this.syncForm.profileName}" synced`,
+              message: details.length > 0 ? `${details.length} change${details.length === 1 ? '' : 's'} applied.` : 'No changes.',
+              details,
+              type: 'info',
+              duration: details.length > 0 ? 8000 : 4000,
+              key: `sync-imported:${this.syncForm.instanceId}:${this.syncForm.profileName}:${details.join('|') || 'none'}`,
+            });
           }
         }
         this.syncResult = result;
@@ -1695,14 +1737,16 @@ export default {
           ...(result.qualityDetails || []),
           ...(result.settingsDetails || [])
         ];
-        let msg = `${inst.name} — "${sh.profileName}" synced`;
-        if (details.length > 0) {
-          const shown = details.length > 5 ? [...details.slice(0, 4), `...and ${details.length - 4} more`] : details;
-          msg += '\n' + shown.join('\n');
-        } else {
-          msg += ' — no changes';
+        if (!silent) {
+          this.showToast({
+            title: `${inst.name} - "${sh.profileName}" synced`,
+            message: details.length > 0 ? `${details.length} change${details.length === 1 ? '' : 's'} applied.` : 'No changes.',
+            details,
+            type: 'info',
+            duration: details.length > 0 ? 8000 : 4000,
+            key: `sync:${inst.id}:${sh.arrProfileId}:${details.join('|') || 'none'}`,
+          });
         }
-        if (!silent) this.showToast(msg, 'info', details.length > 0 ? 8000 : 4000);
         this.setRuleSyncError(inst.id, sh.arrProfileId, '');
         await this.loadSyncHistory(inst.id);
         const summary = details.length > 0 ? details.slice(0, 3).join(', ') : 'no changes';
@@ -1844,14 +1888,23 @@ export default {
       for (const rule of rules) {
         results.push(await this.quickSync(inst, ruleToHistoryShape(rule), true));
       }
-      const lines = results.map(r => {
-        if (!r.ok) return `${r.name} — FAILED: ${r.error}`;
-        if (r.details?.length > 0) return `${r.name} — ${r.details.slice(0, 2).join(', ')}`;
-        return `${r.name} — no changes`;
+      const details = results.flatMap(r => {
+        if (!r.ok) return [`${r.name} - FAILED: ${r.error}`];
+        if (r.details?.length > 0) return [r.name, ...r.details.map(detail => `  ${detail}`)];
+        return [`${r.name} - no changes`];
       });
       const errors = results.filter(r => !r.ok).length;
       const toastType = errors === results.length ? 'error' : errors > 0 ? 'warning' : 'info';
-      this.showToast(`Sync All (${inst.name}):\n${lines.join('\n')}`, toastType, 10000);
+      this.showToast({
+        title: `Sync All (${inst.name})`,
+        message: errors > 0
+          ? `${results.length - errors} succeeded, ${errors} failed.`
+          : `${results.length} profile${results.length === 1 ? '' : 's'} synced.`,
+        details,
+        type: toastType,
+        duration: 10000,
+        key: `sync-all:${inst.id}:${results.map(r => `${r.name}:${r.ok}:${r.error || r.summary || ''}`).join('|')}`,
+      });
     },
 
     // --- Sync History ---
@@ -2248,8 +2301,14 @@ export default {
         if (rule && rule.enabled) {
           await this.toggleAutoSyncRule(rule);
         }
-        const details = result.details?.length ? '\n' + result.details.slice(0, 5).join('\n') : '';
-        this.showToast(`Rolled back "${entry.arrProfileName}" to ${prevDate}. Auto-sync disabled.${details}`, 'info', 8000);
+        this.showToast({
+          title: `Rolled back "${entry.arrProfileName}"`,
+          message: `Restored ${prevDate}. Auto-sync disabled.`,
+          details: result.details || [],
+          type: 'info',
+          duration: 8000,
+          key: `rollback:${inst.id}:${entry.arrProfileId}:${prevDate}`,
+        });
         await this.loadProfileHistory(inst.id, entry.arrProfileId);
         await this.loadSyncHistory(inst.id);
       } else {

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -291,7 +291,7 @@ export default {
               message: `Sync rule removed from ${instanceName}.`,
               type: 'warning',
               duration: 6000,
-              key: `cleanup:${instanceName}:${names[0]}`,
+              key: this.toastKey('cleanup', instanceName, names[0]),
             });
           } else {
             this.showToast({
@@ -300,7 +300,9 @@ export default {
               details: names.map(n => `"${n}"`),
               type: 'warning',
               duration: 8000,
-              key: `cleanup:${instanceName}:${names.join('|')}`,
+              key: this.toastKey(
+                'cleanup', instanceName, names.length, names[0], names[names.length - 1], names
+              ),
             });
           }
         }
@@ -329,16 +331,26 @@ export default {
                 message: `${profileLabel(ev)}: ${ev.error}`,
                 type: 'error',
                 duration: 8000,
-                key: `autosync:error:${group.instanceName}:${ev.profileName}:${ev.timestamp || ev.error}`,
+                key: this.toastKey(
+                  'autosync', 'error', group.instanceName, ev.profileName, ev.timestamp || ev.error
+                ),
               });
             } else {
+              const latestTimestamp = group.events.reduce((latest, ev) => ev.timestamp && ev.timestamp > latest ? ev.timestamp : latest, '');
               this.showToast({
                 title: `Auto-sync failed: ${group.instanceName}`,
                 message: `${group.events.length} profiles failed.`,
                 details: group.events.map(ev => `${profileLabel(ev)}: ${ev.error}`),
                 type: 'error',
                 duration: 10000,
-                key: `autosync:error:${group.instanceName}:${group.events.map(ev => ev.timestamp || ev.profileName).join('|')}`,
+                key: this.toastKey(
+                  'autosync',
+                  'error',
+                  group.instanceName,
+                  group.events.length,
+                  latestTimestamp,
+                  group.events.map(ev => [ev.profileName, ev.error])
+                ),
               });
             }
           } else if (group.events.length === 1) {
@@ -349,9 +361,12 @@ export default {
               details: ev.details || [],
               type: 'info',
               duration: 8000,
-              key: `autosync:info:${group.instanceName}:${ev.profileName}:${ev.timestamp || ''}`,
+              key: this.toastKey(
+                'autosync', 'info', group.instanceName, ev.profileName, ev.timestamp || ''
+              ),
             });
           } else {
+            const latestTimestamp = group.events.reduce((latest, ev) => ev.timestamp && ev.timestamp > latest ? ev.timestamp : latest, '');
             const details = group.events.flatMap(ev => [
               `"${profileLabel(ev)}"`,
               ...((ev.details || []).map(detail => `  ${detail}`)),
@@ -362,7 +377,14 @@ export default {
               details,
               type: 'info',
               duration: 10000,
-              key: `autosync:info:${group.instanceName}:${group.events.map(ev => ev.timestamp || ev.profileName).join('|')}`,
+              key: this.toastKey(
+                'autosync',
+                'info',
+                group.instanceName,
+                group.events.length,
+                latestTimestamp,
+                group.events.map(ev => ev.profileName)
+              ),
             });
           }
         }
@@ -1594,7 +1616,9 @@ export default {
               details,
               type: 'info',
               duration: details.length > 0 ? 8000 : 4000,
-              key: `sync-imported:${this.syncForm.instanceId}:${this.syncForm.profileName}:${details.join('|') || 'none'}`,
+              key: this.toastKey(
+                'sync-imported', this.syncForm.instanceId, this.syncForm.profileName, details.length, details
+              ),
             });
           }
         }
@@ -1744,7 +1768,7 @@ export default {
             details,
             type: 'info',
             duration: details.length > 0 ? 8000 : 4000,
-            key: `sync:${inst.id}:${sh.arrProfileId}:${details.join('|') || 'none'}`,
+            key: this.toastKey('sync', inst.id, sh.arrProfileId, details.length, details),
           });
         }
         this.setRuleSyncError(inst.id, sh.arrProfileId, '');
@@ -1903,7 +1927,13 @@ export default {
         details,
         type: toastType,
         duration: 10000,
-        key: `sync-all:${inst.id}:${results.map(r => `${r.name}:${r.ok}:${r.error || r.summary || ''}`).join('|')}`,
+        key: this.toastKey(
+          'sync-all',
+          inst.id,
+          results.length,
+          errors,
+          results.map(r => [r.name, r.ok, r.error || r.summary || ''])
+        ),
       });
     },
 
@@ -2307,7 +2337,9 @@ export default {
           details: result.details || [],
           type: 'info',
           duration: 8000,
-          key: `rollback:${inst.id}:${entry.arrProfileId}:${prevDate}`,
+          key: this.toastKey(
+            'rollback', inst.id, entry.arrProfileId, prevEntry.appliedAt || prevEntry.lastSync || entry.arrProfileId
+          ),
         });
         await this.loadProfileHistory(inst.id, entry.arrProfileId);
         await this.loadSyncHistory(inst.id);

--- a/ui/static/js/features/toasts.js
+++ b/ui/static/js/features/toasts.js
@@ -1,0 +1,276 @@
+const TOAST_MAX_VISIBLE = 3;
+const TOAST_MAX_QUEUED = 20;
+const TOAST_DEDUPE_WINDOW_MS = 15000;
+const TOAST_PREVIEW_MAX_LINES = 4;
+const TOAST_PREVIEW_MAX_CHARS = 240;
+const DEFAULT_TOAST_DURATION = 9000;
+const MIN_TOAST_DURATION = 5000;
+
+function normalizeType(type) {
+  return ['info', 'success', 'warning', 'error'].includes(type) ? type : 'info';
+}
+
+function normalizeDetails(details) {
+  if (!details) return [];
+  const values = Array.isArray(details) ? details : [details];
+  return values
+    .flatMap((value) => String(value ?? '').split(/\r?\n/))
+    .map((line) => line.trimEnd())
+    .filter((line) => line.trim());
+}
+
+function compactText(parts) {
+  return parts
+    .map((part) => String(part ?? '').replace(/\r\n/g, '\n').trimEnd())
+    .filter((part) => part.trim())
+    .join('\n');
+}
+
+function previewText(text) {
+  const full = String(text ?? '').replace(/\r\n/g, '\n').trim();
+  if (!full) return { text: '', truncated: false };
+
+  const lines = full.split('\n');
+  let preview = lines.slice(0, TOAST_PREVIEW_MAX_LINES).join('\n');
+  let truncated = lines.length > TOAST_PREVIEW_MAX_LINES;
+
+  if (preview.length > TOAST_PREVIEW_MAX_CHARS) {
+    preview = preview.slice(0, TOAST_PREVIEW_MAX_CHARS);
+    truncated = true;
+  }
+
+  preview = preview.replace(/\s+$/g, '');
+  if (truncated && !preview.endsWith('...')) preview += '...';
+  return { text: preview, truncated };
+}
+
+export default {
+  state: {
+    toasts: [],
+    toastQueue: [],
+    toastOverflowCount: 0,
+    _toastSequence: 0,
+  },
+
+  methods: {
+    showToast(input, type = 'info', duration = DEFAULT_TOAST_DURATION, options = {}) {
+      const toast = this._normalizeToast(input, type, duration, options);
+      const duplicate = this._findDuplicateToast(toast.key, Date.now());
+      if (duplicate) {
+        this._mergeDuplicateToast(duplicate, toast);
+        return duplicate.id;
+      }
+
+      if (this.toasts.length < TOAST_MAX_VISIBLE) {
+        this.toasts = [...this.toasts, toast];
+        this._startToastTimer(toast, true);
+      } else if (this.toastQueue.length < TOAST_MAX_QUEUED) {
+        this.toastQueue = [...this.toastQueue, toast];
+      } else {
+        this.toastOverflowCount += 1;
+      }
+
+      return toast.id;
+    },
+
+    dismissToast(id) {
+      const active = this.toasts.find((toast) => toast.id === id);
+      if (active) this._clearToastTimer(active);
+
+      const beforeVisible = this.toasts.length;
+      this.toasts = this.toasts.filter((toast) => toast.id !== id);
+      this.toastQueue = this.toastQueue.filter((toast) => toast.id !== id);
+
+      if (beforeVisible !== this.toasts.length) {
+        this._promoteQueuedToasts();
+      }
+    },
+
+    pauseToast(id) {
+      const toast = this.toasts.find((item) => item.id === id);
+      if (!toast || toast.paused || !toast.duration) return;
+      if (toast.timerId) {
+        const elapsed = Date.now() - toast.startedAt;
+        toast.remainingMs = Math.max(0, toast.remainingMs - elapsed);
+        this._clearToastTimer(toast);
+      }
+      toast.paused = true;
+      this._syncToastCollections();
+    },
+
+    resumeToast(id) {
+      const toast = this.toasts.find((item) => item.id === id);
+      if (!toast || toast.expanded || !toast.paused || !toast.duration) return;
+      toast.paused = false;
+      if (toast.remainingMs <= 0) {
+        this.dismissToast(id);
+        return;
+      }
+      this._startToastTimer(toast, false);
+    },
+
+    toggleToast(id) {
+      const toast = this.toasts.find((item) => item.id === id);
+      if (!toast || !toast.expandable) return;
+
+      toast.expanded = !toast.expanded;
+      if (toast.expanded) {
+        this.pauseToast(id);
+      } else {
+        this.resumeToast(id);
+      }
+      this._syncToastCollections();
+    },
+
+    toastDisplayText(toast) {
+      if (!toast) return '';
+      return toast.expanded ? toast.fullText : toast.previewText;
+    },
+
+    toastClass(toast) {
+      const type = normalizeType(toast?.type);
+      const compactText = `${toast?.title || ''} ${toast?.fullText || ''}`.trim();
+      const compact = !toast?.expandable && compactText.length <= 110;
+      return [
+        'toast',
+        `toast-${type}`,
+        compact ? 'toast-compact' : '',
+        toast?.expanded ? 'toast-expanded' : '',
+      ].filter(Boolean).join(' ');
+    },
+
+    toastRole(toast) {
+      return toast?.type === 'error' || toast?.type === 'warning' ? 'alert' : 'status';
+    },
+
+    toastProgressStyle(toast) {
+      if (!toast?.duration) return 'display:none';
+      const remaining = Math.max(0, toast.remainingMs || toast.duration);
+      const state = toast.paused || toast.expanded ? 'paused' : 'running';
+      return `animation-duration:${remaining}ms;animation-play-state:${state}`;
+    },
+
+    toastPendingCount() {
+      return this.toastQueue.length + this.toastOverflowCount;
+    },
+
+    toastPendingLabel() {
+      const queued = this.toastQueue.length;
+      const collapsed = this.toastOverflowCount;
+      const queuedLabel = queued === 1 ? '1 queued' : `${queued} queued`;
+      const collapsedLabel = collapsed === 1 ? '1 collapsed' : `${collapsed} collapsed`;
+      if (queued && collapsed) return `${queuedLabel}, ${collapsedLabel}`;
+      if (queued) return queuedLabel;
+      if (collapsed) return collapsedLabel;
+      return '';
+    },
+
+    _normalizeToast(input, type, duration, options = {}) {
+      const structured = input && typeof input === 'object' && !Array.isArray(input);
+      const raw = structured ? input : {};
+      const toastType = normalizeType(raw.type || type);
+      const title = String(raw.title ?? options.title ?? '').trim();
+      const details = normalizeDetails(raw.details ?? options.details);
+      const message = String(structured ? (raw.message ?? raw.text ?? '') : (input ?? '')).trim();
+      const fullText = compactText([message, ...details]);
+      const preview = previewText(fullText || title);
+      const parsedDuration = Number(raw.duration ?? duration ?? DEFAULT_TOAST_DURATION);
+      const rawDuration = Number.isFinite(parsedDuration) ? parsedDuration : DEFAULT_TOAST_DURATION;
+      const toastDuration = rawDuration > 0 ? Math.max(MIN_TOAST_DURATION, rawDuration) : 0;
+      const now = Date.now();
+
+      this._toastSequence = (this._toastSequence || 0) + 1;
+
+      return {
+        id: `${now}-${this._toastSequence}`,
+        type: toastType,
+        title,
+        message,
+        details,
+        fullText: fullText || title,
+        previewText: preview.text,
+        expanded: false,
+        expandable: preview.truncated,
+        duration: Math.max(0, toastDuration),
+        remainingMs: Math.max(0, toastDuration),
+        repeatCount: 1,
+        key: raw.key || options.key || `${toastType}:${title}:${fullText || title}`.slice(0, 700),
+        createdAt: now,
+        lastSeenAt: now,
+        startedAt: 0,
+        timerId: null,
+        paused: false,
+        animationNonce: 0,
+      };
+    },
+
+    _findDuplicateToast(key, now) {
+      if (!key) return null;
+      return [...this.toasts, ...this.toastQueue].find((toast) =>
+        toast.key === key && now - (toast.lastSeenAt || toast.createdAt || 0) <= TOAST_DEDUPE_WINDOW_MS
+      ) || null;
+    },
+
+    _mergeDuplicateToast(existing, incoming) {
+      existing.repeatCount = (existing.repeatCount || 1) + 1;
+      existing.lastSeenAt = Date.now();
+      existing.duration = Math.max(existing.duration || 0, incoming.duration || 0);
+      existing.remainingMs = existing.duration;
+
+      if (this.toasts.some((toast) => toast.id === existing.id) && !existing.expanded && !existing.paused) {
+        this._startToastTimer(existing, true);
+      }
+      this._syncToastCollections();
+    },
+
+    _startToastTimer(toast, resetRemaining = false) {
+      this._clearToastTimer(toast);
+      if (!toast.duration) {
+        toast.remainingMs = 0;
+        return;
+      }
+
+      if (resetRemaining || !toast.remainingMs || toast.remainingMs > toast.duration) {
+        toast.remainingMs = toast.duration;
+      }
+      toast.paused = false;
+      toast.startedAt = Date.now();
+      toast.animationNonce = (toast.animationNonce || 0) + 1;
+      toast.timerId = setTimeout(() => this.dismissToast(toast.id), toast.remainingMs);
+      this._syncToastCollections();
+    },
+
+    _clearToastTimer(toast) {
+      if (toast?.timerId) clearTimeout(toast.timerId);
+      if (toast) toast.timerId = null;
+    },
+
+    _promoteQueuedToasts() {
+      while (this.toasts.length < TOAST_MAX_VISIBLE && this.toastQueue.length > 0) {
+        const [next, ...rest] = this.toastQueue;
+        this.toastQueue = rest;
+        this.toasts = [...this.toasts, next];
+        this._startToastTimer(next, true);
+      }
+
+      if (this.toastQueue.length === 0 && this.toastOverflowCount > 0 && this.toasts.length < TOAST_MAX_VISIBLE) {
+        const collapsed = this.toastOverflowCount;
+        this.toastOverflowCount = 0;
+        const summary = this._normalizeToast({
+          title: 'Notifications collapsed',
+          message: `${collapsed} additional notification${collapsed === 1 ? '' : 's'} were hidden while the toast queue was full.`,
+          type: 'info',
+          duration: 5000,
+          key: `toast-overflow-summary:${Date.now()}`,
+        }, 'info', 5000);
+        this.toasts = [...this.toasts, summary];
+        this._startToastTimer(summary, true);
+      }
+    },
+
+    _syncToastCollections() {
+      this.toasts = [...this.toasts];
+      this.toastQueue = [...this.toastQueue];
+    },
+  },
+};

--- a/ui/static/js/features/toasts.js
+++ b/ui/static/js/features/toasts.js
@@ -234,9 +234,12 @@ export default {
       const message = String(structured ? (raw.message ?? raw.text ?? '') : (input ?? '')).trim();
       const fullText = compactText([message, ...details]);
       const preview = previewText(fullText || title);
-      const parsedDuration = Number(raw.duration ?? duration ?? DEFAULT_TOAST_DURATION);
+      const hasExplicitDuration = structured ? raw.duration !== undefined : duration !== undefined;
+      const parsedDuration = Number(hasExplicitDuration ? (raw.duration ?? duration) : DEFAULT_TOAST_DURATION);
       const rawDuration = Number.isFinite(parsedDuration) ? parsedDuration : DEFAULT_TOAST_DURATION;
-      const toastDuration = rawDuration > 0 ? Math.max(MIN_TOAST_DURATION, rawDuration) : 0;
+      const toastDuration = rawDuration > 0 && !hasExplicitDuration
+        ? Math.max(MIN_TOAST_DURATION, rawDuration)
+        : Math.max(0, rawDuration);
       const keySource = raw.key ?? options.key;
       const key = keySource === undefined
         ? this.toastKey(toastType, title, fullText || title)

--- a/ui/static/js/features/toasts.js
+++ b/ui/static/js/features/toasts.js
@@ -3,6 +3,8 @@ const TOAST_MAX_QUEUED = 20;
 const TOAST_DEDUPE_WINDOW_MS = 15000;
 const TOAST_PREVIEW_MAX_LINES = 4;
 const TOAST_PREVIEW_MAX_CHARS = 240;
+const TOAST_KEY_MAX_CHARS = 180;
+const TOAST_KEY_PREFIX_CHARS = 120;
 const DEFAULT_TOAST_DURATION = 9000;
 const MIN_TOAST_DURATION = 5000;
 
@@ -44,6 +46,60 @@ function previewText(text) {
   return { text: preview, truncated };
 }
 
+function hashString(hash, value) {
+  const text = String(value ?? '');
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash;
+}
+
+function hashPart(hash, part, seen = new WeakSet()) {
+  if (part === null || part === undefined) return hashString(hash, '');
+  if (Array.isArray(part)) {
+    hash = hashString(hash, `[${part.length}:`);
+    for (const item of part) hash = hashPart(hashString(hash, '|'), item, seen);
+    return hashString(hash, ']');
+  }
+  if (typeof part === 'object') {
+    if (seen.has(part)) return hashString(hash, '[circular]');
+    seen.add(part);
+    const keys = Object.keys(part).sort();
+    hash = hashString(hash, `{${keys.length}:`);
+    for (const key of keys) {
+      hash = hashString(hash, key);
+      hash = hashPart(hashString(hash, '='), part[key], seen);
+    }
+    seen.delete(part);
+    return hashString(hash, '}');
+  }
+  return hashString(hash, part);
+}
+
+function keyPreview(part) {
+  if (part === null || part === undefined) return '';
+  if (Array.isArray(part)) return `list:${part.length}`;
+  if (typeof part === 'object') return `object:${Object.keys(part).length}`;
+  return String(part).trim().replace(/\s+/g, ' ').slice(0, 48);
+}
+
+function normalizeToastKey(parts) {
+  let hash = 2166136261;
+  let prefix = '';
+  for (const part of parts) {
+    hash = hashPart(hashString(hash, '\u001f'), part);
+    const preview = keyPreview(part);
+    if (!preview) continue;
+    const next = prefix ? `${prefix}:${preview}` : preview;
+    prefix = next.length > TOAST_KEY_PREFIX_CHARS ? next.slice(0, TOAST_KEY_PREFIX_CHARS) : next;
+  }
+
+  const suffix = `#${hash.toString(36).padStart(7, '0')}`;
+  const base = prefix || 'toast';
+  return `${base.slice(0, TOAST_KEY_MAX_CHARS - suffix.length)}${suffix}`;
+}
+
 export default {
   state: {
     toasts: [],
@@ -71,6 +127,10 @@ export default {
       }
 
       return toast.id;
+    },
+
+    toastKey(...parts) {
+      return normalizeToastKey(parts);
     },
 
     dismissToast(id) {
@@ -129,8 +189,8 @@ export default {
 
     toastClass(toast) {
       const type = normalizeType(toast?.type);
-      const compactText = `${toast?.title || ''} ${toast?.fullText || ''}`.trim();
-      const compact = !toast?.expandable && compactText.length <= 110;
+      const compactBody = `${toast?.title || ''} ${toast?.fullText || ''}`.trim();
+      const compact = !toast?.expandable && compactBody.length <= 110;
       return [
         'toast',
         `toast-${type}`,
@@ -177,6 +237,10 @@ export default {
       const parsedDuration = Number(raw.duration ?? duration ?? DEFAULT_TOAST_DURATION);
       const rawDuration = Number.isFinite(parsedDuration) ? parsedDuration : DEFAULT_TOAST_DURATION;
       const toastDuration = rawDuration > 0 ? Math.max(MIN_TOAST_DURATION, rawDuration) : 0;
+      const keySource = raw.key ?? options.key;
+      const key = keySource === undefined
+        ? this.toastKey(toastType, title, fullText || title)
+        : this.toastKey(keySource);
       const now = Date.now();
 
       this._toastSequence = (this._toastSequence || 0) + 1;
@@ -194,7 +258,7 @@ export default {
         duration: Math.max(0, toastDuration),
         remainingMs: Math.max(0, toastDuration),
         repeatCount: 1,
-        key: raw.key || options.key || `${toastType}:${title}:${fullText || title}`.slice(0, 700),
+        key,
         createdAt: now,
         lastSeenAt: now,
         startedAt: 0,

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -22,9 +22,11 @@ import profileBuilder from './features/profile-builder.js';
 import profiles from './features/profiles.js';
 import qualitySizes from './features/quality-sizes.js';
 import scoring from './features/scoring.js';
+import toasts from './features/toasts.js';
 
 const featureModules = [
   navigation,
+  toasts,
   manifest,
   authSecurity,
   autoSync,

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -244,8 +244,6 @@ export default function baseState() {
     confirmModal: { show: false, title: '', message: '', confirmLabel: '', cancelLabel: '', secondaryLabel: '', hideCancel: false, onConfirm: null, onCancel: null, onSecondary: null },
     inputModal: { show: false, title: '', message: '', value: '', placeholder: '', confirmLabel: '', onConfirm: null, onCancel: null },
     sandboxCopyModal: { show: false, title: '', text: '', copied: false },
-    toasts: [], // { id, message, type: 'info'|'warning'|'error', timeout }
-
     // Import
     importedProfiles: { radarr: [], sonarr: [] },
     showImportModal: false, // false or app type string

--- a/ui/static/partials/modals/toasts.html
+++ b/ui/static/partials/modals/toasts.html
@@ -1,13 +1,33 @@
 {{define "modals/toasts"}}
   <!-- Toast notifications -->
-  <div style="position:fixed;top:16px;left:50%;transform:translateX(-50%);z-index:10000;display:flex;flex-direction:column;gap:8px;max-width:450px;width:100%;max-height:80vh;overflow-y:auto">
+  <div class="toast-stack" x-show="toasts.length > 0 || toastPendingCount() > 0" aria-live="polite" aria-relevant="additions text">
     <template x-for="toast in toasts" :key="toast.id">
-      <div :style="'position:relative;padding:10px 14px;border-radius:8px;font-size:12px;line-height:1.5;box-shadow:0 4px 12px var(--alpha-shadow);cursor:pointer;animation:fadeIn 0.2s;overflow:hidden;' + (toast.type === 'warning' ? 'background:var(--accent-orange-bg);border:1px solid var(--accent-orange);color:var(--accent-orange)' : toast.type === 'error' ? 'background:var(--accent-red-bg);border:1px solid var(--accent-red);color:var(--accent-red)' : 'background:var(--accent-green-bg);border:1px solid var(--accent-green-strong);color:var(--accent-green)')"
-           @click="toasts = toasts.filter(t => t.id !== toast.id)">
-        <span style="white-space:pre-line" x-text="toast.message"></span>
-        <div :style="'position:absolute;bottom:0;left:0;height:3px;border-radius:0 0 8px 8px;opacity:0.6;background:currentColor;animation:toastProgress ' + (toast.duration || 8000) + 'ms linear forwards'"></div>
+      <div :class="toastClass(toast)"
+           :role="toastRole(toast)"
+           @mouseenter="pauseToast(toast.id)"
+           @mouseleave="resumeToast(toast.id)"
+           @focusin="pauseToast(toast.id)"
+           @focusout="if (!$el.contains($event.relatedTarget)) resumeToast(toast.id)">
+        <button type="button" class="toast-close" aria-label="Dismiss notification" @click.stop="dismissToast(toast.id)">x</button>
+        <div class="toast-content"
+             :class="toast.expandable ? 'toast-content-expandable' : ''"
+             :role="toast.expandable ? 'button' : null"
+             :tabindex="toast.expandable ? 0 : -1"
+             :aria-expanded="toast.expandable ? String(toast.expanded) : null"
+             @click="toggleToast(toast.id)"
+             @keydown.enter.prevent="toggleToast(toast.id)"
+             @keydown.space.prevent="toggleToast(toast.id)">
+          <div class="toast-header" x-show="toast.title || toast.repeatCount > 1">
+            <div class="toast-title" x-show="toast.title" x-text="toast.title"></div>
+            <div class="toast-repeat" x-show="toast.repeatCount > 1" x-text="'x' + toast.repeatCount"></div>
+          </div>
+          <div class="toast-message" :class="toast.expanded ? 'toast-message-expanded' : ''" x-text="toastDisplayText(toast)"></div>
+          <div class="toast-more" x-show="toast.expandable" x-text="toast.expanded ? 'Show less' : 'Show more'"></div>
+        </div>
+        <div class="toast-progress" :key="toast.id + '-' + toast.animationNonce" :style="toastProgressStyle(toast)"></div>
       </div>
     </template>
+    <div class="toast-queue-footer" x-show="toastPendingCount() > 0" x-text="toastPendingLabel()"></div>
   </div>
 
 {{end}}

--- a/ui/static/partials/modals/toasts.html
+++ b/ui/static/partials/modals/toasts.html
@@ -24,7 +24,14 @@
           <div class="toast-message" :class="toast.expanded ? 'toast-message-expanded' : ''" x-text="toastDisplayText(toast)"></div>
           <div class="toast-more" x-show="toast.expandable" x-text="toast.expanded ? 'Show less' : 'Show more'"></div>
         </div>
-        <div class="toast-progress" :key="toast.id + '-' + toast.animationNonce" :style="toastProgressStyle(toast)"></div>
+        <div class="toast-progress"
+             :style="toastProgressStyle(toast)"
+             x-effect="
+               toast.animationNonce;
+               $el.style.animation = 'none';
+               $el.offsetWidth;
+               $el.style.animation = '';
+             "></div>
       </div>
     </template>
     <div class="toast-queue-footer" x-show="toastPendingCount() > 0" x-text="toastPendingLabel()"></div>


### PR DESCRIPTION
### Summary

This PR improves Clonarr’s in-app toast notifications so they stay readable, expandable, dismissible, and manageable during long messages or repeated actions.

### Changes

- Adds a shared toast manager for queueing, dedupe, repeat counts, timers, and inline expansion.
- Limits visible toasts to 3 and queues additional notifications.
- Adds explicit close controls to every toast.
- Supports compact previews with expandable full details.
- Updates high-volume toast producers to pass structured details instead of pre-truncated strings.
- Removes backend pre-truncation for auto-sync event details.
- Improves toast sizing, duration, contrast, and theme visibility in light and dark mode.
- Adds bounded hashed toast dedupe keys via `toastKey()` to avoid oversized key strings.
- Replaces large joined-string toast keys in high-volume call sites.
- Uses stable rollback key inputs instead of locale-formatted dates.
