### PR TITLE
Add TRaSH data reset action

### DIFF
--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -42,6 +42,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	// TRaSH
 	mux.HandleFunc("GET /api/trash/status", s.handleTrashStatus)
 	mux.HandleFunc("POST /api/trash/pull", s.handleTrashPull)
+	mux.HandleFunc("POST /api/trash/reset", s.handleTrashReset)
 	mux.HandleFunc("GET /api/trash/{app}/cfs", s.handleTrashCFs)
 	mux.HandleFunc("GET /api/trash/{app}/score-contexts", s.handleTrashScoreContexts)
 	mux.HandleFunc("GET /api/trash/{app}/cf-groups", s.handleTrashCFGroups)

--- a/internal/api/trash.go
+++ b/internal/api/trash.go
@@ -125,6 +125,13 @@ func (s *Server) handleTrashPull(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleTrashReset(w http.ResponseWriter, r *http.Request) {
+	unlockSyncs, busy := s.Core.TryLockConfiguredSyncs()
+	if busy {
+		writeError(w, http.StatusConflict, "Sync already in progress; try again after it finishes")
+		return
+	}
+	defer unlockSyncs()
+
 	if err := s.Core.Trash.Reset(); err != nil {
 		if errors.Is(err, core.ErrTrashBusy) {
 			writeError(w, http.StatusConflict, "TRaSH pull/reset already in progress")

--- a/internal/api/trash.go
+++ b/internal/api/trash.go
@@ -3,6 +3,7 @@ package api
 import (
 	"clonarr/internal/core"
 	"clonarr/internal/utils"
+	"errors"
 	"log"
 	"net/http"
 	"sort"
@@ -121,6 +122,18 @@ func (s *Server) handleTrashPull(w http.ResponseWriter, r *http.Request) {
 	})
 	w.WriteHeader(http.StatusAccepted)
 	writeJSON(w, map[string]string{"status": "pulling"})
+}
+
+func (s *Server) handleTrashReset(w http.ResponseWriter, r *http.Request) {
+	if err := s.Core.Trash.Reset(); err != nil {
+		if errors.Is(err, core.ErrTrashBusy) {
+			writeError(w, http.StatusConflict, "TRaSH pull/reset already in progress")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "Failed to reset TRaSH data: "+err.Error())
+		return
+	}
+	writeJSON(w, map[string]string{"status": "reset"})
 }
 
 // shortCommit returns the first 7 characters of a git commit hash for

--- a/internal/api/trash_api_test.go
+++ b/internal/api/trash_api_test.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"clonarr/internal/core"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func setupTrashAPIServerWithCachedData(t *testing.T) (*Server, string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	cfg := core.NewConfigStore(dir)
+	if err := cfg.Set(core.DefaultConfig()); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "trash-guides"), 0755); err != nil {
+		t.Fatalf("mkdir trash-guides: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "trash-guides", "sentinel.txt"), []byte("data"), 0644); err != nil {
+		t.Fatalf("write repo sentinel: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "last-pull.txt"), []byte("2026-05-11T12:00:00Z"), 0644); err != nil {
+		t.Fatalf("write last-pull: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "last-pull-diff.json"), []byte(`{"prevCommit":"old","newCommit":"abc123","summary":"changed","time":"2026-05-11T12:00:00Z"}`), 0644); err != nil {
+		t.Fatalf("write last diff: %v", err)
+	}
+
+	app := &core.App{
+		Config:       cfg,
+		Trash:        core.NewTrashStore(dir),
+		DebugLog:     core.NewDebugLogger(dir),
+		ActivityLog:  core.NewActivityLogger(dir),
+		PullUpdateCh: make(chan string, 1),
+	}
+	return &Server{Core: app}, dir
+}
+
+func TestTrashAPIResetClearsStatus(t *testing.T) {
+	server, dir := setupTrashAPIServerWithCachedData(t)
+	mux := http.NewServeMux()
+	server.RegisterRoutes(mux)
+
+	statusReq := httptest.NewRequest(http.MethodGet, "/api/trash/status", nil)
+	statusW := httptest.NewRecorder()
+	mux.ServeHTTP(statusW, statusReq)
+	if statusW.Code != http.StatusOK {
+		t.Fatalf("initial status = %d, want %d", statusW.Code, http.StatusOK)
+	}
+	var before core.TrashStatus
+	if err := json.NewDecoder(statusW.Body).Decode(&before); err != nil {
+		t.Fatalf("decode initial status: %v", err)
+	}
+	if !before.Cloned || before.CommitHash == "" || before.LastDiff == nil {
+		t.Fatalf("initial status was not seeded as cloned: %+v", before)
+	}
+
+	resetReq := httptest.NewRequest(http.MethodPost, "/api/trash/reset", nil)
+	resetW := httptest.NewRecorder()
+	mux.ServeHTTP(resetW, resetReq)
+	if resetW.Code != http.StatusOK {
+		t.Fatalf("reset status = %d, want %d: %s", resetW.Code, http.StatusOK, resetW.Body.String())
+	}
+	var body map[string]string
+	if err := json.NewDecoder(resetW.Body).Decode(&body); err != nil {
+		t.Fatalf("decode reset body: %v", err)
+	}
+	if body["status"] != "reset" {
+		t.Fatalf("status body = %q, want reset", body["status"])
+	}
+
+	statusReq = httptest.NewRequest(http.MethodGet, "/api/trash/status", nil)
+	statusW = httptest.NewRecorder()
+	mux.ServeHTTP(statusW, statusReq)
+	if statusW.Code != http.StatusOK {
+		t.Fatalf("post-reset status = %d, want %d", statusW.Code, http.StatusOK)
+	}
+	var after core.TrashStatus
+	if err := json.NewDecoder(statusW.Body).Decode(&after); err != nil {
+		t.Fatalf("decode post-reset status: %v", err)
+	}
+	if after.Cloned || after.CommitHash != "" || after.LastDiff != nil || after.PullError != "" {
+		t.Fatalf("post-reset status not cleared: %+v", after)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "trash-guides")); !os.IsNotExist(err) {
+		t.Fatalf("trash-guides was not deleted: %v", err)
+	}
+}
+
+func TestTrashAPIResetBusyReturnsConflict(t *testing.T) {
+	server, dir := setupTrashAPIServerWithCachedData(t)
+	mux := http.NewServeMux()
+	server.RegisterRoutes(mux)
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir fake bin: %v", err)
+	}
+	marker := filepath.Join(dir, "git-started")
+	release := filepath.Join(dir, "git-release")
+	fakeGit := filepath.Join(binDir, "git")
+	script := "#!/bin/sh\n" +
+		": > \"" + marker + "\"\n" +
+		"while [ ! -f \"" + release + "\" ]; do sleep 0.05; done\n" +
+		"exit 1\n"
+	if err := os.WriteFile(fakeGit, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Cleanup(func() {
+		_ = os.WriteFile(release, []byte("release"), 0644)
+	})
+
+	pullReq := httptest.NewRequest(http.MethodPost, "/api/trash/pull", nil)
+	pullW := httptest.NewRecorder()
+	mux.ServeHTTP(pullW, pullReq)
+	if pullW.Code != http.StatusAccepted {
+		t.Fatalf("pull status = %d, want %d: %s", pullW.Code, http.StatusAccepted, pullW.Body.String())
+	}
+	waitForFile(t, marker)
+
+	resetReq := httptest.NewRequest(http.MethodPost, "/api/trash/reset", nil)
+	resetW := httptest.NewRecorder()
+	mux.ServeHTTP(resetW, resetReq)
+	if resetW.Code != http.StatusConflict {
+		t.Fatalf("reset status = %d, want %d: %s", resetW.Code, http.StatusConflict, resetW.Body.String())
+	}
+	if !strings.Contains(resetW.Body.String(), "TRaSH pull/reset already in progress") {
+		t.Fatalf("reset body missing busy error: %s", resetW.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "trash-guides")); err != nil {
+		t.Fatalf("trash-guides was changed while busy: %v", err)
+	}
+
+	if err := os.WriteFile(release, []byte("release"), 0644); err != nil {
+		t.Fatalf("release fake git: %v", err)
+	}
+	waitForNotPulling(t, server)
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", path)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForNotPulling(t *testing.T, server *Server) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if !server.Core.Trash.Status().Pulling {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for pull lock to release")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/api/trash_api_test.go
+++ b/internal/api/trash_api_test.go
@@ -145,6 +145,45 @@ func TestTrashAPIResetBusyReturnsConflict(t *testing.T) {
 	waitForNotPulling(t, server)
 }
 
+func TestTrashAPIResetSyncInProgressReturnsConflict(t *testing.T) {
+	server, dir := setupTrashAPIServerWithCachedData(t)
+	if err := server.Core.Config.Update(func(cfg *core.Config) {
+		cfg.Instances = append(cfg.Instances, core.Instance{
+			ID:     "inst-reset-busy",
+			Name:   "Reset Busy",
+			Type:   "radarr",
+			URL:    "http://127.0.0.1:7878",
+			APIKey: "test",
+		})
+	}); err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+
+	mu := server.Core.GetSyncMutex("inst-reset-busy")
+	mu.Lock()
+	defer mu.Unlock()
+
+	mux := http.NewServeMux()
+	server.RegisterRoutes(mux)
+	resetReq := httptest.NewRequest(http.MethodPost, "/api/trash/reset", nil)
+	resetW := httptest.NewRecorder()
+	mux.ServeHTTP(resetW, resetReq)
+	if resetW.Code != http.StatusConflict {
+		t.Fatalf("reset status = %d, want %d: %s", resetW.Code, http.StatusConflict, resetW.Body.String())
+	}
+	if !strings.Contains(resetW.Body.String(), "Sync already in progress; try again after it finishes") {
+		t.Fatalf("reset body missing sync-busy error: %s", resetW.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, "trash-guides")); err != nil {
+		t.Fatalf("trash-guides was changed while sync was busy: %v", err)
+	}
+
+	st := server.Core.Trash.Status()
+	if !st.Cloned || st.CommitHash == "" || st.LastDiff == nil {
+		t.Fatalf("status was unexpectedly cleared while sync was busy: %+v", st)
+	}
+}
+
 func waitForFile(t *testing.T, path string) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/internal/core/autosync.go
+++ b/internal/core/autosync.go
@@ -20,6 +20,14 @@ import (
 // SourceAutoPullInterval (scheduled tick), SourceManualPull (user clicked
 // Pull in the UI).
 func (app *App) AutoSyncAfterPull(trigger string) {
+	currentCommit := app.Trash.CurrentCommit()
+	if currentCommit == "" {
+		if app.DebugLog != nil {
+			app.DebugLog.Logf(LogAutoSync, "TRaSH data not loaded — skipping AutoSyncAfterPull")
+		}
+		return
+	}
+
 	// Clean up stale rules/history for Arr profiles that no longer exist
 	app.CleanupStaleRules()
 
@@ -39,11 +47,6 @@ func (app *App) AutoSyncAfterPull(trigger string) {
 		return
 	}
 	if len(cfg.AutoSync.Rules) == 0 {
-		return
-	}
-
-	currentCommit := app.Trash.CurrentCommit()
-	if currentCommit == "" {
 		return
 	}
 
@@ -104,6 +107,14 @@ func filterEligibleRulesForPull(rules []AutoSyncRule, currentCommit string) []Au
 // orphaned, imported, or disabled are still skipped — same gates as the
 // pull-driven path.
 func (app *App) ForceSyncAllRules() {
+	currentCommit := app.Trash.CurrentCommit()
+	if currentCommit == "" {
+		if app.DebugLog != nil {
+			app.DebugLog.Logf(LogAutoSync, "TRaSH data not loaded — skipping ForceSyncAllRules")
+		}
+		return
+	}
+
 	app.CleanupStaleRules()
 	app.MigratePriorAvailableGroups()
 
@@ -113,11 +124,6 @@ func (app *App) ForceSyncAllRules() {
 		return
 	}
 	if len(cfg.AutoSync.Rules) == 0 {
-		return
-	}
-
-	currentCommit := app.Trash.CurrentCommit()
-	if currentCommit == "" {
 		return
 	}
 
@@ -1020,8 +1026,8 @@ func (app *App) WaitForInstanceReachable(inst Instance) bool {
 // Mirrors frontend's pdOverrideSummary + pdGroupOptionalCount:
 //
 //   - overrides = profile-level changes (general + quality + per-CF score
-//     overrides + extras). Walks rule.Overrides + rule.QualityStructure
-//     + rule.QualityOverrides + rule.ScoreOverrides directly.
+//     overrides + extras). Walks rule.Overrides, rule.QualityStructure,
+//     rule.QualityOverrides, and rule.ScoreOverrides directly.
 //   - optional  = TRaSH-blessed activations outside profile defaults.
 //     Walks the profile's cf-groups (via ProfileDetailData) and counts
 //     non-required CFs whose selected state diverges from cf.Default.
@@ -1200,7 +1206,11 @@ func (app *App) MigratePriorAvailableGroups() {
 
 	// Cache by commit hash — many rules typically share the same
 	// LastSyncCommit, so we git-read each commit's groups only once.
-	commitCache := make(map[string]map[string]CommitGroupInfo)
+	type commitGroupLookup struct {
+		groups map[string]CommitGroupInfo
+		ok     bool
+	}
+	commitCache := make(map[string]commitGroupLookup)
 
 	var migrated int
 	for _, rule := range cfg.AutoSync.Rules {
@@ -1214,15 +1224,19 @@ func (app *App) MigratePriorAvailableGroups() {
 			continue // imported profile — group resolution is a separate path
 		}
 
-		commitGroups, ok := commitCache[rule.LastSyncCommit]
-		if !ok {
-			commitGroups = app.Trash.GroupsAtCommit(rule.LastSyncCommit)
-			commitCache[rule.LastSyncCommit] = commitGroups
+		lookup, cached := commitCache[rule.LastSyncCommit]
+		if !cached {
+			groups, ok := app.Trash.GroupsAtCommit(rule.LastSyncCommit)
+			lookup = commitGroupLookup{groups: groups, ok: ok}
+			commitCache[rule.LastSyncCommit] = lookup
+		}
+		if !lookup.ok {
+			continue // repo/commit unavailable; leave nil so migration can retry later
 		}
 
 		// Filter to groups that included this rule's profile at that commit.
 		snapshot := make(map[string]bool)
-		for groupTID, info := range commitGroups {
+		for groupTID, info := range lookup.groups {
 			for _, profTID := range info.Includes {
 				if profTID == rule.TrashProfileID {
 					snapshot[groupTID] = info.DefaultEnabled
@@ -1231,9 +1245,10 @@ func (app *App) MigratePriorAvailableGroups() {
 			}
 		}
 
-		// Save. Even an empty snapshot is recorded (as empty map) so we
-		// don't repeat the migration on every pull tick — the empty map
-		// itself signals "we've looked, found nothing relevant".
+		// Save. Even an empty snapshot from a successful commit lookup is
+		// recorded (as empty map) so we don't repeat the migration on every
+		// pull tick — the empty map itself signals "we've looked, found
+		// nothing relevant".
 		ruleID := rule.ID
 		app.Config.Update(func(cfg *Config) {
 			for i := range cfg.AutoSync.Rules {

--- a/internal/core/autosync_test.go
+++ b/internal/core/autosync_test.go
@@ -2,6 +2,9 @@ package core
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -292,8 +295,8 @@ func TestApplyOrphanMarking_MixedTransitions(t *testing.T) {
 		}},
 	}
 	valid := map[string]map[int]bool{
-		"inst-A": {1: true},        // 10 missing
-		"inst-B": {20: true},       // 20 reappeared
+		"inst-A": {1: true},  // 10 missing
+		"inst-B": {20: true}, // 20 reappeared
 	}
 	now := "2026-04-27T12:00:00Z"
 
@@ -304,5 +307,121 @@ func TestApplyOrphanMarking_MixedTransitions(t *testing.T) {
 	}
 	if cfg.AutoSync.Rules[1].OrphanedAt != "" {
 		t.Errorf("r2 should be cleared")
+	}
+}
+
+func seedTrashGroupGitCommit(t *testing.T, dataDir string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dataDir, "docs", "json", "radarr", "cf-groups"), 0755); err != nil {
+		t.Fatalf("mkdir cf-groups: %v", err)
+	}
+	groupJSON := `{
+  "name": "Test Group",
+  "trash_id": "group-1",
+  "default": "true",
+  "quality_profiles": { "include": { "profile": "profile-1" } }
+}`
+	if err := os.WriteFile(filepath.Join(dataDir, "docs", "json", "radarr", "cf-groups", "group.json"), []byte(groupJSON), 0644); err != nil {
+		t.Fatalf("write cf-group: %v", err)
+	}
+
+	cmds := [][]string{
+		{"git", "-C", dataDir, "init", "-q"},
+		{"git", "-C", dataDir, "config", "user.email", "test@example.com"},
+		{"git", "-C", dataDir, "config", "user.name", "test"},
+		{"git", "-C", dataDir, "config", "commit.gpgsign", "false"},
+		{"git", "-C", dataDir, "add", "docs/json/radarr/cf-groups/group.json"},
+		{"git", "-C", dataDir, "commit", "-q", "-m", "groups"},
+	}
+	for _, c := range cmds {
+		if out, err := exec.Command(c[0], c[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%s: %v\n%s", strings.Join(c, " "), err, out)
+		}
+	}
+	out, err := exec.Command("git", "-C", dataDir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestMigratePriorAvailableGroupsLeavesNilWhenGitLookupFails(t *testing.T) {
+	dir := t.TempDir()
+	cfg := NewConfigStore(dir)
+	if err := cfg.Set(&Config{
+		AutoSync: AutoSyncConfig{Rules: []AutoSyncRule{{
+			ID:             "rule-1",
+			TrashProfileID: "profile-1",
+			LastSyncCommit: "missing-commit",
+		}}},
+	}); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	app := &App{
+		Config:   cfg,
+		Trash:    NewTrashStore(dir),
+		DebugLog: NewDebugLogger(dir),
+	}
+
+	app.MigratePriorAvailableGroups()
+
+	got := cfg.Get().AutoSync.Rules[0].PriorAvailableGroups
+	if got != nil {
+		t.Fatalf("PriorAvailableGroups = %#v, want nil so migration can retry", got)
+	}
+}
+
+func TestMigratePriorAvailableGroupsPopulatesFromCommit(t *testing.T) {
+	dir := t.TempDir()
+	commit := seedTrashGroupGitCommit(t, filepath.Join(dir, "trash-guides"))
+	cfg := NewConfigStore(dir)
+	if err := cfg.Set(&Config{
+		AutoSync: AutoSyncConfig{Rules: []AutoSyncRule{{
+			ID:             "rule-1",
+			TrashProfileID: "profile-1",
+			LastSyncCommit: commit,
+		}}},
+	}); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	app := &App{
+		Config:   cfg,
+		Trash:    NewTrashStore(dir),
+		DebugLog: NewDebugLogger(dir),
+	}
+
+	app.MigratePriorAvailableGroups()
+
+	got := cfg.Get().AutoSync.Rules[0].PriorAvailableGroups
+	if got == nil || !got["group-1"] {
+		t.Fatalf("PriorAvailableGroups = %#v, want group-1=true", got)
+	}
+}
+
+func TestForceSyncAllRulesWithNoTrashCommitSkipsMigration(t *testing.T) {
+	dir := t.TempDir()
+	commit := seedTrashGroupGitCommit(t, filepath.Join(dir, "trash-guides"))
+	cfg := NewConfigStore(dir)
+	if err := cfg.Set(&Config{
+		AutoSync: AutoSyncConfig{Rules: []AutoSyncRule{{
+			ID:             "rule-1",
+			Enabled:        true,
+			TrashProfileID: "profile-1",
+			LastSyncCommit: commit,
+		}}},
+	}); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+	app := &App{
+		Config:   cfg,
+		Trash:    NewTrashStore(dir),
+		DebugLog: NewDebugLogger(dir),
+	}
+
+	app.ForceSyncAllRules()
+
+	got := cfg.Get().AutoSync.Rules[0].PriorAvailableGroups
+	if got != nil {
+		t.Fatalf("PriorAvailableGroups = %#v, want nil when current TRaSH commit is empty", got)
 	}
 }

--- a/internal/core/sync.go
+++ b/internal/core/sync.go
@@ -21,6 +21,41 @@ func (app *App) GetSyncMutex(instanceID string) *sync.Mutex {
 	return v.(*sync.Mutex)
 }
 
+// TryLockConfiguredSyncs attempts to lock every currently configured instance
+// sync mutex. The returned unlock function releases all locks acquired by this
+// call. If any instance is already syncing, previously acquired locks are
+// released and busy is true.
+func (app *App) TryLockConfiguredSyncs() (unlock func(), busy bool) {
+	cfg := app.Config.Get()
+	seen := make(map[string]bool, len(cfg.Instances))
+	instanceIDs := make([]string, 0, len(cfg.Instances))
+	for _, inst := range cfg.Instances {
+		if inst.ID == "" || seen[inst.ID] {
+			continue
+		}
+		seen[inst.ID] = true
+		instanceIDs = append(instanceIDs, inst.ID)
+	}
+	sort.Strings(instanceIDs)
+
+	locked := make([]*sync.Mutex, 0, len(instanceIDs))
+	for _, id := range instanceIDs {
+		mu := app.GetSyncMutex(id)
+		if !mu.TryLock() {
+			for i := len(locked) - 1; i >= 0; i-- {
+				locked[i].Unlock()
+			}
+			return func() {}, true
+		}
+		locked = append(locked, mu)
+	}
+	return func() {
+		for i := len(locked) - 1; i >= 0; i-- {
+			locked[i].Unlock()
+		}
+	}, false
+}
+
 // GetLastSyncedCFs returns the CF snapshot from the previous sync for "add_new" mode.
 // Returns nil if not needed (behavior is not "add_new") or no history exists.
 func (app *App) GetLastSyncedCFs(instanceID string, arrProfileID int, behavior *SyncBehavior) []string {
@@ -108,12 +143,12 @@ type SyncSummary struct {
 
 // SyncRequest is the input for a dry-run or apply operation.
 type SyncRequest struct {
-	InstanceID        string          `json:"instanceId"`
-	ProfileTrashID    string          `json:"profileTrashId"`
-	ImportedProfileID string          `json:"importedProfileId,omitempty"` // alternative: sync from imported/custom profile
-	ArrProfileID      int             `json:"arrProfileId"`                // target Arr profile to set scores on (0 = create new)
-	ProfileName       string          `json:"profileName"`                 // custom name for new profile (optional)
-	SelectedCFs       []string        `json:"selectedCFs"`                 // optional: additional CF trash_ids from groups
+	InstanceID        string   `json:"instanceId"`
+	ProfileTrashID    string   `json:"profileTrashId"`
+	ImportedProfileID string   `json:"importedProfileId,omitempty"` // alternative: sync from imported/custom profile
+	ArrProfileID      int      `json:"arrProfileId"`                // target Arr profile to set scores on (0 = create new)
+	ProfileName       string   `json:"profileName"`                 // custom name for new profile (optional)
+	SelectedCFs       []string `json:"selectedCFs"`                 // optional: additional CF trash_ids from groups
 	// ExpandRule, when true, tells handleApply to look up the auto-sync rule
 	// for (instanceId, arrProfileId), run ExpandSelectedCFsForBrandNewGroups
 	// to auto-include CFs from brand-new default-on TRaSH cf-groups, and
@@ -123,15 +158,15 @@ type SyncRequest struct {
 	// the manual Sync All path (frontend quickSync → /api/sync/apply) didn't.
 	// Default false: every other caller of /api/sync/apply (Profile Sync's
 	// Save & Sync, Compare apply, sync-history rerun, etc.) is unaffected.
-	ExpandRule        bool            `json:"expandRule,omitempty"`
+	ExpandRule bool `json:"expandRule,omitempty"`
 	// KeepArrCFIDs lists Arr CF IDs that must NOT be zeroed by ResetMode='reset_to_zero'.
 	// Used by Compare flow when the user unchecks an "Extra in Arr" row (= keep at current score).
 	// Backend treats these as if they were part of the synced set during the reset loop.
 	// Save & Sync flow leaves this empty — it relies on scoreOverrides + extraCFs (trash-id keyed).
-	KeepArrCFIDs      []int           `json:"keepArrCFIDs,omitempty"`
-	ScoreOverrides    map[string]int  `json:"scoreOverrides,omitempty"`    // per-CF score overrides (trash_id → score)
-	QualityOverrides  map[string]bool `json:"qualityOverrides,omitempty"`  // legacy flat quality override (name → allowed). Used when QualityStructure is empty.
-	QualityStructure  []QualityItem   `json:"qualityStructure,omitempty"`  // full structure override (replaces TRaSH items). Trumps QualityOverrides when set.
+	KeepArrCFIDs     []int           `json:"keepArrCFIDs,omitempty"`
+	ScoreOverrides   map[string]int  `json:"scoreOverrides,omitempty"`   // per-CF score overrides (trash_id → score)
+	QualityOverrides map[string]bool `json:"qualityOverrides,omitempty"` // legacy flat quality override (name → allowed). Used when QualityStructure is empty.
+	QualityStructure []QualityItem   `json:"qualityStructure,omitempty"` // full structure override (replaces TRaSH items). Trumps QualityOverrides when set.
 	// Profile setting overrides (nil = use TRaSH default)
 	Overrides *SyncOverrides `json:"overrides,omitempty"`
 	// Sync behavior rules (nil = defaults: add_missing, remove_custom, reset_to_zero)

--- a/internal/core/trash.go
+++ b/internal/core/trash.go
@@ -224,6 +224,7 @@ type TrashData struct {
 type TrashStore struct {
 	mu                sync.RWMutex // protects data
 	pullMu            sync.Mutex   // serializes clone/pull operations (C4)
+	repoMu            sync.RWMutex // protects dataDir git/filesystem access against reset/delete
 	data              *TrashData
 	dataDir           string                         // path to TRaSH repo clone
 	pullError         string                         // last pull error (empty = OK)
@@ -288,6 +289,9 @@ func (ts *TrashStore) Reset() error {
 	}
 	defer ts.pullMu.Unlock()
 
+	ts.repoMu.Lock()
+	defer ts.repoMu.Unlock()
+
 	dataRoot := filepath.Dir(ts.dataDir)
 	paths := []string{
 		ts.dataDir,
@@ -312,6 +316,14 @@ func (ts *TrashStore) Reset() error {
 // Groups changes by app type (Radarr/Sonarr) and category (CFs, Profiles, Groups, etc).
 // Uses git diff --name-status to show Added/Modified/Deleted per file.
 func (ts *TrashStore) DiffChangedFiles(prevCommit, newCommit string) string {
+	ts.repoMu.RLock()
+	defer ts.repoMu.RUnlock()
+	return ts.diffChangedFilesLocked(prevCommit, newCommit)
+}
+
+// diffChangedFilesLocked is DiffChangedFiles without locking. Caller must hold
+// repoMu for read or write.
+func (ts *TrashStore) diffChangedFilesLocked(prevCommit, newCommit string) string {
 	cmd := exec.Command("git", "-C", ts.dataDir, "diff", "--name-status", prevCommit, newCommit)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -659,6 +671,9 @@ func (ts *TrashStore) GroupsAtCommit(commit string) (map[string]CommitGroupInfo,
 	if commit == "" || ts.dataDir == "" {
 		return nil, false
 	}
+	ts.repoMu.RLock()
+	defer ts.repoMu.RUnlock()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
@@ -719,6 +734,9 @@ func (ts *TrashStore) DiffPull(prevCommit, newCommit string) (*PullChangeSet, er
 	if prevCommit == "" || newCommit == "" || prevCommit == newCommit {
 		return &PullChangeSet{}, nil
 	}
+	ts.repoMu.RLock()
+	defer ts.repoMu.RUnlock()
+
 	// 10s timeout — `git diff --name-status` on the sparse-checkout repo is
 	// normally a milliseconds operation, but a wedged filesystem (NFS drop,
 	// disk failure) could otherwise hang the goroutine forever. Failing the
@@ -934,6 +952,9 @@ func (ts *TrashStore) CloneOrPull(repoURL, branch string) error {
 	}
 	defer ts.pullMu.Unlock()
 
+	ts.repoMu.Lock()
+	defer ts.repoMu.Unlock()
+
 	if err := os.MkdirAll(filepath.Dir(ts.dataDir), 0755); err != nil {
 		return fmt.Errorf("create data dir: %w", err)
 	}
@@ -1045,6 +1066,9 @@ func (ts *TrashStore) LoadFromDisk() error {
 	}
 	defer ts.pullMu.Unlock()
 
+	ts.repoMu.Lock()
+	defer ts.repoMu.Unlock()
+
 	if _, err := os.Stat(filepath.Join(ts.dataDir, ".git")); err != nil {
 		return fmt.Errorf("TRaSH repo not cloned at %s", ts.dataDir)
 	}
@@ -1054,7 +1078,7 @@ func (ts *TrashStore) LoadFromDisk() error {
 
 // loadAndSwap reads commit metadata + parses CF/profile JSON from the on-disk
 // repo and atomically swaps a new snapshot into the store. Caller must hold
-// pullMu.
+// pullMu and repoMu.
 //
 // On failure, records the error in ts.pullError so TrashStatus / the UI can
 // surface a "pull failing" state instead of silently showing a stale snapshot.
@@ -1101,7 +1125,7 @@ func (ts *TrashStore) loadAndSwap() error {
 	ts.mu.RUnlock()
 
 	if prevCommit != "" && data.CommitHash != prevCommit {
-		if diff := ts.DiffChangedFiles(prevCommit, data.CommitHash); diff != "" {
+		if diff := ts.diffChangedFilesLocked(prevCommit, data.CommitHash); diff != "" {
 			data.LastDiff = &PullDiff{
 				PrevCommit: prevCommit,
 				NewCommit:  data.CommitHash,

--- a/internal/core/trash.go
+++ b/internal/core/trash.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -16,6 +17,10 @@ import (
 	"sync"
 	"time"
 )
+
+// ErrTrashBusy indicates a TRaSH pull, load, or reset operation already holds
+// the store operation lock.
+var ErrTrashBusy = errors.New("TRaSH pull/reset already in progress")
 
 // --- TRaSH Data Types ---
 
@@ -272,6 +277,35 @@ func (ts *TrashStore) CurrentCommit() string {
 // DataDir returns the path to the TRaSH repo clone directory.
 func (ts *TrashStore) DataDir() string {
 	return ts.dataDir
+}
+
+// Reset clears the local TRaSH Guides clone and pull metadata, then replaces
+// the in-memory snapshot with an empty dataset. User configuration and locally
+// saved profiles/CFs live outside this store and are intentionally untouched.
+func (ts *TrashStore) Reset() error {
+	if !ts.pullMu.TryLock() {
+		return ErrTrashBusy
+	}
+	defer ts.pullMu.Unlock()
+
+	dataRoot := filepath.Dir(ts.dataDir)
+	paths := []string{
+		ts.dataDir,
+		filepath.Join(dataRoot, "last-pull.txt"),
+		filepath.Join(dataRoot, "last-pull-diff.json"),
+	}
+	for _, path := range paths {
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("remove %s: %w", path, err)
+		}
+	}
+
+	ts.mu.Lock()
+	ts.data = &TrashData{}
+	ts.pullError = ""
+	ts.lastChangelogDate = ""
+	ts.mu.Unlock()
+	return nil
 }
 
 // DiffChangedFiles returns a human-readable summary of files changed between two commits.

--- a/internal/core/trash.go
+++ b/internal/core/trash.go
@@ -647,17 +647,25 @@ type CommitGroupInfo struct {
 	Includes       []string // profile trash_ids in quality_profiles.include
 }
 
-// GroupsAtCommit returns cf-group trash_ids and their state at the given
-// git commit. Walks both radarr/cf-groups/ and sonarr/cf-groups/ and
-// reads each .json via `git show <commit>:<path>`. Errors are absorbed
-// (specific commit may not exist after shallow-clone re-init) — caller
-// treats empty result as "no info, leave migration entry empty".
-func (ts *TrashStore) GroupsAtCommit(commit string) map[string]CommitGroupInfo {
+// GroupsAtCommit returns cf-group trash_ids and their state at the given git
+// commit, plus whether the commit lookup succeeded. Walks both
+// radarr/cf-groups/ and sonarr/cf-groups/ and reads each .json via
+// `git show <commit>:<path>`.
+//
+// ok=false means the repo/commit could not be read, so callers should not
+// persist an empty snapshot. ok=true with an empty map is a valid lookup that
+// found no groups.
+func (ts *TrashStore) GroupsAtCommit(commit string) (map[string]CommitGroupInfo, bool) {
 	if commit == "" || ts.dataDir == "" {
-		return nil
+		return nil, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	commitCmd := exec.CommandContext(ctx, "git", "-C", ts.dataDir, "cat-file", "-e", commit+"^{commit}")
+	if err := commitCmd.Run(); err != nil {
+		return nil, false
+	}
 
 	result := make(map[string]CommitGroupInfo)
 	for _, app := range []string{"radarr", "sonarr"} {
@@ -665,7 +673,7 @@ func (ts *TrashStore) GroupsAtCommit(commit string) map[string]CommitGroupInfo {
 		listCmd := exec.CommandContext(ctx, "git", "-C", ts.dataDir, "ls-tree", "--name-only", commit, dir)
 		listOut, err := listCmd.Output()
 		if err != nil {
-			continue
+			return nil, false
 		}
 		for _, path := range strings.Split(strings.TrimSpace(string(listOut)), "\n") {
 			if !strings.HasSuffix(path, ".json") {
@@ -699,7 +707,7 @@ func (ts *TrashStore) GroupsAtCommit(commit string) map[string]CommitGroupInfo {
 			}
 		}
 	}
-	return result
+	return result, true
 }
 
 // DiffPull runs `git diff --name-status <prev>..<new> -- docs/json/` and

--- a/internal/core/trash_test.go
+++ b/internal/core/trash_test.go
@@ -1,6 +1,143 @@
 package core
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func seedTrashStoreForReset(t *testing.T) (*TrashStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	ts := NewTrashStore(dir)
+
+	if err := os.MkdirAll(filepath.Join(dir, "trash-guides", ".git"), 0755); err != nil {
+		t.Fatalf("mkdir trash-guides: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "trash-guides", "sentinel.txt"), []byte("data"), 0644); err != nil {
+		t.Fatalf("write repo sentinel: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "last-pull.txt"), []byte("2026-05-11T12:00:00Z"), 0644); err != nil {
+		t.Fatalf("write last-pull: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "last-pull-diff.json"), []byte(`{"prevCommit":"old","newCommit":"abc123","summary":"changed","time":"2026-05-11T12:00:00Z"}`), 0644); err != nil {
+		t.Fatalf("write last diff: %v", err)
+	}
+
+	ts.data = &TrashData{
+		LastPull:   time.Date(2026, time.May, 11, 12, 0, 0, 0, time.UTC),
+		CommitHash: "abc123",
+		CommitDate: "2026-05-11 12:00:00 +0000",
+		LastDiff: &PullDiff{
+			PrevCommit: "old",
+			NewCommit:  "abc123",
+			Summary:    "changed",
+			Time:       "2026-05-11T12:00:00Z",
+		},
+		Changelog: []ChangelogSection{{Date: "2026-05-11"}},
+		Radarr: AppData{
+			CustomFormats: map[string]*TrashCF{"cf1": {TrashID: "cf1"}},
+			CFGroups:      []*TrashCFGroup{{Name: "group"}},
+			Profiles:      []*TrashQualityProfile{{Name: "profile"}},
+		},
+		Sonarr: AppData{
+			CustomFormats: map[string]*TrashCF{"cf2": {TrashID: "cf2"}},
+			CFGroups:      []*TrashCFGroup{{Name: "group"}},
+			Profiles:      []*TrashQualityProfile{{Name: "profile"}},
+		},
+	}
+	ts.pullError = "previous failure"
+	ts.lastChangelogDate = "2026-05-11"
+
+	return ts, dir
+}
+
+func assertPathMissing(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("%s exists or stat failed with non-missing error: %v", path, err)
+	}
+}
+
+func assertPathExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("%s missing: %v", path, err)
+	}
+}
+
+func TestTrashStoreResetClearsLocalTrashData(t *testing.T) {
+	ts, dir := seedTrashStoreForReset(t)
+
+	if err := ts.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+
+	assertPathMissing(t, filepath.Join(dir, "trash-guides"))
+	assertPathMissing(t, filepath.Join(dir, "last-pull.txt"))
+	assertPathMissing(t, filepath.Join(dir, "last-pull-diff.json"))
+
+	st := ts.Status()
+	if st.Cloned {
+		t.Fatalf("Cloned = true, want false")
+	}
+	if st.CommitHash != "" {
+		t.Fatalf("CommitHash = %q, want empty", st.CommitHash)
+	}
+	if st.LastPull != "" {
+		t.Fatalf("LastPull = %q, want empty", st.LastPull)
+	}
+	if st.LastDiff != nil {
+		t.Fatalf("LastDiff = %#v, want nil", st.LastDiff)
+	}
+	if st.PullError != "" {
+		t.Fatalf("PullError = %q, want empty", st.PullError)
+	}
+	if st.RadarrCFs != 0 || st.SonarrCFs != 0 || st.RadarrGroups != 0 || st.SonarrGroups != 0 || st.RadarrProfs != 0 || st.SonarrProfs != 0 {
+		t.Fatalf("counts not cleared: %+v", st)
+	}
+	if ts.lastChangelogDate != "" {
+		t.Fatalf("lastChangelogDate = %q, want empty", ts.lastChangelogDate)
+	}
+}
+
+func TestTrashStoreResetIdempotentWhenFilesMissing(t *testing.T) {
+	ts := NewTrashStore(t.TempDir())
+
+	if err := ts.Reset(); err != nil {
+		t.Fatalf("first Reset: %v", err)
+	}
+	if err := ts.Reset(); err != nil {
+		t.Fatalf("second Reset: %v", err)
+	}
+
+	st := ts.Status()
+	if st.Cloned || st.CommitHash != "" || st.LastDiff != nil || st.PullError != "" {
+		t.Fatalf("status not empty after idempotent reset: %+v", st)
+	}
+}
+
+func TestTrashStoreResetBusyLeavesFilesIntact(t *testing.T) {
+	ts, dir := seedTrashStoreForReset(t)
+
+	ts.pullMu.Lock()
+	err := ts.Reset()
+	ts.pullMu.Unlock()
+
+	if !errors.Is(err, ErrTrashBusy) {
+		t.Fatalf("Reset error = %v, want ErrTrashBusy", err)
+	}
+	assertPathExists(t, filepath.Join(dir, "trash-guides"))
+	assertPathExists(t, filepath.Join(dir, "last-pull.txt"))
+	assertPathExists(t, filepath.Join(dir, "last-pull-diff.json"))
+
+	st := ts.Status()
+	if !st.Cloned || st.CommitHash == "" || st.LastDiff == nil || st.PullError == "" {
+		t.Fatalf("status was unexpectedly cleared while busy: %+v", st)
+	}
+}
 
 // CompareCFCategories drives the unified group-sort across both backend and
 // frontend (the JS _compareCFCategories mirrors this). The contract:
@@ -8,6 +145,7 @@ import "testing"
 //   - Tier 1: SQP-prefix categories
 //   - Tier 2: "Other" / unrecognised
 //   - Tier 3: Custom
+//
 // Within tier, alphabetical on category name.
 func TestCompareCFCategories_Tiering(t *testing.T) {
 	cases := []struct {
@@ -61,14 +199,14 @@ func TestCompareCFGroups_Tiering(t *testing.T) {
 	intp := func(n int) *int { return &n }
 
 	cases := []struct {
-		desc                                   string
-		aName                                  string
-		aGroup                                 *int
-		aCustom                                bool
-		bName                                  string
-		bGroup                                 *int
-		bCustom                                bool
-		want                                   int // -1, 0, +1
+		desc    string
+		aName   string
+		aGroup  *int
+		aCustom bool
+		bName   string
+		bGroup  *int
+		bCustom bool
+		want    int // -1, 0, +1
 	}{
 		// Both have Group — compare by integer
 		{"both have group, lower wins", "[Audio]", intp(1), false, "[German]", intp(11), false, -1},
@@ -112,16 +250,16 @@ func TestCompareCFGroups_Tiering(t *testing.T) {
 // upper-case "[SQP]" prefix but defensive coding for any drift.
 func TestCategoryTier_SQPCaseInsensitive(t *testing.T) {
 	cases := map[string]int{
-		"SQP":                          1,
-		"sqp-1":                        1,
-		"SqP-4 (MA Hybrid)":            1,
-		"sqp-something":                1,
-		"Audio":                        0,
-		"Custom":                       3,
-		"Other":                        2,
-		"":                             2,
-		"Streaming Services":           0,
-		"Squad":                        0, // does not start with SQP — the literal Q matters
+		"SQP":                1,
+		"sqp-1":              1,
+		"SqP-4 (MA Hybrid)":  1,
+		"sqp-something":      1,
+		"Audio":              0,
+		"Custom":             3,
+		"Other":              2,
+		"":                   2,
+		"Streaming Services": 0,
+		"Squad":              0, // does not start with SQP — the literal Q matters
 	}
 	for cat, want := range cases {
 		got := CategoryTier(cat)

--- a/internal/core/trash_test.go
+++ b/internal/core/trash_test.go
@@ -139,6 +139,52 @@ func TestTrashStoreResetBusyLeavesFilesIntact(t *testing.T) {
 	}
 }
 
+func TestTrashStoreResetWaitsForRepoReaders(t *testing.T) {
+	ts, dir := seedTrashStoreForReset(t)
+
+	ts.repoMu.RLock()
+	done := make(chan error, 1)
+	go func() {
+		done <- ts.Reset()
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if ts.Status().Pulling {
+			break
+		}
+		if time.Now().After(deadline) {
+			ts.repoMu.RUnlock()
+			t.Fatalf("timed out waiting for Reset to acquire pull lock")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case err := <-done:
+		ts.repoMu.RUnlock()
+		t.Fatalf("Reset completed while repo read lock was held: %v", err)
+	default:
+	}
+	assertPathExists(t, filepath.Join(dir, "trash-guides"))
+	assertPathExists(t, filepath.Join(dir, "last-pull.txt"))
+	assertPathExists(t, filepath.Join(dir, "last-pull-diff.json"))
+
+	ts.repoMu.RUnlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Reset after repo read lock released: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for Reset after repo read lock released")
+	}
+
+	assertPathMissing(t, filepath.Join(dir, "trash-guides"))
+	assertPathMissing(t, filepath.Join(dir, "last-pull.txt"))
+	assertPathMissing(t, filepath.Join(dir, "last-pull-diff.json"))
+}
+
 // CompareCFCategories drives the unified group-sort across both backend and
 // frontend (the JS _compareCFCategories mirrors this). The contract:
 //   - Tier 0: regular TRaSH categories (alphabetical within tier)

--- a/ui/static/css/layout.css
+++ b/ui/static/css/layout.css
@@ -15,6 +15,7 @@
   .topnav .sync-status .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--accent-green); flex-shrink: 0; }
   .topnav .sync-status .dot.stale { background: var(--accent-orange); }
   .topnav .sync-status .dot.none { background: var(--text-secondary); }
+  .topnav .trash-sync-button { gap: 4px; }
 
   /* Changelog dropdown */
   .changelog-dropdown { position: absolute; top: calc(100% + 6px); right: 0; width: 500px; background: var(--bg-card); border: 1px solid var(--border-subtle); border-radius: 8px; box-shadow: 0 8px 24px var(--alpha-shadow); z-index: 200; max-height: 420px; overflow-y: auto; }
@@ -53,4 +54,3 @@
   .section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
   .section-title { font-size: 18px; font-weight: 600; }
   .section-subtitle { font-size: 13px; color: var(--text-muted); margin-top: 4px; }
-

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -468,11 +468,11 @@ export default {
     },
 
     resetTrashData() {
-      if (this.trashResetting || this.trashStatus?.pulling || this.pulling) return;
+      if (this.trashResetting || this.trashStatus?.pulling || this.pulling || this.syncing) return;
       this.confirmModal = {
         show: true,
         title: 'Reset TRaSH Data',
-        message: 'Delete the local TRaSH Guides cache and pull metadata?\n\nUser settings, instances, sync rules, custom profiles, and custom CFs are not deleted.\n\nClonarr will show TRaSH as not cloned until you use Pull, or until the next scheduled pull runs if scheduled pulls are enabled.',
+        message: 'Delete the local TRaSH Guides cache and pull metadata?\n\nUser settings, instances, sync rules, custom profiles, and custom CFs are not deleted.\n\nAfter reset, Pull downloads a fresh TRaSH cache. If it lands on the same TRaSH commit your rules already synced, Pull will not force Arr profiles to resync. Use Sync All after Pull if you want to force an Arr refresh.',
         confirmLabel: 'Reset data',
         onConfirm: () => this._resetTrashDataConfirmed(),
       };
@@ -494,7 +494,7 @@ export default {
         }
         await this.loadTrashStatus();
         this.clearTrashDerivedCaches();
-        this.showToast('TRaSH data reset. Use Pull to download fresh data.', 'info', 5000);
+        this.showToast('TRaSH data reset. Pull downloads fresh data; use Sync All after Pull for a forced Arr refresh.', 'info', 7000);
       } catch (e) {
         this.showToast('Failed to reset TRaSH data: ' + e.message, 'error', 6000);
       } finally {

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -467,6 +467,75 @@ export default {
       }
     },
 
+    resetTrashData() {
+      if (this.trashResetting || this.trashStatus?.pulling || this.pulling) return;
+      this.confirmModal = {
+        show: true,
+        title: 'Reset TRaSH Data',
+        message: 'Delete the local TRaSH Guides cache and pull metadata?\n\nUser settings, instances, sync rules, custom profiles, and custom CFs are not deleted.\n\nClonarr will show TRaSH as not cloned until you use Pull, or until the next scheduled pull runs if scheduled pulls are enabled.',
+        confirmLabel: 'Reset data',
+        onConfirm: () => this._resetTrashDataConfirmed(),
+      };
+    },
+
+    async _resetTrashDataConfirmed() {
+      if (this.trashResetting) return;
+      this.trashResetting = true;
+      try {
+        const r = await fetch('/api/trash/reset', { method: 'POST' });
+        if (!r.ok) {
+          let msg = 'Failed to reset TRaSH data';
+          try {
+            const data = await r.json();
+            if (data?.error) msg = data.error;
+          } catch {}
+          this.showToast(msg, 'error', 6000);
+          return;
+        }
+        await this.loadTrashStatus();
+        this.clearTrashDerivedCaches();
+        this.showToast('TRaSH data reset. Use Pull to download fresh data.', 'info', 5000);
+      } catch (e) {
+        this.showToast('Failed to reset TRaSH data: ' + e.message, 'error', 6000);
+      } finally {
+        this.trashResetting = false;
+      }
+    },
+
+    clearTrashDerivedCaches() {
+      this.trashProfiles = { radarr: [], sonarr: [] };
+      this.qualitySizesPerApp = {};
+      this.cfBrowseData = {};
+      this.conflictsData = {};
+      this.namingData = {};
+
+      this.pbCategories = [];
+      this.pbScoreSets = [];
+      this.pbQualityPresets = [];
+
+      this.extraCFAllCFs = [];
+      this.extraCFGroups = [];
+      this._extraInProfileSet = null;
+
+      this.cfgbCFs = [];
+      this.cfgbGroups = [];
+      this.cfgbProfiles = [];
+      this.cfgbTrashCFGroups = [];
+      this.cfgbHasCustom = false;
+      this.cfgbUngroupedTrashCount = 0;
+      this.cfgbUngroupedRemainingCount = 0;
+      this.cfgbLoadError = '';
+      this._cfgbTrashFlat = [];
+      this._cfgbTrashGroupMap = new Map();
+      this._cfgbTrashHasCustom = false;
+      this._cfgbLoadFor = '';
+
+      this._sandboxCFCache = {};
+      this._trashScoreContextCache = {};
+      this.sandboxCFBrowser = { ...this.sandboxCFBrowser, categories: [] };
+      this.showChangelog = false;
+    },
+
     // --- Profile Detail ---
 
     // restoreFromRule controls auto-restore from existing sync rules:

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -532,7 +532,19 @@ export default {
 
       this._sandboxCFCache = {};
       this._trashScoreContextCache = {};
-      this.sandboxCFBrowser = { ...this.sandboxCFBrowser, categories: [] };
+      this.profileDetail = null;
+      this.showProfileInfo = false;
+      this.profileBuilder = false;
+      this.sandboxCFBrowser = {
+        open: false,
+        appType: '',
+        categories: [],
+        customCFs: [],
+        selected: {},
+        scores: {},
+        expanded: {},
+        filter: '',
+      };
       this.showChangelog = false;
     },
 

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -88,6 +88,7 @@ export default function baseState() {
     expandedInstances: {},
     expandedProfileGroups: {},
     pulling: false,
+    trashResetting: false,
     profileTabs: {},  // per app-type profile tab: { radarr: 'trash-sync', sonarr: 'trash-sync' }
     compareInstanceIds: {},  // per app-type: { radarr: 'id', sonarr: 'id' }
     syncRulesExpanded: {},  // per app-type: { radarr: true, sonarr: false }

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -17,7 +17,7 @@
          @keydown.escape.window="if (showChangelog) { showChangelog = false; $nextTick(() => $refs.trashChangelogButton?.focus()) }">
       <span class="dot" :class="{ stale: !trashStatus.cloned, none: !trashStatus.commitHash }"></span>
       <template x-if="trashStatus.cloned">
-        <button type="button" class="inline-action" @click="showChangelog = !showChangelog"
+        <button type="button" class="inline-action trash-sync-button" @click="showChangelog = !showChangelog"
                 x-ref="trashChangelogButton"
                 :aria-expanded="showChangelog"
                 aria-controls="trash-changelog-dropdown"
@@ -32,7 +32,12 @@
         </button>
       </template>
       <template x-if="!trashStatus.cloned">
-        <span>TRaSH not synced</span>
+        <span>
+          TRaSH not synced
+          <span class="sync-next" x-show="trashStatus.nextPull"
+                style="color:var(--text-muted);font-size:12px;margin-left:6px"
+                x-text="'· ' + nextPullLabel()"></span>
+        </span>
       </template>
       <button class="btn btn-sm" @click="pullTrash()" :disabled="pulling" style="margin-left:8px">
         <span x-show="pulling" class="spinner"></span>

--- a/ui/static/partials/sections/settings.html
+++ b/ui/static/partials/sections/settings.html
@@ -227,8 +227,22 @@
                 </span>
               </template>
               <template x-if="!trashStatus.cloned">
-                <span style="color:var(--text-muted)">Not cloned yet. Click Pull in the nav bar.</span>
+                <span style="color:var(--text-muted)">
+                  Not cloned yet. Click Pull in the nav bar<span x-show="trashStatus.nextPull" x-text="', or wait for ' + nextPullLabel()"></span>.
+                </span>
               </template>
+            </div>
+          </div>
+          <div class="setting-row">
+            <div class="setting-label">Reset TRaSH Data</div>
+            <div class="setting-value" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+              <button class="btn btn-sm btn-danger"
+                      @click="resetTrashData()"
+                      :disabled="trashStatus.pulling || pulling || trashResetting">
+                <span x-show="trashResetting" class="spinner"></span>
+                <span>Reset data</span>
+              </button>
+              <span style="font-size:12px;color:var(--text-muted)">Deletes only the local TRaSH Guides cache and pull metadata.</span>
             </div>
           </div>
         </div>

--- a/ui/static/partials/sections/settings.html
+++ b/ui/static/partials/sections/settings.html
@@ -238,11 +238,11 @@
             <div class="setting-value" style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
               <button class="btn btn-sm btn-danger"
                       @click="resetTrashData()"
-                      :disabled="trashStatus.pulling || pulling || trashResetting">
+                      :disabled="trashStatus.pulling || pulling || syncing || trashResetting">
                 <span x-show="trashResetting" class="spinner"></span>
                 <span>Reset data</span>
               </button>
-              <span style="font-size:12px;color:var(--text-muted)">Deletes only the local TRaSH Guides cache and pull metadata.</span>
+              <span style="font-size:12px;color:var(--text-muted)">Deletes only the local cache. Pull redownloads TRaSH data; Sync All forces an Arr refresh.</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Summary

Adds a reset action for local TRaSH Guides data from Settings.

### Changes

- Add POST /api/trash/reset.
- Add TrashStore.Reset() to delete:
    - trash-guides/
    - last-pull.txt
    - last-pull-diff.json
- Preserve user settings, instances, sync rules, custom profiles, custom CFs, config, and sync history.
- Clear TRaSH-derived frontend caches after reset.
- Add a Settings > TRaSH Guides Reset data button with confirmation.
- Keep scheduled pull visibility when TRaSH data is not cloned.
- Fix spacing between TRaSH synced and the sync timestamp in the top nav.