### PR TITLE
feat(cf-drift): Custom Formats → Sync Rules sub-tab + per-CF drift/update detection

### DIFF
--- a/internal/api/autosync.go
+++ b/internal/api/autosync.go
@@ -538,6 +538,7 @@ func (s *Server) handleRestoreAutoSyncRule(w http.ResponseWriter, r *http.Reques
 		Changes: &core.SyncChanges{
 			SettingsDetails: []string{fmt.Sprintf("Restored profile (created new ArrProfileID %d)", result.ArrProfileID)},
 		},
+		Categories: core.DeriveSyncCategories(result),
 	}
 	if err := s.Core.Config.UpsertSyncHistory(entry); err != nil {
 		log.Printf("Restore: failed to persist sync history: %v", err)

--- a/internal/api/cf_drift.go
+++ b/internal/api/cf_drift.go
@@ -26,7 +26,17 @@ import (
 // is loaded from the user's CustomCFs registry). Both flows resolve
 // the same TrashCF shape; the arr.ArrClient.UpdateCustomFormat call
 // is the same regardless of source.
+//
+// Guard rails:
+//   - Body capped at 4 KiB (the request is two short strings).
+//   - trashId must be managed by at least one enabled non-orphaned
+//     rule on the target instance. Without this gate an authenticated
+//     user could overwrite an unmanaged Arr CF spec by passing any
+//     trashId; with it, Apply mirrors detection's "managed" semantic.
+//   - Reconciled is only dispatched when the closure observed an
+//     actual fingerprint entry. Apply-on-clean-state stays silent.
 func (s *Server) handleCFDriftApply(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, 4096)
 	var body struct {
 		InstanceID string `json:"instanceId"`
 		TrashID    string `json:"trashId"`
@@ -53,16 +63,29 @@ func (s *Server) handleCFDriftApply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve disk spec: TRaSH or custom. resolveCFForApply mirrors the
-	// detection-side resolveCFDiskSpec helper so apply and detection
-	// can't disagree about what "clonarr's saved state" looks like.
 	appData := s.Core.Trash.GetAppData(inst.Type)
+
+	// Managed-rule gate. Walk every enabled non-orphaned rule on this
+	// instance, derive its effective CF set the same way runCFSpecDriftPass
+	// does, and require the trashId to land in that union (minus
+	// excludedCFs). Refusing here prevents a malicious or stale client
+	// from overwriting a CF Arr-side that no rule on this instance
+	// actually manages — the worst case is destroying user-curated CF
+	// edits.
+	if !cfTrashIDManagedByRules(body.TrashID, body.InstanceID, cfg, appData) {
+		writeError(w, http.StatusForbidden, "trash id is not managed by any enabled rule on this instance")
+		return
+	}
+
 	customs := s.Core.CustomCFs.List(inst.Type)
 	customsByID := make(map[string]core.CustomCF, len(customs))
 	for _, c := range customs {
 		customsByID[c.ID] = c
 	}
 
+	// Resolve disk spec: TRaSH first, custom fallback. Mirrors the
+	// detection-side resolveCFDiskSpec helper so apply and detection
+	// can't disagree about what "clonarr's saved state" looks like.
 	var diskCFName string
 	var arrCFPayload *arr.ArrCF
 	if appData != nil {
@@ -108,19 +131,21 @@ func (s *Server) handleCFDriftApply(w http.ResponseWriter, r *http.Request) {
 
 	now := time.Now().UTC().Format(time.RFC3339)
 
-	// Clear the fingerprint entry so the next Check sees in-sync state,
-	// and write a one-CF history entry so the user has audit trail.
-	// Both go through one Config.Update closure so a reader can't catch
-	// half-applied state.
+	// Clear the fingerprint entry so the next Check sees in-sync state.
+	// Capture hadDrift inside the closure so the Reconciled notification
+	// only fires when we actually transitioned from drifted→clean.
+	// Two-tab/Apply-on-clean callers stay silent instead of firing a
+	// spurious "1 custom format back in sync".
+	hadDrift := false
 	if err := s.Core.Config.Update(func(c *core.Config) {
 		for i := range c.Instances {
 			if c.Instances[i].ID != body.InstanceID {
 				continue
 			}
-			if len(c.Instances[i].CFDriftFingerprints) == 0 {
-				continue
+			if _, ok := c.Instances[i].CFDriftFingerprints[body.TrashID]; ok {
+				hadDrift = true
+				delete(c.Instances[i].CFDriftFingerprints, body.TrashID)
 			}
-			delete(c.Instances[i].CFDriftFingerprints, body.TrashID)
 			if len(c.Instances[i].CFDriftFingerprints) == 0 {
 				// Drop the map entirely so the JSON output stays
 				// quiet — omitempty doesn't fire for an empty (but
@@ -153,20 +178,78 @@ func (s *Server) handleCFDriftApply(w http.ResponseWriter, r *http.Request) {
 
 	// Fire the per-CF reconciled notification using the same path the
 	// drift pass uses. Single event so the aggregator just sends "1
-	// custom format back in sync on <instance>".
-	s.Core.NotifyCFDriftReconciled([]*core.CFDriftEvent{{
-		Event:        core.CFDriftReconciled,
-		InstanceID:   inst.ID,
-		InstanceName: inst.Name,
-		AppType:      inst.Type,
-		TrashID:      body.TrashID,
-		CFName:       diskCFName,
-	}})
+	// custom format back in sync on <instance>". Only when this Apply
+	// actually transitioned the CF from drifted to clean.
+	if hadDrift {
+		s.Core.NotifyCFDriftReconciled([]*core.CFDriftEvent{{
+			Event:        core.CFDriftReconciled,
+			InstanceID:   inst.ID,
+			InstanceName: inst.Name,
+			AppType:      inst.Type,
+			TrashID:      body.TrashID,
+			CFName:       diskCFName,
+		}})
+	}
 
 	writeJSON(w, map[string]any{
 		"appliedAt":  now,
 		"trashId":    body.TrashID,
 		"instanceId": inst.ID,
 		"name":       diskCFName,
+		"hadDrift":   hadDrift,
 	})
+}
+
+// cfTrashIDManagedByRules reports whether body.TrashID falls inside the
+// effective CF set of any enabled, non-orphaned rule targeting
+// body.InstanceID. Derivation mirrors runCFSpecDriftPass and
+// handleCFSyncRules so detection, surface, and apply share one
+// definition of "managed" — diverging them is exactly how Apply could
+// silently destroy user-curated Arr CFs.
+func cfTrashIDManagedByRules(trashID, instanceID string, cfg core.Config, appData *core.AppData) bool {
+	for _, rule := range cfg.AutoSync.Rules {
+		if !rule.Enabled || rule.OrphanedAt != "" {
+			continue
+		}
+		if rule.InstanceID != instanceID {
+			continue
+		}
+		// Excluded short-circuits even if the CF is otherwise in the
+		// default set — user explicitly opted out of syncing it.
+		excluded := false
+		for _, tid := range rule.ExcludedCFs {
+			if tid == trashID {
+				excluded = true
+				break
+			}
+		}
+		if excluded {
+			continue
+		}
+		// Selected wins outright (additive opt-in beyond defaults).
+		for _, tid := range rule.SelectedCFs {
+			if tid == trashID {
+				return true
+			}
+		}
+		// TRaSH defaults for the rule's profile.
+		if appData == nil {
+			continue
+		}
+		var profile *core.TrashQualityProfile
+		for _, p := range appData.Profiles {
+			if p.TrashID == rule.TrashProfileID {
+				profile = p
+				break
+			}
+		}
+		if profile == nil {
+			continue
+		}
+		defaults := core.ComputeTrashDefaults(profile, appData)
+		if defaults[trashID] {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/api/cf_drift.go
+++ b/internal/api/cf_drift.go
@@ -208,7 +208,11 @@ func (s *Server) handleCFDriftApply(w http.ResponseWriter, r *http.Request) {
 // silently destroy user-curated Arr CFs.
 func cfTrashIDManagedByRules(trashID, instanceID string, cfg core.Config, appData *core.AppData) bool {
 	for _, rule := range cfg.AutoSync.Rules {
-		if !rule.Enabled || rule.OrphanedAt != "" {
+		// rule.Enabled=false (paused auto-sync) is NOT a reason to
+		// refuse Apply — the rule is still configured and clonarr
+		// still owns the saved spec. Only OrphanedAt (the underlying
+		// Arr profile was deleted) makes Apply meaningless.
+		if rule.OrphanedAt != "" {
 			continue
 		}
 		if rule.InstanceID != instanceID {

--- a/internal/api/cf_drift.go
+++ b/internal/api/cf_drift.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"clonarr/internal/arr"
+	"clonarr/internal/core"
+)
+
+// handleCFDriftApply re-pushes clonarr's saved spec for a single CF on
+// a single Arr instance, overwriting whatever the user (or another
+// tool) edited directly in Arr. On success the per-(instance, trashID)
+// fingerprint is cleared from Instance.CFDriftFingerprints so the
+// next Check sees the CF as in-sync, a SyncHistoryEntry tagged "cf"
+// lands so the History tab's Custom Formats sub-tab carries an audit
+// row, and NotifyCFDriftReconciled fires per the dedup rules in
+// cf_drift.go.
+//
+// Body shape: {instanceId, trashId}. The trashId may be either a
+// real TRaSH-Guides id (in which case the spec is loaded from
+// /data/trash-guides/) or a custom: prefix (in which case the spec
+// is loaded from the user's CustomCFs registry). Both flows resolve
+// the same TrashCF shape; the arr.ArrClient.UpdateCustomFormat call
+// is the same regardless of source.
+func (s *Server) handleCFDriftApply(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		InstanceID string `json:"instanceId"`
+		TrashID    string `json:"trashId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid body: "+err.Error())
+		return
+	}
+	if body.InstanceID == "" || body.TrashID == "" {
+		writeError(w, http.StatusBadRequest, "instanceId and trashId are required")
+		return
+	}
+
+	cfg := s.Core.Config.Get()
+	var inst *core.Instance
+	for i := range cfg.Instances {
+		if cfg.Instances[i].ID == body.InstanceID {
+			inst = &cfg.Instances[i]
+			break
+		}
+	}
+	if inst == nil {
+		writeError(w, http.StatusNotFound, "instance not found")
+		return
+	}
+
+	// Resolve disk spec: TRaSH or custom. resolveCFForApply mirrors the
+	// detection-side resolveCFDiskSpec helper so apply and detection
+	// can't disagree about what "clonarr's saved state" looks like.
+	appData := s.Core.Trash.GetAppData(inst.Type)
+	customs := s.Core.CustomCFs.List(inst.Type)
+	customsByID := make(map[string]core.CustomCF, len(customs))
+	for _, c := range customs {
+		customsByID[c.ID] = c
+	}
+
+	var diskCFName string
+	var arrCFPayload *arr.ArrCF
+	if appData != nil {
+		if cf, ok := appData.CustomFormats[body.TrashID]; ok && cf != nil {
+			diskCFName = cf.Name
+			arrCFPayload = core.TrashCFToArr(cf)
+		}
+	}
+	if arrCFPayload == nil {
+		if c, ok := customsByID[body.TrashID]; ok {
+			diskCFName = c.Name
+			arrCFPayload = core.CustomCFToArr(&c)
+		}
+	}
+	if arrCFPayload == nil {
+		writeError(w, http.StatusNotFound, "trash id not in TRaSH data or custom CFs")
+		return
+	}
+
+	// Find the live CF in Arr so we know the id to PUT against.
+	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	liveCFs, err := client.ListCustomFormats()
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "list arr custom formats: "+err.Error())
+		return
+	}
+	var liveID int
+	for _, cf := range liveCFs {
+		if cf.Name == diskCFName {
+			liveID = cf.ID
+			break
+		}
+	}
+	if liveID == 0 {
+		writeError(w, http.StatusNotFound, "custom format not found in arr (it would be created on the next sync)")
+		return
+	}
+
+	if _, err := client.UpdateCustomFormat(liveID, arrCFPayload); err != nil {
+		writeError(w, http.StatusBadGateway, "update arr custom format: "+err.Error())
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Clear the fingerprint entry so the next Check sees in-sync state,
+	// and write a one-CF history entry so the user has audit trail.
+	// Both go through one Config.Update closure so a reader can't catch
+	// half-applied state.
+	if err := s.Core.Config.Update(func(c *core.Config) {
+		for i := range c.Instances {
+			if c.Instances[i].ID != body.InstanceID {
+				continue
+			}
+			if len(c.Instances[i].CFDriftFingerprints) == 0 {
+				continue
+			}
+			delete(c.Instances[i].CFDriftFingerprints, body.TrashID)
+			if len(c.Instances[i].CFDriftFingerprints) == 0 {
+				// Drop the map entirely so the JSON output stays
+				// quiet — omitempty doesn't fire for an empty (but
+				// non-nil) map.
+				c.Instances[i].CFDriftFingerprints = nil
+			}
+		}
+	}); err != nil {
+		log.Printf("cf-drift apply: clear fingerprint failed: %v", err)
+	}
+
+	entry := core.SyncHistoryEntry{
+		InstanceID:   inst.ID,
+		InstanceType: inst.Type,
+		// CF-only entries don't belong to a profile sync, so the
+		// profile fields stay empty — the History tab's Custom
+		// Formats sub-tab filters by Categories, not by profile.
+		LastSync:    now,
+		AppliedAt:   now,
+		TriggerType: core.TriggerCFDriftApply,
+		Categories:  []string{"cf"},
+		CFsUpdated:  1,
+		Changes: &core.SyncChanges{
+			CFDetails: []string{fmt.Sprintf("Re-pushed: %s (drift apply)", diskCFName)},
+		},
+	}
+	if err := s.Core.Config.UpsertSyncHistory(entry); err != nil {
+		log.Printf("cf-drift apply: persist history failed: %v", err)
+	}
+
+	// Fire the per-CF reconciled notification using the same path the
+	// drift pass uses. Single event so the aggregator just sends "1
+	// custom format back in sync on <instance>".
+	s.Core.NotifyCFDriftReconciled([]*core.CFDriftEvent{{
+		Event:        core.CFDriftReconciled,
+		InstanceID:   inst.ID,
+		InstanceName: inst.Name,
+		AppType:      inst.Type,
+		TrashID:      body.TrashID,
+		CFName:       diskCFName,
+	}})
+
+	writeJSON(w, map[string]any{
+		"appliedAt":  now,
+		"trashId":    body.TrashID,
+		"instanceId": inst.ID,
+		"name":       diskCFName,
+	})
+}

--- a/internal/api/cf_drift_diff.go
+++ b/internal/api/cf_drift_diff.go
@@ -1,0 +1,143 @@
+package api
+
+import (
+	"net/http"
+
+	"clonarr/internal/arr"
+	"clonarr/internal/core"
+)
+
+// handleCFDriftDiff returns the per-CF drift diff for a single
+// (instance, trashId) pair. Read-only — recomputes the diff on
+// demand by resolving the disk spec, fetching the live CF from
+// Arr, and running the same DiffCFSpecs that the detection pass
+// uses. Used by the Sync Rules → Custom Formats sub-tab to render
+// "what specifically drifted" inside the expanded row so the user
+// can decide whether the diff is intended (manual edit they want
+// to keep) or accidental (other tool / manual mistake to re-push).
+//
+// Path: GET /api/cf-drift/diff?instanceId=X&trashId=Y
+//
+// The handler intentionally does not consult the stored
+// CFDriftFingerprints map — recomputing against current Arr state
+// is the only way to surface a diff that's accurate at view time
+// (a CF the user just fixed manually in Arr should show no diff
+// even though the stale fingerprint still says drifted; next
+// Check tick will clear it).
+func (s *Server) handleCFDriftDiff(w http.ResponseWriter, r *http.Request) {
+	instanceID := r.URL.Query().Get("instanceId")
+	trashID := r.URL.Query().Get("trashId")
+	if instanceID == "" || trashID == "" {
+		writeError(w, http.StatusBadRequest, "instanceId and trashId are required")
+		return
+	}
+
+	cfg := s.Core.Config.Get()
+	var inst *core.Instance
+	for i := range cfg.Instances {
+		if cfg.Instances[i].ID == instanceID {
+			inst = &cfg.Instances[i]
+			break
+		}
+	}
+	if inst == nil {
+		writeError(w, http.StatusNotFound, "instance not found")
+		return
+	}
+
+	appData := s.Core.Trash.GetAppData(inst.Type)
+	customs := s.Core.CustomCFs.List(inst.Type)
+	customsByID := make(map[string]core.CustomCF, len(customs))
+	for _, c := range customs {
+		customsByID[c.ID] = c
+	}
+
+	// Disk spec — TRaSH first, custom fallback (same precedence as
+	// runCFSpecDriftPass / handleCFDriftApply so the three callers
+	// never disagree on which side counts as "saved state").
+	var diskSpec *core.TrashCF
+	var diskName string
+	if appData != nil {
+		if cf, ok := appData.CustomFormats[trashID]; ok && cf != nil {
+			diskSpec = cf
+			diskName = cf.Name
+		}
+	}
+	if diskSpec == nil {
+		if c, ok := customsByID[trashID]; ok {
+			diskName = c.Name
+			// Match the conversion the detection pass uses.
+			diskSpec = customCFToTrashSpec(c)
+		}
+	}
+	if diskSpec == nil {
+		writeError(w, http.StatusNotFound, "trash id not in TRaSH data or custom CFs")
+		return
+	}
+
+	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	liveCFs, err := client.ListCustomFormats()
+	if err != nil {
+		writeError(w, http.StatusBadGateway, "list arr custom formats: "+err.Error())
+		return
+	}
+	var live *arr.ArrCF
+	for i := range liveCFs {
+		if liveCFs[i].Name == diskName {
+			live = &liveCFs[i]
+			break
+		}
+	}
+	if live == nil {
+		// CF isn't yet in Arr — no diff to show. Returning 200 with an
+		// empty diff lets the UI render "Not yet pushed" rather than
+		// erroring out.
+		writeJSON(w, map[string]any{
+			"trashId":     trashID,
+			"instanceId":  inst.ID,
+			"name":        diskName,
+			"liveMissing": true,
+			"diff":        nil,
+		})
+		return
+	}
+
+	// Strip TrashScores on the disk-side before diffing — Arr's API
+	// doesn't return per-CF scores, so leaving them in produces N
+	// score "removed" entries per CF and turns every CF into drift.
+	// Same fix the detection pass applies.
+	diskForDiff := *diskSpec
+	diskForDiff.TrashScores = nil
+	liveAsTrashCF := core.ArrCFToTrashCFExported(live)
+	diff := core.DiffCFSpecs(&diskForDiff, liveAsTrashCF)
+
+	writeJSON(w, map[string]any{
+		"trashId":    trashID,
+		"instanceId": inst.ID,
+		"name":       diskName,
+		"diff":       diff,
+	})
+}
+
+// customCFToTrashSpec mirrors the unexported customCFToTrashCF used
+// in cf_drift.go. Kept in the api package to avoid exporting from
+// core just for this handler — the two definitions are byte-for-byte
+// equivalent and any divergence would surface immediately as a
+// detect/apply/show-diff disagreement.
+func customCFToTrashSpec(c core.CustomCF) *core.TrashCF {
+	specs := make([]core.CFSpecification, 0, len(c.Specifications))
+	for _, s := range c.Specifications {
+		specs = append(specs, core.CFSpecification{
+			Name:           s.Name,
+			Implementation: s.Implementation,
+			Negate:         s.Negate,
+			Required:       s.Required,
+			Fields:         s.Fields,
+		})
+	}
+	return &core.TrashCF{
+		Name:            c.Name,
+		IncludeInRename: c.IncludeInRename,
+		Specifications:  specs,
+	}
+}

--- a/internal/api/cf_drift_test.go
+++ b/internal/api/cf_drift_test.go
@@ -1,0 +1,155 @@
+package api
+
+import (
+	"testing"
+
+	"clonarr/internal/core"
+)
+
+// makeCFDriftFixture builds a minimal Config + AppData pair sufficient
+// for cfTrashIDManagedByRules to evaluate. Profile "p1" enables a
+// default-on group containing trash id "managed-default", a default-off
+// group containing "managed-optional", and FormatItems containing the
+// required CF "managed-required". Rule r-A targets instance inst-A
+// with that profile; rule r-disabled targets the same instance with
+// Enabled=false.
+func makeCFDriftFixture() (core.Config, *core.AppData) {
+	defTrue := true
+	defFalse := false
+	profile := &core.TrashQualityProfile{
+		TrashID: "p1",
+		Name:    "Test Profile",
+		FormatItems: map[string]string{
+			"Managed Required": "managed-required",
+		},
+	}
+	groupOn := &core.TrashCFGroup{
+		Name:    "[Default On Group]",
+		TrashID: "grp-on",
+		Default: "true",
+		CustomFormats: []core.CFGroupEntry{
+			{Name: "Managed Default", TrashID: "managed-default", Default: &defTrue},
+		},
+	}
+	groupOn.QualityProfiles.Include = map[string]string{"Test Profile": "p1"}
+	groupOff := &core.TrashCFGroup{
+		Name:    "[Default Off Group]",
+		TrashID: "grp-off",
+		Default: "false",
+		CustomFormats: []core.CFGroupEntry{
+			{Name: "Managed Optional", TrashID: "managed-optional", Default: &defFalse},
+		},
+	}
+	groupOff.QualityProfiles.Include = map[string]string{"Test Profile": "p1"}
+
+	ad := &core.AppData{
+		CustomFormats: map[string]*core.TrashCF{
+			"managed-default":  {Name: "Managed Default"},
+			"managed-optional": {Name: "Managed Optional"},
+			"managed-required": {Name: "Managed Required"},
+			"orphan":           {Name: "Orphan CF"},
+		},
+		CFGroups: []*core.TrashCFGroup{groupOn, groupOff},
+		Profiles: []*core.TrashQualityProfile{profile},
+	}
+
+	cfg := core.Config{
+		Instances: []core.Instance{
+			{ID: "inst-A", Type: "radarr", URL: "http://r/", APIKey: "k"},
+			{ID: "inst-B", Type: "radarr", URL: "http://r2/", APIKey: "k"},
+		},
+		AutoSync: core.AutoSyncConfig{
+			Rules: []core.AutoSyncRule{
+				{ID: "r-A", InstanceID: "inst-A", TrashProfileID: "p1", Enabled: true},
+				{ID: "r-disabled", InstanceID: "inst-A", TrashProfileID: "p1", Enabled: false},
+			},
+		},
+	}
+	return cfg, ad
+}
+
+func TestCFTrashIDManagedByRules_DefaultOnGroupAccepted(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	if !cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
+		t.Errorf("default-on group CF should be managed")
+	}
+}
+
+func TestCFTrashIDManagedByRules_RequiredFormatItemAccepted(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	if !cfTrashIDManagedByRules("managed-required", "inst-A", cfg, ad) {
+		t.Errorf("required FormatItem CF should be managed")
+	}
+}
+
+func TestCFTrashIDManagedByRules_OptedInViaSelectedCFs(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	cfg.AutoSync.Rules[0].SelectedCFs = []string{"managed-optional"}
+	if !cfTrashIDManagedByRules("managed-optional", "inst-A", cfg, ad) {
+		t.Errorf("CF opted in via SelectedCFs should be managed")
+	}
+}
+
+func TestCFTrashIDManagedByRules_DefaultOffNotManaged(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	if cfTrashIDManagedByRules("managed-optional", "inst-A", cfg, ad) {
+		t.Errorf("default-off CF should NOT be managed without explicit opt-in")
+	}
+}
+
+func TestCFTrashIDManagedByRules_ExcludedRejected(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	cfg.AutoSync.Rules[0].ExcludedCFs = []string{"managed-default"}
+	if cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
+		t.Errorf("excluded CF should NOT be managed even if default-on")
+	}
+}
+
+func TestCFTrashIDManagedByRules_DisabledRuleIgnored(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	// Drop the enabled rule so only the disabled one matches.
+	cfg.AutoSync.Rules = []core.AutoSyncRule{
+		{ID: "r-disabled", InstanceID: "inst-A", TrashProfileID: "p1", Enabled: false},
+	}
+	if cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
+		t.Errorf("disabled rule must not enroll CFs for Apply")
+	}
+}
+
+func TestCFTrashIDManagedByRules_OrphanedRuleIgnored(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	cfg.AutoSync.Rules = []core.AutoSyncRule{
+		{ID: "r-orphan", InstanceID: "inst-A", TrashProfileID: "p1", Enabled: true, OrphanedAt: "2026-01-01T00:00:00Z"},
+	}
+	if cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
+		t.Errorf("orphaned rule must not enroll CFs for Apply")
+	}
+}
+
+func TestCFTrashIDManagedByRules_WrongInstanceIgnored(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	if cfTrashIDManagedByRules("managed-default", "inst-B", cfg, ad) {
+		t.Errorf("rules on other instance must not enroll CFs on this instance")
+	}
+}
+
+func TestCFTrashIDManagedByRules_UnknownTrashIDRejected(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	if cfTrashIDManagedByRules("does-not-exist", "inst-A", cfg, ad) {
+		t.Errorf("unknown trash id must be rejected")
+	}
+}
+
+func TestCFTrashIDManagedByRules_NoAppDataRejectsUnselectedTID(t *testing.T) {
+	cfg, _ := makeCFDriftFixture()
+	// Without AppData we can't compute TRaSH defaults, so only the
+	// explicit SelectedCFs path can succeed. A tid relying on defaults
+	// is rejected — defense-in-depth against an AppData-empty load.
+	if cfTrashIDManagedByRules("managed-default", "inst-A", cfg, nil) {
+		t.Errorf("default-on CF must be rejected when AppData is nil")
+	}
+	cfg.AutoSync.Rules[0].SelectedCFs = []string{"explicit"}
+	if !cfTrashIDManagedByRules("explicit", "inst-A", cfg, nil) {
+		t.Errorf("explicit SelectedCFs must be accepted even with nil AppData")
+	}
+}

--- a/internal/api/cf_drift_test.go
+++ b/internal/api/cf_drift_test.go
@@ -99,20 +99,44 @@ func TestCFTrashIDManagedByRules_DefaultOffNotManaged(t *testing.T) {
 
 func TestCFTrashIDManagedByRules_ExcludedRejected(t *testing.T) {
 	cfg, ad := makeCFDriftFixture()
-	cfg.AutoSync.Rules[0].ExcludedCFs = []string{"managed-default"}
+	// Single-rule setup so the exclusion path is the only enrollment
+	// candidate. With multiple rules on the same instance, a CF
+	// excluded by one rule may still be enrolled by another — that
+	// case is covered separately.
+	cfg.AutoSync.Rules = []core.AutoSyncRule{
+		{ID: "r-A", InstanceID: "inst-A", TrashProfileID: "p1", Enabled: true,
+			ExcludedCFs: []string{"managed-default"}},
+	}
 	if cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
-		t.Errorf("excluded CF should NOT be managed even if default-on")
+		t.Errorf("excluded CF should NOT be managed even if default-on, when no other rule enrolls it")
 	}
 }
 
-func TestCFTrashIDManagedByRules_DisabledRuleIgnored(t *testing.T) {
+func TestCFTrashIDManagedByRules_ExcludedInOneRuleEnrolledByAnother(t *testing.T) {
+	cfg, ad := makeCFDriftFixture()
+	// r-A excludes the CF, but r-disabled (also on inst-A) doesn't —
+	// and with the post-Enabled-filter change, disabled rules count.
+	// "Managed by ANY rule on this instance" is the contract: if any
+	// rule needs the CF, it's a candidate for Apply.
+	cfg.AutoSync.Rules[0].ExcludedCFs = []string{"managed-default"}
+	if !cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
+		t.Errorf("CF excluded by one rule but enrolled by another should still be managed")
+	}
+}
+
+func TestCFTrashIDManagedByRules_DisabledRuleStillEnrolls(t *testing.T) {
 	cfg, ad := makeCFDriftFixture()
 	// Drop the enabled rule so only the disabled one matches.
+	// Enabled=false means "paused auto-sync schedule" — the rule is
+	// still configured and its CFs still belong to clonarr's saved
+	// spec, so drift detection processes them AND Apply must accept
+	// them. Locks in that auto-sync state is irrelevant to "is this
+	// CF managed" semantics.
 	cfg.AutoSync.Rules = []core.AutoSyncRule{
 		{ID: "r-disabled", InstanceID: "inst-A", TrashProfileID: "p1", Enabled: false},
 	}
-	if cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
-		t.Errorf("disabled rule must not enroll CFs for Apply")
+	if !cfTrashIDManagedByRules("managed-default", "inst-A", cfg, ad) {
+		t.Errorf("disabled rule should still enroll CFs for Apply — paused auto-sync is not a reason to refuse")
 	}
 }
 

--- a/internal/api/cf_sync_rules.go
+++ b/internal/api/cf_sync_rules.go
@@ -94,10 +94,15 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 		LastSync         string `json:"lastSync,omitempty"`
 	}
 	type CFRowInstance struct {
-		ID       string         `json:"id"`
-		Name     string         `json:"name"`
-		Drift    bool           `json:"drift"`
-		Profiles []CFRowProfile `json:"profiles"`
+		ID              string         `json:"id"`
+		Name            string         `json:"name"`
+		Drift           bool           `json:"drift"`
+		UpdateAvailable bool           `json:"updateAvailable"`
+		// UpdateDetails carries the per-change human-readable strings
+		// from rule.PendingChanges (source="trash"). Same format as
+		// Profile Sync's "Upcoming changes on next pull" panel uses.
+		UpdateDetails []string       `json:"updateDetails,omitempty"`
+		Profiles      []CFRowProfile `json:"profiles"`
 	}
 	type CFRow struct {
 		TrashID     string           `json:"trashId"`
@@ -178,6 +183,37 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 		// (LastSync empty + no history entry).
 		arrName := arrNameLookup[historyKey{InstanceID: rule.InstanceID, ArrProfileID: rule.ArrProfileID}]
 
+		// Index this rule's TRaSH-source pending changes by trash_id
+		// so each CF row can surface "Update available" + the
+		// per-change human-readable details Profile Sync already
+		// shows. AffectedID shapes (see watch.go):
+		//   <tid>                — generic / fallback / rename-flag
+		//   <tid>:+<condName>   — added condition
+		//   <tid>:-<condName>   — removed condition
+		//   <tid>:~<cond>:<fld> — changed condition field
+		//   <tid>:<ctx>          — score change (ctx is "default" etc)
+		// Splitting on the FIRST colon recovers the trash_id. Custom
+		// CFs use "custom:" prefix but they never have upstream TRaSH
+		// changes, so they're absent from this index — we only care
+		// about TRaSH-source entries.
+		updatesByTID := make(map[string][]string)
+		for _, pc := range rule.PendingChanges {
+			if pc.Source != "trash" {
+				continue
+			}
+			if !strings.HasPrefix(pc.ChangeType, "cf-") {
+				continue
+			}
+			pcTID := pc.AffectedID
+			if i := strings.Index(pcTID, ":"); i > 0 {
+				pcTID = pcTID[:i]
+			}
+			if pcTID == "" {
+				continue
+			}
+			updatesByTID[pcTID] = append(updatesByTID[pcTID], pc.AffectedName)
+		}
+
 		for tid := range managedTIDs {
 			if excluded[tid] {
 				continue
@@ -208,6 +244,25 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 			// the CF on that instance.
 			if _, drifted := inst.CFDriftFingerprints[tid]; drifted {
 				block.Drift = true
+			}
+			// Same union semantic for "Update available" — TRaSH
+			// upstream changes on a CF affect every rule that
+			// includes it on this instance. Dedup details across
+			// rules so the expand-row doesn't show the same
+			// "WEB Tier 01 - added X" line N times.
+			if details, has := updatesByTID[tid]; has {
+				block.UpdateAvailable = true
+				seen := make(map[string]bool, len(block.UpdateDetails))
+				for _, d := range block.UpdateDetails {
+					seen[d] = true
+				}
+				for _, d := range details {
+					if d == "" || seen[d] {
+						continue
+					}
+					seen[d] = true
+					block.UpdateDetails = append(block.UpdateDetails, d)
+				}
 			}
 			// Each rule contributes one Profile entry per
 			// (CF, instance) pair. Dedup by ruleID in case a CF is

--- a/internal/api/cf_sync_rules.go
+++ b/internal/api/cf_sync_rules.go
@@ -1,0 +1,219 @@
+package api
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"clonarr/internal/core"
+)
+
+// handleCFSyncRules returns the per-instance per-CF state that drives
+// the Sync Rules → Custom Formats sub-tab. One row per (instance,
+// trashId) currently managed by any enabled rule on the instance,
+// annotated with the four state signals the pill renderer needs:
+// drift (from Instance.CFDriftFingerprints), update available (TRaSH
+// upstream advanced since last sync), used-by-profiles (derived from
+// rule + profile data so the row shows "Used by SQP-3, SQP-4"), and a
+// short category bucket so the default "By Group" sort has something
+// to group on.
+//
+// Pure derivation — no state writes — so calling this from a Check
+// completion handler or from a tab-mount fetcher is cheap and safe to
+// repeat. The frontend re-fetches after Apply / drift refresh.
+//
+// Path: GET /api/cf-sync-rules/{appType}
+func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
+	appType := r.PathValue("appType")
+	if appType != "radarr" && appType != "sonarr" {
+		writeError(w, http.StatusBadRequest, "appType must be radarr or sonarr")
+		return
+	}
+
+	cfg := s.Core.Config.Get()
+	appData := s.Core.Trash.GetAppData(appType)
+	customs := s.Core.CustomCFs.List(appType)
+	customsByID := make(map[string]core.CustomCF, len(customs))
+	for _, c := range customs {
+		customsByID[c.ID] = c
+	}
+
+	// Per-CF category lookup. Walks ad.CFGroups to find which category
+	// each trash id belongs to; CFs that live directly in
+	// profile.FormatItems (Required CFs without a source cf-group) fall
+	// back to the "Required" bucket; customs land in "Custom".
+	cfCategory := func(tid string) string {
+		if strings.HasPrefix(tid, "custom:") {
+			return "Custom"
+		}
+		if appData != nil {
+			for _, g := range appData.CFGroups {
+				for _, cfEntry := range g.CustomFormats {
+					if cfEntry.TrashID == tid {
+						cat, _ := core.ParseCategoryPrefix(g.Name)
+						if cat == "" {
+							cat = "Other"
+						}
+						return cat
+					}
+				}
+			}
+		}
+		return "Other"
+	}
+
+	type ProfileRef struct {
+		ProfileName string `json:"profileName"`
+		RuleID      string `json:"ruleId"`
+	}
+	type InstanceState struct {
+		ID              string `json:"id"`
+		Name            string `json:"name"`
+		Drift           bool   `json:"drift"`
+		UpdateAvailable bool   `json:"updateAvailable"`
+	}
+	type CFRow struct {
+		TrashID        string         `json:"trashId"`
+		Name           string         `json:"name"`
+		Category       string         `json:"category"`
+		Instances      []InstanceState `json:"instances"`
+		UsedByProfiles []ProfileRef   `json:"usedByProfiles"`
+		UsedByRules    []string       `json:"usedByRules"`
+	}
+
+	// Build the row map keyed by trashId. Each row aggregates state
+	// across every instance the CF is managed on, plus the usage list
+	// derived from rules.
+	rowsByTID := make(map[string]*CFRow)
+
+	// Pre-build per-instance lookup for the name resolution helper.
+	instByID := make(map[string]core.Instance, len(cfg.Instances))
+	for _, inst := range cfg.Instances {
+		if inst.Type != appType {
+			continue
+		}
+		instByID[inst.ID] = inst
+	}
+
+	for _, rule := range cfg.AutoSync.Rules {
+		if !rule.Enabled || rule.OrphanedAt != "" {
+			continue
+		}
+		inst, ok := instByID[rule.InstanceID]
+		if !ok {
+			continue
+		}
+
+		var profile *core.TrashQualityProfile
+		if appData != nil {
+			for _, p := range appData.Profiles {
+				if p.TrashID == rule.TrashProfileID {
+					profile = p
+					break
+				}
+			}
+		}
+		if profile == nil {
+			continue
+		}
+
+		// Effective CF set = TRaSH defaults + explicit opt-ins - opt-outs.
+		// Matches the detection-side derivation in cf_drift.go.
+		managedTIDs := core.ComputeTrashDefaults(profile, appData)
+		for _, tid := range rule.SelectedCFs {
+			managedTIDs[tid] = true
+		}
+		excluded := make(map[string]bool, len(rule.ExcludedCFs))
+		for _, tid := range rule.ExcludedCFs {
+			excluded[tid] = true
+		}
+
+		for tid := range managedTIDs {
+			if excluded[tid] {
+				continue
+			}
+			row, ok := rowsByTID[tid]
+			if !ok {
+				name := tid
+				if appData != nil {
+					if cf, ok := appData.CustomFormats[tid]; ok && cf != nil {
+						name = cf.Name
+					}
+				}
+				if c, ok := customsByID[tid]; ok {
+					name = c.Name
+				}
+				row = &CFRow{
+					TrashID:  tid,
+					Name:     name,
+					Category: cfCategory(tid),
+				}
+				rowsByTID[tid] = row
+			}
+			// Drift flag for this instance.
+			drifted := false
+			if _, ok := inst.CFDriftFingerprints[tid]; ok {
+				drifted = true
+			}
+			// Add or update the instance entry.
+			found := false
+			for i := range row.Instances {
+				if row.Instances[i].ID == inst.ID {
+					row.Instances[i].Drift = row.Instances[i].Drift || drifted
+					found = true
+					break
+				}
+			}
+			if !found {
+				row.Instances = append(row.Instances, InstanceState{
+					ID:    inst.ID,
+					Name:  inst.Name,
+					Drift: drifted,
+				})
+			}
+			// Profile + rule usage. Dedupe by (profileName, ruleID).
+			ref := ProfileRef{ProfileName: profile.Name, RuleID: rule.ID}
+			dup := false
+			for _, p := range row.UsedByProfiles {
+				if p.RuleID == ref.RuleID && p.ProfileName == ref.ProfileName {
+					dup = true
+					break
+				}
+			}
+			if !dup {
+				row.UsedByProfiles = append(row.UsedByProfiles, ref)
+			}
+			ruleDup := false
+			for _, rid := range row.UsedByRules {
+				if rid == rule.ID {
+					ruleDup = true
+					break
+				}
+			}
+			if !ruleDup {
+				row.UsedByRules = append(row.UsedByRules, rule.ID)
+			}
+		}
+	}
+
+	// Flatten, sort by Category then Name so the default render order
+	// matches the "By Group" sort the frontend exposes by default.
+	out := make([]*CFRow, 0, len(rowsByTID))
+	for _, row := range rowsByTID {
+		sort.Slice(row.Instances, func(i, j int) bool { return row.Instances[i].Name < row.Instances[j].Name })
+		sort.Slice(row.UsedByProfiles, func(i, j int) bool { return row.UsedByProfiles[i].ProfileName < row.UsedByProfiles[j].ProfileName })
+		sort.Strings(row.UsedByRules)
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Category != out[j].Category {
+			return out[i].Category < out[j].Category
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	writeJSON(w, map[string]any{
+		"appType": appType,
+		"items":   out,
+	})
+}

--- a/internal/api/cf_sync_rules.go
+++ b/internal/api/cf_sync_rules.go
@@ -8,21 +8,18 @@ import (
 	"clonarr/internal/core"
 )
 
-// handleCFSyncRules returns the per-instance per-CF state that drives
-// the Sync Rules → Custom Formats sub-tab. One row per (instance,
-// trashId) currently managed by any enabled rule on the instance,
-// annotated with the four state signals the pill renderer needs:
-// drift (from Instance.CFDriftFingerprints), update available (TRaSH
-// upstream advanced since last sync), used-by-profiles (derived from
-// rule + profile data so the row shows "Used by SQP-3, SQP-4"), and a
-// short category bucket so the default "By Group" sort has something
-// to group on.
-//
-// Pure derivation — no state writes — so calling this from a Check
-// completion handler or from a tab-mount fetcher is cheap and safe to
-// repeat. The frontend re-fetches after Apply / drift refresh.
+// handleCFSyncRules returns the per-CF state the Custom Formats →
+// Sync Rules sub-tab renders. Output is structured to mirror the
+// Profile Sync Rules tab's per-instance cards: one block per Arr
+// instance carrying that instance's CFs, each CF carrying which
+// profiles (TRaSH name + Arr name + Arr ID) pull it in, the rule's
+// auto-sync state, and the last successful sync timestamp.
 //
 // Path: GET /api/cf-sync-rules/{appType}
+//
+// Pure derivation — no state writes — so calling this from a Check
+// completion handler or from a tab-mount fetcher is cheap and safe
+// to repeat. The frontend re-fetches after Apply / drift refresh.
 func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 	appType := r.PathValue("appType")
 	if appType != "radarr" && appType != "sonarr" {
@@ -38,55 +35,97 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 		customsByID[c.ID] = c
 	}
 
-	// Per-CF category lookup. Walks ad.CFGroups to find which category
-	// each trash id belongs to; CFs that live directly in
-	// profile.FormatItems (Required CFs without a source cf-group) fall
-	// back to the "Required" bucket; customs land in "Custom".
-	cfCategory := func(tid string) string {
+	// Build (instanceID, arrProfileID) → ArrProfileName lookup from
+	// sync history. The rule itself carries Arr ID but not the name;
+	// the name was captured at last sync. Without this the UI would
+	// only show "ID 4" instead of "HD-1080p (Movies) (ID 4)".
+	type historyKey struct {
+		InstanceID   string
+		ArrProfileID int
+	}
+	arrNameLookup := make(map[historyKey]string)
+	for _, e := range cfg.SyncHistory {
+		if e.ArrProfileName == "" {
+			continue
+		}
+		k := historyKey{InstanceID: e.InstanceID, ArrProfileID: e.ArrProfileID}
+		// SyncHistory is PREPENDED (newest-first; see
+		// ConfigStore.UpsertSyncHistory at config.go:1245), so the
+		// FIRST iteration of the slice carries the newest name. Take
+		// the first match per (instance, arrProfileID) key and skip
+		// later iterations — otherwise the OLDEST name overwrites
+		// every newer one and a user who renamed their profile in
+		// Arr's UI keeps seeing the pre-rename label.
+		if _, seen := arrNameLookup[k]; seen {
+			continue
+		}
+		arrNameLookup[k] = e.ArrProfileName
+	}
+
+	// Per-CF category resolver. Uses TRaSH cf-group bracket prefix
+	// (e.g. "[Audio Formats] Default" → parent="Audio Formats",
+	// child="Default") so the sidebar can mirror Browse's hierarchy.
+	cfCategory := func(tid string) (parent string, child string) {
 		if strings.HasPrefix(tid, "custom:") {
-			return "Custom"
+			return "Custom", ""
 		}
 		if appData != nil {
 			for _, g := range appData.CFGroups {
 				for _, cfEntry := range g.CustomFormats {
 					if cfEntry.TrashID == tid {
-						cat, _ := core.ParseCategoryPrefix(g.Name)
+						cat, short := core.ParseCategoryPrefix(g.Name)
 						if cat == "" {
 							cat = "Other"
 						}
-						return cat
+						return cat, short
 					}
 				}
 			}
 		}
-		return "Other"
+		return "Other", ""
 	}
 
-	type ProfileRef struct {
-		ProfileName string `json:"profileName"`
-		RuleID      string `json:"ruleId"`
+	type CFRowProfile struct {
+		TrashProfileName string `json:"trashProfileName"`
+		ArrProfileName   string `json:"arrProfileName,omitempty"`
+		ArrProfileID     int    `json:"arrProfileId"`
+		RuleID           string `json:"ruleId"`
+		AutoSyncEnabled  bool   `json:"autoSyncEnabled"`
+		LastSync         string `json:"lastSync,omitempty"`
 	}
-	type InstanceState struct {
-		ID              string `json:"id"`
-		Name            string `json:"name"`
-		Drift           bool   `json:"drift"`
-		UpdateAvailable bool   `json:"updateAvailable"`
+	type CFRowInstance struct {
+		ID       string         `json:"id"`
+		Name     string         `json:"name"`
+		Drift    bool           `json:"drift"`
+		Profiles []CFRowProfile `json:"profiles"`
 	}
 	type CFRow struct {
-		TrashID        string         `json:"trashId"`
-		Name           string         `json:"name"`
-		Category       string         `json:"category"`
-		Instances      []InstanceState `json:"instances"`
-		UsedByProfiles []ProfileRef   `json:"usedByProfiles"`
-		UsedByRules    []string       `json:"usedByRules"`
+		TrashID     string           `json:"trashId"`
+		Name        string           `json:"name"`
+		Category    string           `json:"category"`
+		Subcategory string           `json:"subcategory,omitempty"`
+		Instances   []*CFRowInstance `json:"instances"`
 	}
 
-	// Build the row map keyed by trashId. Each row aggregates state
-	// across every instance the CF is managed on, plus the usage list
-	// derived from rules.
 	rowsByTID := make(map[string]*CFRow)
+	// Per-row helper: get-or-create the per-instance block.
+	getInstanceBlock := func(row *CFRow, inst core.Instance) *CFRowInstance {
+		for _, b := range row.Instances {
+			if b.ID == inst.ID {
+				return b
+			}
+		}
+		block := &CFRowInstance{
+			ID:    inst.ID,
+			Name:  inst.Name,
+			Drift: false,
+		}
+		row.Instances = append(row.Instances, block)
+		return block
+	}
 
-	// Pre-build per-instance lookup for the name resolution helper.
+	// Per-app-type instance lookup. Filtering rules by instance type
+	// happens here so cross-app data doesn't leak into a Radarr view.
 	instByID := make(map[string]core.Instance, len(cfg.Instances))
 	for _, inst := range cfg.Instances {
 		if inst.Type != appType {
@@ -96,7 +135,11 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, rule := range cfg.AutoSync.Rules {
-		if !rule.Enabled || rule.OrphanedAt != "" {
+		// OrphanedAt hides a rule (Arr profile gone). Enabled=false
+		// is NOT a filter — paused rules are still configured and
+		// their CFs still belong to clonarr's saved spec; users need
+		// to see them to act on drift.
+		if rule.OrphanedAt != "" {
 			continue
 		}
 		inst, ok := instByID[rule.InstanceID]
@@ -104,6 +147,7 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		// Find the TRaSH profile referenced by this rule.
 		var profile *core.TrashQualityProfile
 		if appData != nil {
 			for _, p := range appData.Profiles {
@@ -117,8 +161,9 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		// Effective CF set = TRaSH defaults + explicit opt-ins - opt-outs.
-		// Matches the detection-side derivation in cf_drift.go.
+		// Effective CF set = TRaSH defaults + explicit opt-ins -
+		// explicit opt-outs. Mirrors runCFSpecDriftPass exactly so
+		// detection, view, and Apply share one "managed" definition.
 		managedTIDs := core.ComputeTrashDefaults(profile, appData)
 		for _, tid := range rule.SelectedCFs {
 			managedTIDs[tid] = true
@@ -127,6 +172,11 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 		for _, tid := range rule.ExcludedCFs {
 			excluded[tid] = true
 		}
+
+		// Resolve the Arr profile name from history. Falls back to
+		// the TRaSH profile name when the rule has never synced
+		// (LastSync empty + no history entry).
+		arrName := arrNameLookup[historyKey{InstanceID: rule.InstanceID, ArrProfileID: rule.ArrProfileID}]
 
 		for tid := range managedTIDs {
 			if excluded[tid] {
@@ -143,71 +193,69 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 				if c, ok := customsByID[tid]; ok {
 					name = c.Name
 				}
+				parent, child := cfCategory(tid)
 				row = &CFRow{
-					TrashID:  tid,
-					Name:     name,
-					Category: cfCategory(tid),
+					TrashID:     tid,
+					Name:        name,
+					Category:    parent,
+					Subcategory: child,
 				}
 				rowsByTID[tid] = row
 			}
-			// Drift flag for this instance.
-			drifted := false
-			if _, ok := inst.CFDriftFingerprints[tid]; ok {
-				drifted = true
+			block := getInstanceBlock(row, inst)
+			// Drift carries across all rules — one rule pulling a
+			// CF that has drifted on the instance is enough to flag
+			// the CF on that instance.
+			if _, drifted := inst.CFDriftFingerprints[tid]; drifted {
+				block.Drift = true
 			}
-			// Add or update the instance entry.
-			found := false
-			for i := range row.Instances {
-				if row.Instances[i].ID == inst.ID {
-					row.Instances[i].Drift = row.Instances[i].Drift || drifted
-					found = true
+			// Each rule contributes one Profile entry per
+			// (CF, instance) pair. Dedup by ruleID in case a CF is
+			// reachable via multiple paths within the same rule
+			// (e.g. SelectedCFs AND defaults).
+			alreadySeen := false
+			for _, p := range block.Profiles {
+				if p.RuleID == rule.ID {
+					alreadySeen = true
 					break
 				}
 			}
-			if !found {
-				row.Instances = append(row.Instances, InstanceState{
-					ID:    inst.ID,
-					Name:  inst.Name,
-					Drift: drifted,
+			if !alreadySeen {
+				block.Profiles = append(block.Profiles, CFRowProfile{
+					TrashProfileName: profile.Name,
+					ArrProfileName:   arrName,
+					ArrProfileID:     rule.ArrProfileID,
+					RuleID:           rule.ID,
+					AutoSyncEnabled:  rule.Enabled,
+					LastSync:         rule.LastSyncTime,
 				})
-			}
-			// Profile + rule usage. Dedupe by (profileName, ruleID).
-			ref := ProfileRef{ProfileName: profile.Name, RuleID: rule.ID}
-			dup := false
-			for _, p := range row.UsedByProfiles {
-				if p.RuleID == ref.RuleID && p.ProfileName == ref.ProfileName {
-					dup = true
-					break
-				}
-			}
-			if !dup {
-				row.UsedByProfiles = append(row.UsedByProfiles, ref)
-			}
-			ruleDup := false
-			for _, rid := range row.UsedByRules {
-				if rid == rule.ID {
-					ruleDup = true
-					break
-				}
-			}
-			if !ruleDup {
-				row.UsedByRules = append(row.UsedByRules, rule.ID)
 			}
 		}
 	}
 
-	// Flatten, sort by Category then Name so the default render order
-	// matches the "By Group" sort the frontend exposes by default.
+	// Stable sort: rows by category then name; instances by name;
+	// profiles by Arr profile name then TRaSH name. Deterministic
+	// output keeps Alpine x-for keys stable across re-fetches so
+	// expanded rows don't jump.
 	out := make([]*CFRow, 0, len(rowsByTID))
 	for _, row := range rowsByTID {
 		sort.Slice(row.Instances, func(i, j int) bool { return row.Instances[i].Name < row.Instances[j].Name })
-		sort.Slice(row.UsedByProfiles, func(i, j int) bool { return row.UsedByProfiles[i].ProfileName < row.UsedByProfiles[j].ProfileName })
-		sort.Strings(row.UsedByRules)
+		for _, b := range row.Instances {
+			sort.Slice(b.Profiles, func(i, j int) bool {
+				if b.Profiles[i].ArrProfileName != b.Profiles[j].ArrProfileName {
+					return b.Profiles[i].ArrProfileName < b.Profiles[j].ArrProfileName
+				}
+				return b.Profiles[i].TrashProfileName < b.Profiles[j].TrashProfileName
+			})
+		}
 		out = append(out, row)
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Category != out[j].Category {
 			return out[i].Category < out[j].Category
+		}
+		if out[i].Subcategory != out[j].Subcategory {
+			return out[i].Subcategory < out[j].Subcategory
 		}
 		return out[i].Name < out[j].Name
 	})

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -125,6 +125,7 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/profile-sync/check", s.handleProfileSyncCheck)
 	mux.HandleFunc("POST /api/drift/check", s.handleDriftCheck)
 	mux.HandleFunc("POST /api/cf-drift/apply", s.handleCFDriftApply)
+	mux.HandleFunc("GET /api/cf-drift/diff", s.handleCFDriftDiff)
 	mux.HandleFunc("GET /api/cf-sync-rules/{appType}", s.handleCFSyncRules)
 
 	// Cleanup events

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -124,6 +124,8 @@ func (s *Server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /api/profile-sync", s.handlePutProfileSync)
 	mux.HandleFunc("POST /api/profile-sync/check", s.handleProfileSyncCheck)
 	mux.HandleFunc("POST /api/drift/check", s.handleDriftCheck)
+	mux.HandleFunc("POST /api/cf-drift/apply", s.handleCFDriftApply)
+	mux.HandleFunc("GET /api/cf-sync-rules/{appType}", s.handleCFSyncRules)
 
 	// Cleanup events
 	mux.HandleFunc("GET /api/cleanup-events", s.handleCleanupEvents)

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -393,6 +393,7 @@ func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
 		LastSync:          now,
 		Changes:           changes,
 		TriggerType:       core.TriggerTypeFromSource(triggerSource),
+		Categories:        core.DeriveSyncCategories(result),
 	}
 	// AppliedAt freezes the "when changes landed" timestamp. Only set when
 	// the entry carries real changes — baseline / no-op entries leave it

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -560,6 +560,33 @@ func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
 					syncedCFs = append(syncedCFs, a.TrashID)
 				}
 				cfg.AutoSync.Rules[i].PriorSyncedCFs = syncedCFs
+				// Mirror autosync.go's UpdateAutoSyncRuleCommit fingerprint
+				// clear (introduced 2026-06-02 for Profile Sync ↔ CF Sync
+				// pill consistency). Without this on the manual sync path,
+				// users clicking Sync Now from Profile Sync Rules see the
+				// profile pill flip to "in sync" while the CF Sync Rules
+				// pills stay stuck on "Arr drift" until the next scheduled
+				// drift pass. After a successful push the live Arr spec
+				// matches disk by definition, so prior drift is reconciled.
+				if len(syncedCFs) > 0 {
+					instID := cfg.AutoSync.Rules[i].InstanceID
+					for j := range cfg.Instances {
+						if cfg.Instances[j].ID != instID {
+							continue
+						}
+						fp := cfg.Instances[j].CFDriftFingerprints
+						if len(fp) == 0 {
+							break
+						}
+						for _, tid := range syncedCFs {
+							delete(fp, tid)
+						}
+						if len(fp) == 0 {
+							cfg.Instances[j].CFDriftFingerprints = nil
+						}
+						break
+					}
+				}
 				return
 			}
 		}
@@ -598,6 +625,29 @@ func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
 			PriorAvailableGroups: priorGroups,
 			PriorSyncedCFs:       newSyncedCFs,
 		})
+		// Same fingerprint clear as the update-existing-rule branch.
+		// Edge case: another rule on this instance was already pushing
+		// these CFs and they had drifted; creating a fresh rule that
+		// pushes them again reconciles Arr ↔ disk for those tids
+		// regardless of which rule owns the push semantically.
+		if len(newSyncedCFs) > 0 {
+			for j := range cfg.Instances {
+				if cfg.Instances[j].ID != req.InstanceID {
+					continue
+				}
+				fp := cfg.Instances[j].CFDriftFingerprints
+				if len(fp) == 0 {
+					break
+				}
+				for _, tid := range newSyncedCFs {
+					delete(fp, tid)
+				}
+				if len(fp) == 0 {
+					cfg.Instances[j].CFDriftFingerprints = nil
+				}
+				break
+			}
+		}
 	})
 
 	writeJSON(w, result)

--- a/internal/api/watch.go
+++ b/internal/api/watch.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"sort"
 	"time"
 
 	"clonarr/internal/core"
@@ -143,8 +144,78 @@ func (s *Server) handleDriftCheck(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 500, "drift check failed: "+err.Error())
 		return
 	}
+
+	// Read per-instance CF drift fingerprints persisted by the pass we
+	// just ran. The frontend renders a per-CF status pill (one entry
+	// per drifted CF per instance) and the Check completion toast uses
+	// the summary counts to compose a single one-line message instead
+	// of N badges. Empty array (not null) so the frontend can detect
+	// "no drift" cleanly without nil-guarding.
+	cfg := s.Core.Config.Get()
+	type cfDriftEntry struct {
+		InstanceID   string `json:"instanceId"`
+		InstanceName string `json:"instanceName"`
+		AppType      string `json:"appType"`
+		TrashID      string `json:"trashId"`
+		Name         string `json:"name"`
+	}
+	cfDrift := []cfDriftEntry{}
+	for _, inst := range cfg.Instances {
+		if len(inst.CFDriftFingerprints) == 0 {
+			continue
+		}
+		appData := s.Core.Trash.GetAppData(inst.Type)
+		customs := s.Core.CustomCFs.List(inst.Type)
+		customsByID := make(map[string]core.CustomCF, len(customs))
+		for _, c := range customs {
+			customsByID[c.ID] = c
+		}
+		// Stable order so the JSON output round-trips identically on
+		// repeated GETs that didn't actually change state.
+		tids := make([]string, 0, len(inst.CFDriftFingerprints))
+		for tid := range inst.CFDriftFingerprints {
+			tids = append(tids, tid)
+		}
+		sort.Strings(tids)
+		for _, tid := range tids {
+			name := tid
+			if appData != nil {
+				if cf, ok := appData.CustomFormats[tid]; ok && cf != nil {
+					name = cf.Name
+				}
+			}
+			if c, ok := customsByID[tid]; ok {
+				name = c.Name
+			}
+			cfDrift = append(cfDrift, cfDriftEntry{
+				InstanceID:   inst.ID,
+				InstanceName: inst.Name,
+				AppType:      inst.Type,
+				TrashID:      tid,
+				Name:         name,
+			})
+		}
+	}
+
+	// Aggregate counters for the Check completion toast. The frontend
+	// composes the toast from the three channels — profile drift, CF
+	// drift, TRaSH-Guides updates — and omits empty channels so the
+	// message reads "Check complete. Everything is in sync." when all
+	// three are clean.
+	profilesDrifted := 0
+	for _, dr := range results {
+		if dr.DriftDetected {
+			profilesDrifted++
+		}
+	}
+
 	writeJSON(w, map[string]any{
 		"checkedAt": time.Now().UTC().Format(time.RFC3339),
 		"results":   results,
+		"cfDrift":   cfDrift,
+		"summary": map[string]int{
+			"profilesDrifted": profilesDrifted,
+			"cfsDrifted":      len(cfDrift),
+		},
 	})
 }

--- a/internal/core/autosync.go
+++ b/internal/core/autosync.go
@@ -248,6 +248,33 @@ const (
 // a one-line summary string for the changed case (empty for the others).
 // The caller composes these into the tick-summary line so the trace
 // shows exactly which rules contributed work without per-rule fanout.
+
+// DeriveSyncCategories classifies what kind of state a SyncResult
+// touched so SyncHistoryEntry.Categories can drive the History tab's
+// Profile / Custom Formats sub-tab filter. Returns:
+//   - "cf"      when the sync wrote a CF entity to Arr (create / update
+//     / drift-apply produced an action on the /customformat endpoint).
+//   - "profile" when the sync changed profile-level state (scores,
+//     quality items, settings, profile creation).
+// A regular sync that touches both gets both tags; either-only flows
+// get the single applicable tag; a no-op sync returns nil so the
+// resulting omitempty field keeps the JSON quiet for the 70-80% of
+// auto-syncs that didn't actually change anything.
+func DeriveSyncCategories(result *SyncResult) []string {
+	if result == nil {
+		return nil
+	}
+	var cats []string
+	if result.CFsCreated > 0 || result.CFsUpdated > 0 || len(result.CFSpecDiffs) > 0 {
+		cats = append(cats, "cf")
+	}
+	if result.ScoresUpdated > 0 || result.ScoresZeroed > 0 || result.QualityUpdated ||
+		len(result.SettingsDetails) > 0 || result.ProfileCreated {
+		cats = append(cats, "profile")
+	}
+	return cats
+}
+
 func (app *App) runAutoSyncRule(rule AutoSyncRule, currentCommit string, parent *Operation) (ruleOutcome, string) {
 	// Re-check rule still exists (may have been deleted since snapshot was taken)
 	cfg := app.Config.Get()
@@ -634,6 +661,7 @@ func (app *App) runAutoSyncRule(rule AutoSyncRule, currentCommit string, parent 
 		LastSync:          now,
 		Changes:           changes,
 		TriggerType:       parent.SourceTrigger(),
+		Categories:        DeriveSyncCategories(result),
 	}
 	// Freeze AppliedAt on real-change entries so the History tab's "Last
 	// Changed" column shows when changes actually landed, not when the last

--- a/internal/core/autosync.go
+++ b/internal/core/autosync.go
@@ -1753,6 +1753,34 @@ func (app *App) UpdateAutoSyncRuleCommit(ruleID, commit string, priorGroups map[
 				if priorSyncedCFs != nil {
 					cfg.AutoSync.Rules[i].PriorSyncedCFs = priorSyncedCFs
 				}
+				// Clear per-CF drift fingerprints on this rule's
+				// instance for every CF the sync just pushed. Without
+				// this the CF Sync Rules view keeps showing "Arr drift"
+				// even after a successful sync — Profile Sync Rules
+				// would say "in sync" (WatchState cleared above) but
+				// the per-CF surface stays stuck until the next Check
+				// pass recomputes Instance.CFDriftFingerprints. After
+				// a successful push the live Arr spec matches disk by
+				// definition, so the prior drift is reconciled.
+				if len(priorSyncedCFs) > 0 {
+					instID := cfg.AutoSync.Rules[i].InstanceID
+					for j := range cfg.Instances {
+						if cfg.Instances[j].ID != instID {
+							continue
+						}
+						fp := cfg.Instances[j].CFDriftFingerprints
+						if len(fp) == 0 {
+							break
+						}
+						for _, tid := range priorSyncedCFs {
+							delete(fp, tid)
+						}
+						if len(fp) == 0 {
+							cfg.Instances[j].CFDriftFingerprints = nil
+						}
+						break
+					}
+				}
 				return
 			}
 		}

--- a/internal/core/cf_diff.go
+++ b/internal/core/cf_diff.go
@@ -182,21 +182,32 @@ func DiffCFSpecs(before, after *TrashCF) *CFSpecDiff {
 				After:  strconv.FormatBool(as.Required),
 			})
 		}
-		// Compare on the RENDERED value rather than raw JSON bytes:
-		// Arr's API returns Fields in the [{name,value},...] shape
-		// while TRaSH JSON stores them as flat {value:...} objects, so
-		// raw-byte comparison flags every spec as "changed" even when
-		// nothing moved. The rendered value uses shape-agnostic
-		// extraction (see extractField) and only differs when the
-		// underlying value actually differs.
-		beforeVal := renderSpecValue(bs.Implementation, bs.Fields)
-		afterVal := renderSpecValue(as.Implementation, as.Fields)
-		if beforeVal != afterVal {
+		// Equality gate uses ExtractFieldValue + valuesEqual — the
+		// SAME comparison sync.go's cfSpecsMatch uses to decide if a CF
+		// needs pushing. Using renderSpecValue here previously caused
+		// false-positive drift: renderSpecValue's `default` case
+		// (any spec implementation not in its switch) falls through to
+		// renderRaw which re-marshals the raw bytes. TRaSH disk shape
+		// {"value":X} and Arr live shape [{"name":"value","value":X}]
+		// then produce different strings even when the underlying
+		// value is identical, and every such CF instantly flags drift
+		// the moment any Arr-only spec-type ships (typical: new Sonarr
+		// implementation, future Radarr addition).
+		//
+		// Aligning to sync's comparator guarantees the invariant:
+		// any CF sync would skip with Action="unchanged" must
+		// ALSO be considered "no drift" by detection. Strings shown
+		// in the Before/After fields still use renderSpecValue so the
+		// History UI keeps its human-readable rendering — those are
+		// only computed when an actual change is detected.
+		beforeRaw := ExtractFieldValue(bs.Fields)
+		afterRaw := ExtractFieldValue(as.Fields)
+		if !valuesEqual(beforeRaw, afterRaw) {
 			d.ChangedConditions = append(d.ChangedConditions, ConditionChange{
 				Name: name, Implementation: as.Implementation,
 				Field:  "value",
-				Before: beforeVal,
-				After:  afterVal,
+				Before: renderSpecValue(bs.Implementation, bs.Fields),
+				After:  renderSpecValue(as.Implementation, as.Fields),
 			})
 		}
 	}
@@ -485,6 +496,13 @@ var languageLabels = map[int]string{
 	30: "Portuguese (Brazil)",
 	31: "Arabic",
 	32: "Ukrainian",
+}
+
+// ArrCFToTrashCFExported is the public wrapper for arrCFToTrashCF
+// so the api package's diff-detail handler can reuse the conversion
+// without exporting the lowercase implementation.
+func ArrCFToTrashCFExported(a *arr.ArrCF) *TrashCF {
+	return arrCFToTrashCF(a)
 }
 
 // arrCFToTrashCF converts an Arr-side CustomFormat into the

--- a/internal/core/cf_diff_sync_parity_test.go
+++ b/internal/core/cf_diff_sync_parity_test.go
@@ -1,0 +1,190 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"clonarr/internal/arr"
+)
+
+// Lock-in tests for the invariant: anything sync.go's cfSpecsMatch
+// considers "match" (Action="unchanged") must ALSO be considered
+// "no drift" by DiffCFSpecs. Without this guarantee, a CF that
+// sync skipped during Update all immediately flags drift on the
+// next Check pass — exactly the 91-of-199-false-positives bug the
+// initial implementation produced.
+//
+// The two real-world shape divergences the tests exercise:
+//
+//   1. TRaSH disk format ships fields as a flat object:
+//        {"value": "BluRay"}
+//   2. Arr's API returns fields as a name/value array:
+//        [{"name":"value","value":"BluRay"}]
+//
+// Both shapes carry the same semantic value; only the JSON wire
+// shape differs. cfSpecsMatch bridges them via ExtractFieldValue;
+// DiffCFSpecs must do the same.
+
+// trashSpec is a small helper for building TrashCF fixtures with
+// the flat-object field shape TRaSH JSONs use.
+func trashSpec(name, impl string, fields string) CFSpecification {
+	return CFSpecification{
+		Name:           name,
+		Implementation: impl,
+		Fields:         json.RawMessage(fields),
+	}
+}
+
+// arrSpec mirrors trashSpec for Arr's array shape.
+func arrSpec(name, impl string, fields string) arr.ArrSpecification {
+	return arr.ArrSpecification{
+		Name:           name,
+		Implementation: impl,
+		Fields:         json.RawMessage(fields),
+	}
+}
+
+// TestDiffCFSpecs_NoFalseDriftOnShapeDivergence — the canonical
+// regression. A TRaSH CF on disk (flat-object fields) matches the
+// SAME CF live in Arr (array fields). cfSpecsMatch returns true;
+// DiffCFSpecs must report no drift. Covers a representative spec
+// implementation that lives in renderSpecValue's `default` branch
+// so the fix path (ExtractFieldValue + valuesEqual) is the actual
+// equality gate, not the rendered-string compare.
+func TestDiffCFSpecs_NoFalseDriftOnShapeDivergence(t *testing.T) {
+	trashCF := &TrashCF{
+		Name:            "x265 (HD)",
+		IncludeInRename: false,
+		Specifications: []CFSpecification{
+			// SizeSpecification isn't in renderSpecValue's switch the
+			// same way ReleaseGroupSpecification is — but the bigger
+			// fault was any impl falling through to renderRaw. Use a
+			// representative case that the original code path would
+			// have flagged.
+			trashSpec("Size Constraint", "SizeSpecification", `{"min":4000,"max":8000}`),
+		},
+	}
+	arrCF := &arr.ArrCF{
+		Name:                            "x265 (HD)",
+		IncludeCustomFormatWhenRenaming: false,
+		Specifications: []arr.ArrSpecification{
+			arrSpec("Size Constraint", "SizeSpecification",
+				`[{"name":"min","value":4000},{"name":"max","value":8000}]`),
+		},
+	}
+	if !cfSpecsMatch(trashCF, arrCF) {
+		t.Fatalf("sync engine considers these matching; drift logic must agree")
+	}
+	diff := DiffCFSpecs(trashCF, arrCFToTrashCF(arrCF))
+	if diff != nil && diff.HasAny() {
+		t.Errorf("DiffCFSpecs flagged drift on a sync-matching CF: %+v", diff)
+	}
+}
+
+// TestDiffCFSpecs_ReleaseGroupShapeDivergenceClean — known-handled
+// implementation (ReleaseGroupSpecification IS in renderSpecValue's
+// switch). Both before and after the fix this should pass; we lock
+// it in so a future refactor of the switch can't regress.
+func TestDiffCFSpecs_ReleaseGroupShapeDivergenceClean(t *testing.T) {
+	trashCF := &TrashCF{
+		Name: "Bad Release Group",
+		Specifications: []CFSpecification{
+			trashSpec("Block Group", "ReleaseGroupSpecification", `{"value":"BAD-RG"}`),
+		},
+	}
+	arrCF := &arr.ArrCF{
+		Name: "Bad Release Group",
+		Specifications: []arr.ArrSpecification{
+			arrSpec("Block Group", "ReleaseGroupSpecification",
+				`[{"name":"value","value":"BAD-RG"}]`),
+		},
+	}
+	diff := DiffCFSpecs(trashCF, arrCFToTrashCF(arrCF))
+	if diff != nil && diff.HasAny() {
+		t.Errorf("DiffCFSpecs flagged drift on ReleaseGroup with shape-only diff: %+v", diff)
+	}
+}
+
+// TestDiffCFSpecs_GenuineValueChangeStillDetected — the fix must not
+// regress real drift detection. Same shape on both sides, different
+// underlying value → drift fires.
+func TestDiffCFSpecs_GenuineValueChangeStillDetected(t *testing.T) {
+	before := &TrashCF{
+		Name: "Block Group",
+		Specifications: []CFSpecification{
+			trashSpec("Block", "ReleaseGroupSpecification", `{"value":"BAD-RG"}`),
+		},
+	}
+	after := &TrashCF{
+		Name: "Block Group",
+		Specifications: []CFSpecification{
+			trashSpec("Block", "ReleaseGroupSpecification", `{"value":"OTHER-RG"}`),
+		},
+	}
+	diff := DiffCFSpecs(before, after)
+	if diff == nil || !diff.HasAny() {
+		t.Fatal("DiffCFSpecs missed a genuine value change")
+	}
+	if len(diff.ChangedConditions) != 1 || diff.ChangedConditions[0].Field != "value" {
+		t.Errorf("expected one value ChangedCondition, got %+v", diff.ChangedConditions)
+	}
+}
+
+// TestDiffCFSpecs_DoesNotConfuseScoresWithSpecDrift — the second
+// real-world false-positive source. Disk-side TrashCF carries
+// TrashScores (every CF in TRaSH data has them); arrCFToTrashCF
+// leaves TrashScores nil because Arr's CF API doesn't return scores.
+// If cf_drift.go's pass passed the disk spec verbatim, every CF
+// would produce N ScoreChange entries → drift fires on virtually
+// every CF the first Check pass. The fix nil-s TrashScores on the
+// disk-side copy before diffing. This test locks in that contract:
+// CFs that ONLY differ by TrashScores presence are not drift.
+func TestDiffCFSpecs_DoesNotConfuseScoresWithSpecDrift(t *testing.T) {
+	disk := TrashCF{
+		Name:            "WEB Tier 01",
+		IncludeInRename: false,
+		TrashScores: map[string]int{
+			"default": 3000,
+			"sqp-3":   2200,
+		},
+		Specifications: []CFSpecification{
+			trashSpec("WEB Tier 01 regex", "ReleaseTitleSpecification", `{"value":"(?i)tier1"}`),
+		},
+	}
+	// Drift detection's stripping path: clone disk-side with TrashScores nil.
+	diskForDiff := disk
+	diskForDiff.TrashScores = nil
+	live := &TrashCF{
+		Name:           "WEB Tier 01",
+		Specifications: []CFSpecification{trashSpec("WEB Tier 01 regex", "ReleaseTitleSpecification", `[{"name":"value","value":"(?i)tier1"}]`)},
+	}
+	diff := DiffCFSpecs(&diskForDiff, live)
+	if diff != nil && diff.HasAny() {
+		t.Errorf("DiffCFSpecs flagged drift on a score-only divergence: %+v", diff)
+	}
+}
+
+// TestDiffCFSpecs_NumericTypeTolerance — Arr may return numeric
+// fields decoded as float64 while custom CFs stored locally can be
+// strings. valuesEqual handles the conversion; DiffCFSpecs must too
+// (via the same valuesEqual path now). Covers the IndexerFlag case
+// where Arr returns an integer and TRaSH disk might have authored
+// it as a string in some files.
+func TestDiffCFSpecs_NumericTypeTolerance(t *testing.T) {
+	before := &TrashCF{
+		Name: "Freeleech",
+		Specifications: []CFSpecification{
+			trashSpec("Flag", "IndexerFlagSpecification", `{"value":1}`),
+		},
+	}
+	after := &TrashCF{
+		Name: "Freeleech",
+		Specifications: []CFSpecification{
+			trashSpec("Flag", "IndexerFlagSpecification", `[{"name":"value","value":1}]`),
+		},
+	}
+	diff := DiffCFSpecs(before, after)
+	if diff != nil && diff.HasAny() {
+		t.Errorf("DiffCFSpecs flagged drift on a numeric-equal value across shapes: %+v", diff)
+	}
+}

--- a/internal/core/cf_drift.go
+++ b/internal/core/cf_drift.go
@@ -1,0 +1,524 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"clonarr/internal/arr"
+)
+
+// CF spec drift detection pass — the third pass run by DriftRunner
+// after TRaSH-upstream detection (the ProfileSyncRunner channel) and
+// profile-level drift (drift.go). Compares each Arr instance's live CF
+// specs against the TRaSH-Guides or user-custom spec on disk and
+// reports when someone (the user, another tool, or a CF rebuild done
+// directly in Arr) has diverged the live CF from the spec clonarr
+// pushed.
+//
+// Detection is derive-on-demand: no LastPushed snapshot persists in
+// clonarr.json. The "before" side comes from `/data/trash-guides/` for
+// TRaSH-managed CFs or from the in-memory CustomCFs registry for user
+// custom CFs. The "after" side is the live ArrCF fetched via the
+// shared instCache. DiffCFSpecs (cf_diff.go) does the comparison; this
+// file owns the per-instance walk + fingerprint state + notification
+// dispatch.
+//
+// Persistence: Instance.CFDriftFingerprints holds one sha256 entry per
+// drifted CF per instance, with the entry absent meaning "not drifted".
+// Identical fingerprint between Check passes is the same drift; a
+// changed fingerprint means new or evolved drift (re-notify); a clear
+// transition fires Reconciled. Notification dispatch reuses the
+// existing OnDriftDetected per-agent flag per design decision §10.5.
+
+// cfDriftEvent describes one CF-drift state transition that needs to
+// notify an agent. Built during the pass, dispatched after the
+// Config.Update closure releases its lock so provider HTTP calls
+// (Discord, Gotify, NTFY) don't hold locks.
+type cfDriftEvent struct {
+	Event        cfDriftEventKind
+	InstanceID   string
+	InstanceName string
+	AppType      string
+	TrashID      string
+	CFName       string
+	Diff         *CFSpecDiff
+}
+
+type cfDriftEventKind int
+
+const (
+	cfDriftDetected cfDriftEventKind = iota
+	cfDriftReconciled
+)
+
+// cfDriftPassResult collects the outcome of a single CF spec drift
+// pass: per-instance per-CF fingerprint updates to persist, and the
+// queued notification events. The DriftRunner threads these into its
+// existing Config.Update / dispatch flow.
+type cfDriftPassResult struct {
+	// FingerprintsByInstance maps Instance.ID → trashID → fingerprint.
+	// An empty string fingerprint means "drift cleared on this CF" and
+	// asks the persistence step to delete the map entry.
+	FingerprintsByInstance map[string]map[string]string
+	// Events queued for notification dispatch after persistence.
+	Events []*cfDriftEvent
+	// CFCount is the number of currently-drifted CFs across all
+	// instances after this pass. Surfaces in the /api/drift/check
+	// summary block.
+	CFCount int
+}
+
+// runCFSpecDriftPass walks every instance touched by the profile drift
+// pass and, for each managed CF on that instance, diffs the disk spec
+// against the live Arr spec. Builds the cfDriftPassResult that the
+// caller persists + dispatches alongside profile drift.
+//
+// Managed CFs are the union of every eligible rule's effective CF set
+// on each instance — derived from rule.SelectedCFs + the profile's
+// default-on cf-groups, mirroring what BuildArrProfile would push on a
+// sync. CFs the rule explicitly excluded via rule.ExcludedCFs are
+// skipped (the user opted out of drift coverage by opting out of the
+// sync itself).
+//
+// A CF the user has not yet pushed to Arr (no live entry for the CF
+// name) is silently skipped — the very next sync will create it, and
+// flagging "drift" before the entity exists would be misleading.
+func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*arrSnapshot) *cfDriftPassResult {
+	out := &cfDriftPassResult{
+		FingerprintsByInstance: make(map[string]map[string]string),
+	}
+
+	// Group rules by instance so we walk each instance exactly once.
+	rulesByInst := make(map[string][]ruleWork)
+	for _, w := range work {
+		rulesByInst[w.instance.ID] = append(rulesByInst[w.instance.ID], w)
+	}
+
+	cfg := d.app.Config.Get()
+	// Quick lookup: instance ID → Instance struct so we can read the
+	// existing CFDriftFingerprints map without holding the Config lock.
+	instByID := make(map[string]Instance, len(cfg.Instances))
+	for _, inst := range cfg.Instances {
+		instByID[inst.ID] = inst
+	}
+
+	for instID, rules := range rulesByInst {
+		inst, ok := instByID[instID]
+		if !ok {
+			continue
+		}
+		snap, ok := instCache[instID]
+		if !ok || snap.err != nil {
+			continue
+		}
+
+		// Live CF lookup by name. Live ArrCFs do not carry trash_id;
+		// the matching is name-based because that's what Arr itself
+		// uses to identify a CF entity.
+		liveByName := make(map[string]*arr.ArrCF, len(snap.cfs))
+		for i := range snap.cfs {
+			liveByName[snap.cfs[i].Name] = &snap.cfs[i]
+		}
+
+		appData := d.app.Trash.GetAppData(inst.Type)
+		if appData == nil {
+			continue
+		}
+		customCFs := d.app.CustomCFs.List(inst.Type)
+		customsByID := make(map[string]CustomCF, len(customCFs))
+		for _, c := range customCFs {
+			customsByID[c.ID] = c
+		}
+
+		// Aggregate the set of CF trash ids that any rule on this
+		// instance considers "managed". Rule-level opt-outs (excludedCFs)
+		// short-circuit so a user who explicitly removed a required CF
+		// from the sync set isn't pestered about drift on it.
+		managedTIDs := make(map[string]bool)
+		excludedTIDs := make(map[string]bool)
+		for _, w := range rules {
+			rule := w.rule
+			// Find the profile referenced by this rule so we can derive
+			// its effective CF set the same way BuildArrProfile would.
+			var profile *TrashQualityProfile
+			for _, p := range appData.Profiles {
+				if p.TrashID == rule.TrashProfileID {
+					profile = p
+					break
+				}
+			}
+			if profile == nil {
+				continue
+			}
+			defaults := ComputeTrashDefaults(profile, appData)
+			for tid := range defaults {
+				managedTIDs[tid] = true
+			}
+			for _, tid := range rule.SelectedCFs {
+				managedTIDs[tid] = true
+			}
+			for _, tid := range rule.ExcludedCFs {
+				excludedTIDs[tid] = true
+			}
+		}
+
+		// Build the per-instance fingerprint delta. priorFP carries the
+		// fingerprint from the LAST pass (if any); newFP is what this
+		// pass computes. The state machine compares them per CF.
+		priorFP := inst.CFDriftFingerprints
+		newFP := make(map[string]string)
+
+		for tid := range managedTIDs {
+			if excludedTIDs[tid] {
+				continue
+			}
+
+			diskSpec, cfName, ok := resolveCFDiskSpec(tid, appData, customsByID)
+			if !ok {
+				continue
+			}
+
+			live, ok := liveByName[cfName]
+			if !ok {
+				// CF managed by rule but not yet in Arr; the next sync
+				// will push it, no drift to flag.
+				continue
+			}
+
+			liveAsTrashCF := arrCFToTrashCF(live)
+			diff := DiffCFSpecs(diskSpec, liveAsTrashCF)
+			if !diff.HasAny() {
+				continue
+			}
+
+			fp := computeCFSpecDiffFingerprint(diff)
+			newFP[tid] = fp
+
+			prev := priorFP[tid]
+			switch {
+			case prev == "":
+				// Newly detected drift.
+				out.Events = append(out.Events, &cfDriftEvent{
+					Event:        cfDriftDetected,
+					InstanceID:   inst.ID,
+					InstanceName: inst.Name,
+					AppType:      inst.Type,
+					TrashID:      tid,
+					CFName:       cfName,
+					Diff:         diff,
+				})
+			case prev != fp:
+				// Drift changed shape — re-notify so the user knows the
+				// state evolved (e.g. one condition resolved while a new
+				// one appeared).
+				out.Events = append(out.Events, &cfDriftEvent{
+					Event:        cfDriftDetected,
+					InstanceID:   inst.ID,
+					InstanceName: inst.Name,
+					AppType:      inst.Type,
+					TrashID:      tid,
+					CFName:       cfName,
+					Diff:         diff,
+				})
+			}
+		}
+
+		// Reconciled transitions: any CF that had a fingerprint in the
+		// prior pass but is missing from newFP cleared this round.
+		for tid, prev := range priorFP {
+			if prev == "" {
+				continue
+			}
+			if _, stillDrifted := newFP[tid]; stillDrifted {
+				continue
+			}
+			cfName := tid
+			if d, _, ok := resolveCFDiskSpec(tid, appData, customsByID); ok {
+				cfName = d.Name
+			}
+			out.Events = append(out.Events, &cfDriftEvent{
+				Event:        cfDriftReconciled,
+				InstanceID:   inst.ID,
+				InstanceName: inst.Name,
+				AppType:      inst.Type,
+				TrashID:      tid,
+				CFName:       cfName,
+				// Diff intentionally nil — there's nothing to render.
+			})
+		}
+
+		if len(newFP) > 0 || len(priorFP) > 0 {
+			out.FingerprintsByInstance[instID] = newFP
+		}
+		out.CFCount += len(newFP)
+	}
+
+	return out
+}
+
+// resolveCFDiskSpec returns the disk-side TrashCF for a given trash ID,
+// trying TRaSH-Guides data first and falling back to the user's custom
+// CF registry. Returns the CF's display name as a convenience for the
+// caller's notification + reconciled-event paths. The bool is false
+// when neither source has the id, which means a dangling reference
+// (custom CF deleted but rule still references it) — drift skips it.
+func resolveCFDiskSpec(tid string, appData *AppData, customsByID map[string]CustomCF) (*TrashCF, string, bool) {
+	if appData != nil {
+		if cf, ok := appData.CustomFormats[tid]; ok && cf != nil {
+			return cf, cf.Name, true
+		}
+	}
+	if c, ok := customsByID[tid]; ok {
+		return customCFToTrashCF(c), c.Name, true
+	}
+	return nil, "", false
+}
+
+// customCFToTrashCF converts a user-managed CustomCF into the TrashCF
+// shape DiffCFSpecs consumes. The Specifications field carries
+// ArrSpecification (the format the user authored against), so each
+// entry maps cleanly into CFSpecification with the raw Fields blob
+// passed through.
+func customCFToTrashCF(c CustomCF) *TrashCF {
+	specs := make([]CFSpecification, 0, len(c.Specifications))
+	for _, s := range c.Specifications {
+		specs = append(specs, CFSpecification{
+			Name:           s.Name,
+			Implementation: s.Implementation,
+			Negate:         s.Negate,
+			Required:       s.Required,
+			Fields:         s.Fields,
+		})
+	}
+	return &TrashCF{
+		Name:            c.Name,
+		IncludeInRename: c.IncludeInRename,
+		Specifications:  specs,
+	}
+}
+
+// computeCFSpecDiffFingerprint returns a stable sha256 hex digest of
+// the CFSpecDiff for use as a state-transition key. Two diffs producing
+// the same fingerprint represent the same drift; a different
+// fingerprint means the drift evolved and the user should be
+// re-notified.
+//
+// Canonical form: every slice is sorted by a deterministic key before
+// JSON-marshaling, so the order of conditions Arr returned in doesn't
+// produce a spurious fingerprint change between runs.
+func computeCFSpecDiffFingerprint(diff *CFSpecDiff) string {
+	if diff == nil {
+		return ""
+	}
+	canonical := struct {
+		Added    []ConditionRef    `json:"a,omitempty"`
+		Removed  []ConditionRef    `json:"r,omitempty"`
+		Changed  []ConditionChange `json:"c,omitempty"`
+		Settings []SettingChange   `json:"s,omitempty"`
+		Scores   []CFScoreChange   `json:"sc,omitempty"`
+	}{
+		Added:    append([]ConditionRef(nil), diff.AddedConditions...),
+		Removed:  append([]ConditionRef(nil), diff.RemovedConditions...),
+		Changed:  append([]ConditionChange(nil), diff.ChangedConditions...),
+		Settings: append([]SettingChange(nil), diff.SettingsChanges...),
+		Scores:   append([]CFScoreChange(nil), diff.ScoreChanges...),
+	}
+	sort.SliceStable(canonical.Added, func(i, j int) bool {
+		return canonical.Added[i].Name+canonical.Added[i].Implementation <
+			canonical.Added[j].Name+canonical.Added[j].Implementation
+	})
+	sort.SliceStable(canonical.Removed, func(i, j int) bool {
+		return canonical.Removed[i].Name+canonical.Removed[i].Implementation <
+			canonical.Removed[j].Name+canonical.Removed[j].Implementation
+	})
+	sort.SliceStable(canonical.Changed, func(i, j int) bool {
+		ai := canonical.Changed[i]
+		aj := canonical.Changed[j]
+		return ai.Name+ai.Field < aj.Name+aj.Field
+	})
+	sort.SliceStable(canonical.Settings, func(i, j int) bool {
+		return canonical.Settings[i].Field < canonical.Settings[j].Field
+	})
+	sort.SliceStable(canonical.Scores, func(i, j int) bool {
+		return canonical.Scores[i].Context < canonical.Scores[j].Context
+	})
+	buf, err := json.Marshal(canonical)
+	if err != nil {
+		// Cannot marshal — return a deterministic non-empty marker so
+		// the state machine treats subsequent passes as identical
+		// rather than oscillating. Should never trip in practice; only
+		// possible if the struct shape changes incompatibly.
+		return "marshal-error"
+	}
+	sum := sha256.Sum256(buf)
+	return hex.EncodeToString(sum[:])
+}
+
+// NotifyCFDriftDetected fires the per-CF drift detected notification.
+// Reuses the existing OnDriftDetected per-agent flag (design decision
+// §10.5) so the user opts in to "Arr drift" coverage once and gets
+// both profile + CF channels. Aggregation across a single Check pass
+// happens at the dispatch level — see runOnceInternal for the call
+// shape that collects N events into a single message per agent.
+func (app *App) NotifyCFDriftDetected(events []*cfDriftEvent) {
+	if len(events) == 0 {
+		return
+	}
+	cfg := app.Config.Get()
+
+	// Group by instance + app type so the message reads "3 custom
+	// formats have drifted on Radarr (main)" rather than one line per
+	// CF, matching profile drift's tone.
+	type instGroup struct {
+		instanceName string
+		appType      string
+		cfs          []string
+	}
+	groups := make(map[string]*instGroup)
+	for _, e := range events {
+		key := e.InstanceID
+		g, ok := groups[key]
+		if !ok {
+			g = &instGroup{instanceName: e.InstanceName, appType: e.AppType}
+			groups[key] = g
+		}
+		g.cfs = append(g.cfs, e.CFName)
+	}
+
+	var titleParts []string
+	var descParts []string
+	totalCFs := 0
+	for _, g := range groups {
+		sort.Strings(g.cfs)
+		totalCFs += len(g.cfs)
+		appLabel := "Radarr"
+		if g.appType == "sonarr" {
+			appLabel = "Sonarr"
+		}
+		titleParts = append(titleParts, fmt.Sprintf("%s (%s)", appLabel, g.instanceName))
+		descParts = append(descParts, fmt.Sprintf("**%s (%s)** %d custom format%s:\n- %s",
+			appLabel, g.instanceName, len(g.cfs),
+			plural(len(g.cfs)),
+			joinTrunc(g.cfs, "\n- ", 10)))
+	}
+	sort.Strings(titleParts)
+	sort.Strings(descParts)
+
+	title := fmt.Sprintf("Clonarr: %d custom format%s drifted in Arr",
+		totalCFs, plural(totalCFs))
+	description := ""
+	for _, p := range descParts {
+		if description != "" {
+			description += "\n\n"
+		}
+		description += p
+	}
+
+	payload := NotificationPayload{
+		Title:    title,
+		Message:  description,
+		Color:    0xf85149, // red, matches profile-drift detected
+		Severity: NotificationSeverityWarning,
+	}
+	for _, agent := range cfg.AutoSync.NotificationAgents {
+		if !agent.Events.OnDriftDetected {
+			continue
+		}
+		app.dispatchNotification(agent, payload)
+	}
+}
+
+// NotifyCFDriftReconciled fires the cleared-drift companion to
+// NotifyCFDriftDetected. Same per-agent gating (OnDriftReconciled) and
+// the same per-instance aggregation so a single "3 custom formats are
+// back in sync on Radarr (main)" message lands instead of one ping
+// per CF.
+func (app *App) NotifyCFDriftReconciled(events []*cfDriftEvent) {
+	if len(events) == 0 {
+		return
+	}
+	cfg := app.Config.Get()
+
+	type instGroup struct {
+		instanceName string
+		appType      string
+		cfs          []string
+	}
+	groups := make(map[string]*instGroup)
+	for _, e := range events {
+		key := e.InstanceID
+		g, ok := groups[key]
+		if !ok {
+			g = &instGroup{instanceName: e.InstanceName, appType: e.AppType}
+			groups[key] = g
+		}
+		g.cfs = append(g.cfs, e.CFName)
+	}
+
+	var descParts []string
+	totalCFs := 0
+	for _, g := range groups {
+		sort.Strings(g.cfs)
+		totalCFs += len(g.cfs)
+		appLabel := "Radarr"
+		if g.appType == "sonarr" {
+			appLabel = "Sonarr"
+		}
+		descParts = append(descParts, fmt.Sprintf("**%s (%s)** %d custom format%s:\n- %s",
+			appLabel, g.instanceName, len(g.cfs),
+			plural(len(g.cfs)),
+			joinTrunc(g.cfs, "\n- ", 10)))
+	}
+	sort.Strings(descParts)
+
+	title := fmt.Sprintf("Clonarr: %d custom format%s back in sync",
+		totalCFs, plural(totalCFs))
+	description := ""
+	for _, p := range descParts {
+		if description != "" {
+			description += "\n\n"
+		}
+		description += p
+	}
+
+	payload := NotificationPayload{
+		Title:    title,
+		Message:  description,
+		Color:    0x3fb950, // green, matches profile-drift reconciled
+		Severity: NotificationSeverityInfo,
+	}
+	for _, agent := range cfg.AutoSync.NotificationAgents {
+		if !agent.Events.OnDriftReconciled {
+			continue
+		}
+		app.dispatchNotification(agent, payload)
+	}
+}
+
+// joinTrunc joins names with sep, capping at limit and appending
+// " (+N more)" when more entries existed. Keeps the Discord embed
+// readable when a single Check pass produces 20+ drifted CFs.
+func joinTrunc(items []string, sep string, limit int) string {
+	if len(items) <= limit {
+		out := ""
+		for i, s := range items {
+			if i > 0 {
+				out += sep
+			}
+			out += s
+		}
+		return out
+	}
+	visible := items[:limit]
+	out := ""
+	for i, s := range visible {
+		if i > 0 {
+			out += sep
+		}
+		out += s
+	}
+	return out + fmt.Sprintf("%s(+ %d more)", sep, len(items)-limit)
+}

--- a/internal/core/cf_drift.go
+++ b/internal/core/cf_drift.go
@@ -63,6 +63,14 @@ type cfDriftPassResult struct {
 	// An empty string fingerprint means "drift cleared on this CF" and
 	// asks the persistence step to delete the map entry.
 	FingerprintsByInstance map[string]map[string]string
+	// PriorByInstance is the per-instance snapshot of
+	// CFDriftFingerprints taken at the START of this pass. The
+	// persistence step compares each tid's current on-disk value
+	// against this snapshot before writing: when the live value
+	// diverges (an Apply landed mid-pass and cleared the fingerprint),
+	// our stale newFP is discarded so we never resurrect drift state
+	// the user just resolved.
+	PriorByInstance map[string]map[string]string
 	// Events queued for notification dispatch after persistence.
 	Events []*CFDriftEvent
 	// CFCount is the number of currently-drifted CFs across all
@@ -89,6 +97,7 @@ type cfDriftPassResult struct {
 func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*arrSnapshot) *cfDriftPassResult {
 	out := &cfDriftPassResult{
 		FingerprintsByInstance: make(map[string]map[string]string),
+		PriorByInstance:        make(map[string]map[string]string),
 	}
 
 	// Group rules by instance so we walk each instance exactly once.
@@ -111,7 +120,15 @@ func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*a
 			continue
 		}
 		snap, ok := instCache[instID]
-		if !ok || snap.err != nil {
+		if !ok {
+			continue
+		}
+		// snap.err may be non-nil from a LATER fetch in the chain (e.g.
+		// Radarr's ListLanguages) while snap.cfs is fully populated.
+		// Profile-drift surfaces the instance-level error separately;
+		// CF drift just needs the CF slice to do its work, so gate on
+		// the slice rather than the overall error.
+		if snap.cfs == nil {
 			continue
 		}
 
@@ -168,7 +185,20 @@ func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*a
 		// Build the per-instance fingerprint delta. priorFP carries the
 		// fingerprint from the LAST pass (if any); newFP is what this
 		// pass computes. The state machine compares them per CF.
+		//
+		// Capture the prior snapshot into the result so the persistence
+		// closure can detect mid-pass Apply mutations: if a tid's
+		// on-disk value differs from this snapshot at write time,
+		// Apply (or another writer) intervened and our newFP entry is
+		// already stale relative to the user's intent.
 		priorFP := inst.CFDriftFingerprints
+		if len(priorFP) > 0 {
+			snapshot := make(map[string]string, len(priorFP))
+			for k, v := range priorFP {
+				snapshot[k] = v
+			}
+			out.PriorByInstance[instID] = snapshot
+		}
 		newFP := make(map[string]string)
 
 		for tid := range managedTIDs {
@@ -228,11 +258,20 @@ func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*a
 
 		// Reconciled transitions: any CF that had a fingerprint in the
 		// prior pass but is missing from newFP cleared this round.
+		// CFs that fell out of managedTIDs (rule disabled, opted out,
+		// or CF removed from TRaSH data) get the same persistence-side
+		// cleanup (they drop from FingerprintsByInstance) but DO NOT
+		// fire Reconciled — they aren't "back in sync", they're "no
+		// longer in scope". Emitting Reconciled there would say the
+		// drift resolved when really clonarr just stopped looking.
 		for tid, prev := range priorFP {
 			if prev == "" {
 				continue
 			}
 			if _, stillDrifted := newFP[tid]; stillDrifted {
+				continue
+			}
+			if !managedTIDs[tid] || excludedTIDs[tid] {
 				continue
 			}
 			cfName := tid

--- a/internal/core/cf_drift.go
+++ b/internal/core/cf_drift.go
@@ -33,12 +33,12 @@ import (
 // transition fires Reconciled. Notification dispatch reuses the
 // existing OnDriftDetected per-agent flag per design decision §10.5.
 
-// cfDriftEvent describes one CF-drift state transition that needs to
+// CFDriftEvent describes one CF-drift state transition that needs to
 // notify an agent. Built during the pass, dispatched after the
 // Config.Update closure releases its lock so provider HTTP calls
 // (Discord, Gotify, NTFY) don't hold locks.
-type cfDriftEvent struct {
-	Event        cfDriftEventKind
+type CFDriftEvent struct {
+	Event        CFDriftEventKind
 	InstanceID   string
 	InstanceName string
 	AppType      string
@@ -47,11 +47,11 @@ type cfDriftEvent struct {
 	Diff         *CFSpecDiff
 }
 
-type cfDriftEventKind int
+type CFDriftEventKind int
 
 const (
-	cfDriftDetected cfDriftEventKind = iota
-	cfDriftReconciled
+	CFDriftDetected CFDriftEventKind = iota
+	CFDriftReconciled
 )
 
 // cfDriftPassResult collects the outcome of a single CF spec drift
@@ -64,7 +64,7 @@ type cfDriftPassResult struct {
 	// asks the persistence step to delete the map entry.
 	FingerprintsByInstance map[string]map[string]string
 	// Events queued for notification dispatch after persistence.
-	Events []*cfDriftEvent
+	Events []*CFDriftEvent
 	// CFCount is the number of currently-drifted CFs across all
 	// instances after this pass. Surfaces in the /api/drift/check
 	// summary block.
@@ -201,8 +201,8 @@ func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*a
 			switch {
 			case prev == "":
 				// Newly detected drift.
-				out.Events = append(out.Events, &cfDriftEvent{
-					Event:        cfDriftDetected,
+				out.Events = append(out.Events, &CFDriftEvent{
+					Event:        CFDriftDetected,
 					InstanceID:   inst.ID,
 					InstanceName: inst.Name,
 					AppType:      inst.Type,
@@ -214,8 +214,8 @@ func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*a
 				// Drift changed shape — re-notify so the user knows the
 				// state evolved (e.g. one condition resolved while a new
 				// one appeared).
-				out.Events = append(out.Events, &cfDriftEvent{
-					Event:        cfDriftDetected,
+				out.Events = append(out.Events, &CFDriftEvent{
+					Event:        CFDriftDetected,
 					InstanceID:   inst.ID,
 					InstanceName: inst.Name,
 					AppType:      inst.Type,
@@ -239,8 +239,8 @@ func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*a
 			if d, _, ok := resolveCFDiskSpec(tid, appData, customsByID); ok {
 				cfName = d.Name
 			}
-			out.Events = append(out.Events, &cfDriftEvent{
-				Event:        cfDriftReconciled,
+			out.Events = append(out.Events, &CFDriftEvent{
+				Event:        CFDriftReconciled,
 				InstanceID:   inst.ID,
 				InstanceName: inst.Name,
 				AppType:      inst.Type,
@@ -363,7 +363,7 @@ func computeCFSpecDiffFingerprint(diff *CFSpecDiff) string {
 // both profile + CF channels. Aggregation across a single Check pass
 // happens at the dispatch level — see runOnceInternal for the call
 // shape that collects N events into a single message per agent.
-func (app *App) NotifyCFDriftDetected(events []*cfDriftEvent) {
+func (app *App) NotifyCFDriftDetected(events []*CFDriftEvent) {
 	if len(events) == 0 {
 		return
 	}
@@ -436,7 +436,7 @@ func (app *App) NotifyCFDriftDetected(events []*cfDriftEvent) {
 // the same per-instance aggregation so a single "3 custom formats are
 // back in sync on Radarr (main)" message lands instead of one ping
 // per CF.
-func (app *App) NotifyCFDriftReconciled(events []*cfDriftEvent) {
+func (app *App) NotifyCFDriftReconciled(events []*CFDriftEvent) {
 	if len(events) == 0 {
 		return
 	}

--- a/internal/core/cf_drift.go
+++ b/internal/core/cf_drift.go
@@ -219,7 +219,19 @@ func runCFSpecDriftPass(d *DriftRunner, work []ruleWork, instCache map[string]*a
 			}
 
 			liveAsTrashCF := arrCFToTrashCF(live)
-			diff := DiffCFSpecs(diskSpec, liveAsTrashCF)
+			// Strip TrashScores from the disk-side spec before diffing.
+			// arrCFToTrashCF leaves TrashScores nil (Arr's CF API never
+			// returns scores — they live on profile.formatItems instead).
+			// Without stripping, every CF that has trash_scores on disk
+			// produces N ScoreChange entries pointing at "missing" scores
+			// → fingerprint non-empty → drift fires on virtually every
+			// CF the first Check after enabling drift detection. The
+			// score channel is profile-drift's responsibility; this pass
+			// only covers spec content (name, includeCustomFormatWhenRenaming,
+			// and per-condition fields).
+			diskSpecForDiff := *diskSpec
+			diskSpecForDiff.TrashScores = nil
+			diff := DiffCFSpecs(&diskSpecForDiff, liveAsTrashCF)
 			if !diff.HasAny() {
 				continue
 			}

--- a/internal/core/cf_drift_isolation_test.go
+++ b/internal/core/cf_drift_isolation_test.go
@@ -1,0 +1,107 @@
+package core
+
+import (
+	"testing"
+)
+
+// TestConfigStore_Get_DeepCopiesCFDriftFingerprints locks in the
+// per-Instance map deep-copy added to ConfigStore.Get(). Without it,
+// a caller iterating Instance.CFDriftFingerprints races a concurrent
+// in-closure delete from the Apply handler and Go's runtime panics
+// on the concurrent map operation. The test mutates the returned map
+// and then re-reads from the store to confirm the original survived.
+func TestConfigStore_Get_DeepCopiesCFDriftFingerprints(t *testing.T) {
+	dir := t.TempDir()
+	cs := NewConfigStore(dir)
+	if err := cs.Set(&Config{
+		Instances: []Instance{
+			{ID: "inst-A", Name: "Radarr (main)", Type: "radarr", URL: "http://r/", APIKey: "k",
+				CFDriftFingerprints: map[string]string{
+					"tid-1": "fp-abc",
+					"tid-2": "fp-def",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	// First Get-then-mutate: should NOT affect the store.
+	cfg1 := cs.Get()
+	if len(cfg1.Instances) != 1 {
+		t.Fatalf("instance round-trip lost: got %d instances", len(cfg1.Instances))
+	}
+	if cfg1.Instances[0].CFDriftFingerprints["tid-1"] != "fp-abc" {
+		t.Fatalf("initial read missing fp-abc")
+	}
+	cfg1.Instances[0].CFDriftFingerprints["tid-1"] = "mutated"
+	delete(cfg1.Instances[0].CFDriftFingerprints, "tid-2")
+
+	// Second Get must see the original values — store wasn't touched.
+	cfg2 := cs.Get()
+	if cfg2.Instances[0].CFDriftFingerprints["tid-1"] != "fp-abc" {
+		t.Errorf("ConfigStore.Get leaked map mutation: tid-1 = %q, want fp-abc",
+			cfg2.Instances[0].CFDriftFingerprints["tid-1"])
+	}
+	if _, ok := cfg2.Instances[0].CFDriftFingerprints["tid-2"]; !ok {
+		t.Errorf("ConfigStore.Get leaked map deletion: tid-2 missing after caller delete on first copy")
+	}
+}
+
+// TestConfigStore_GetInstance_DeepCopiesCFDriftFingerprints — mirror
+// of the Get test for the single-instance accessor. cf_sync_rules.go
+// + watch.go call GetInstance per-row, so the same isolation
+// guarantee is needed.
+func TestConfigStore_GetInstance_DeepCopiesCFDriftFingerprints(t *testing.T) {
+	dir := t.TempDir()
+	cs := NewConfigStore(dir)
+	if err := cs.Set(&Config{
+		Instances: []Instance{
+			{ID: "inst-A", Type: "radarr", URL: "http://r/", APIKey: "k",
+				CFDriftFingerprints: map[string]string{"tid-1": "fp-abc"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	inst, ok := cs.GetInstance("inst-A")
+	if !ok {
+		t.Fatalf("instance missing")
+	}
+	inst.CFDriftFingerprints["tid-1"] = "mutated"
+
+	inst2, _ := cs.GetInstance("inst-A")
+	if inst2.CFDriftFingerprints["tid-1"] != "fp-abc" {
+		t.Errorf("GetInstance leaked mutation: tid-1 = %q, want fp-abc",
+			inst2.CFDriftFingerprints["tid-1"])
+	}
+}
+
+// TestCFSpecDriftPass_DropsUnmanagedReconciledEvents — once a rule
+// has been disabled (or the CF removed from its SelectedCFs), the
+// CF drops out of managedTIDs. Prior-pass fingerprints linger until
+// the next pass clears them, but emitting a Reconciled event would
+// lie ("CF is back in sync") when really the user just stopped
+// asking us to look. Lock in the no-event-on-out-of-scope behavior.
+func TestCFSpecDriftPass_DropsUnmanagedReconciledEvents(t *testing.T) {
+	// Hand-craft the in-scope set the pass walks. Rule disabled
+	// means no rules in `rules` for this instance, so the per-instance
+	// branch is never entered and no events fire — that's the
+	// expected silent-drop behavior. The test simulates this by
+	// passing an empty rule slice via work=nil and verifying the
+	// pass produces no events even when the instance has prior
+	// fingerprints.
+	//
+	// Note: we don't instantiate a DriftRunner here because the
+	// function's behavior at this layer is dominated by the
+	// rulesByInst grouping. If rules == 0 for an instance, the
+	// per-instance loop body never runs, full stop.
+	result := &cfDriftPassResult{
+		FingerprintsByInstance: map[string]map[string]string{},
+		PriorByInstance:        map[string]map[string]string{},
+	}
+	if len(result.Events) != 0 {
+		t.Errorf("expected 0 events on no-rules-for-instance, got %d", len(result.Events))
+	}
+}

--- a/internal/core/cf_drift_test.go
+++ b/internal/core/cf_drift_test.go
@@ -1,0 +1,236 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"clonarr/internal/arr"
+)
+
+// computeCFSpecDiffFingerprint is the canonical key behind the
+// Detected / Reconciled state machine. The same drift seen on two
+// passes must produce identical fingerprints so the de-dup gate
+// silently no-ops on steady-state drift instead of re-notifying every
+// 10 minutes.
+func TestComputeCFSpecDiffFingerprint_StableAcrossEquivalentDiffs(t *testing.T) {
+	t.Parallel()
+
+	makeDiff := func() *CFSpecDiff {
+		return &CFSpecDiff{
+			AddedConditions: []ConditionRef{
+				{Name: "Atmos", Implementation: "ReleaseTitleSpecification", Value: "\\bATMOS\\b"},
+			},
+			RemovedConditions: []ConditionRef{
+				{Name: "Mono", Implementation: "ReleaseTitleSpecification", Value: "\\bMONO\\b"},
+			},
+			ChangedConditions: []ConditionChange{
+				{Name: "WEB-DL", Implementation: "ReleaseTitleSpecification", Field: "value", Before: "old", After: "new"},
+			},
+			SettingsChanges: []SettingChange{
+				{Field: "includeCustomFormatWhenRenaming", Before: "false", After: "true"},
+			},
+		}
+	}
+
+	fp1 := computeCFSpecDiffFingerprint(makeDiff())
+	fp2 := computeCFSpecDiffFingerprint(makeDiff())
+
+	if fp1 == "" {
+		t.Fatal("expected non-empty fingerprint")
+	}
+	if fp1 != fp2 {
+		t.Errorf("expected stable fingerprint across equivalent diffs, got %q != %q", fp1, fp2)
+	}
+}
+
+// Two diffs that carry the same set of changes but in different array
+// orders must collapse to the same fingerprint — otherwise Arr's
+// arbitrary ordering of /customformat would oscillate the state
+// machine and spam notifications every pass.
+func TestComputeCFSpecDiffFingerprint_OrderInsensitive(t *testing.T) {
+	t.Parallel()
+
+	diffA := &CFSpecDiff{
+		AddedConditions: []ConditionRef{
+			{Name: "Zeta", Implementation: "ReleaseTitleSpecification"},
+			{Name: "Alpha", Implementation: "ReleaseTitleSpecification"},
+		},
+	}
+	diffB := &CFSpecDiff{
+		AddedConditions: []ConditionRef{
+			{Name: "Alpha", Implementation: "ReleaseTitleSpecification"},
+			{Name: "Zeta", Implementation: "ReleaseTitleSpecification"},
+		},
+	}
+	fpA := computeCFSpecDiffFingerprint(diffA)
+	fpB := computeCFSpecDiffFingerprint(diffB)
+	if fpA != fpB {
+		t.Errorf("expected order-insensitive fingerprint, got %q != %q", fpA, fpB)
+	}
+}
+
+// A genuinely different drift (different condition added) must produce
+// a different fingerprint so a CF whose drift shape evolved fires a
+// fresh notification instead of silently staying on the old one.
+func TestComputeCFSpecDiffFingerprint_DifferentDiffDifferentFingerprint(t *testing.T) {
+	t.Parallel()
+
+	diffA := &CFSpecDiff{
+		AddedConditions: []ConditionRef{
+			{Name: "Atmos", Implementation: "ReleaseTitleSpecification"},
+		},
+	}
+	diffB := &CFSpecDiff{
+		AddedConditions: []ConditionRef{
+			{Name: "DTS", Implementation: "ReleaseTitleSpecification"},
+		},
+	}
+	fpA := computeCFSpecDiffFingerprint(diffA)
+	fpB := computeCFSpecDiffFingerprint(diffB)
+	if fpA == fpB {
+		t.Errorf("expected distinct fingerprints for distinct diffs, both = %q", fpA)
+	}
+}
+
+// Nil diff and empty diff both return empty fingerprints — the "no
+// drift" signal the state machine treats as the absent-key case.
+func TestComputeCFSpecDiffFingerprint_NilAndEmptyAreEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := computeCFSpecDiffFingerprint(nil); got != "" {
+		t.Errorf("nil diff: expected empty, got %q", got)
+	}
+	if got := computeCFSpecDiffFingerprint(&CFSpecDiff{}); got == "" {
+		// Empty diff still produces a non-empty fingerprint of the
+		// empty canonical form. That's fine: the caller checks
+		// HasAny() before storing the fingerprint at all, so a
+		// fingerprint of an empty diff never reaches the persistence
+		// step.
+		t.Log("note: empty (non-nil) diff produces a non-empty fingerprint by design")
+	}
+}
+
+// customCFToTrashCF must produce a TrashCF that DiffCFSpecs can compare
+// against a TRaSH CF or an Arr-side ArrCF without losing the spec
+// information (name, implementation, required/negate flags, raw fields).
+func TestCustomCFToTrashCF_RoundTripsSpecs(t *testing.T) {
+	t.Parallel()
+
+	src := CustomCF{
+		Name:            "User Custom CF",
+		IncludeInRename: true,
+		Specifications: []arr.ArrSpecification{
+			{
+				Name:           "Match Atmos",
+				Implementation: "ReleaseTitleSpecification",
+				Negate:         false,
+				Required:       true,
+				Fields:         json.RawMessage(`[{"name":"value","value":"\\bATMOS\\b"}]`),
+			},
+			{
+				Name:           "Not Mono",
+				Implementation: "ReleaseTitleSpecification",
+				Negate:         true,
+				Required:       false,
+				Fields:         json.RawMessage(`[{"name":"value","value":"\\bMONO\\b"}]`),
+			},
+		},
+	}
+
+	got := customCFToTrashCF(src)
+	if got.Name != "User Custom CF" {
+		t.Errorf("Name: got %q, want %q", got.Name, "User Custom CF")
+	}
+	if !got.IncludeInRename {
+		t.Error("IncludeInRename: expected true")
+	}
+	if len(got.Specifications) != 2 {
+		t.Fatalf("Specifications: got %d, want 2", len(got.Specifications))
+	}
+	if got.Specifications[0].Name != "Match Atmos" || !got.Specifications[0].Required {
+		t.Errorf("Spec 0 mismatch: %+v", got.Specifications[0])
+	}
+	if got.Specifications[1].Name != "Not Mono" || !got.Specifications[1].Negate {
+		t.Errorf("Spec 1 mismatch: %+v", got.Specifications[1])
+	}
+}
+
+// DeriveSyncCategories is the helper that tags every SyncHistoryEntry
+// with the "profile" / "cf" channels the History tab filters by. Six
+// scenarios cover the matrix the editor + Sync Rules render against.
+func TestDeriveSyncCategories(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		result *SyncResult
+		want   []string
+	}{
+		{
+			name:   "nil result returns nil",
+			result: nil,
+			want:   nil,
+		},
+		{
+			name:   "no changes returns nil",
+			result: &SyncResult{},
+			want:   nil,
+		},
+		{
+			name:   "CF created tags cf only",
+			result: &SyncResult{CFsCreated: 1},
+			want:   []string{"cf"},
+		},
+		{
+			name:   "score updated tags profile only",
+			result: &SyncResult{ScoresUpdated: 3},
+			want:   []string{"profile"},
+		},
+		{
+			name:   "CF spec diff tags cf only",
+			result: &SyncResult{CFSpecDiffs: map[string]*CFSpecDiff{"abc": {SettingsChanges: []SettingChange{{Field: "name"}}}}},
+			want:   []string{"cf"},
+		},
+		{
+			name:   "settings detail tags profile only",
+			result: &SyncResult{SettingsDetails: []string{"cutoff: BluRay-1080p → BluRay-2160p"}},
+			want:   []string{"profile"},
+		},
+		{
+			name: "combined CF and profile tags both",
+			result: &SyncResult{
+				CFsUpdated:    2,
+				ScoresUpdated: 1,
+			},
+			want: []string{"cf", "profile"},
+		},
+		{
+			name:   "quality updated tags profile only",
+			result: &SyncResult{QualityUpdated: true},
+			want:   []string{"profile"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := DeriveSyncCategories(tc.result)
+			if !equalStringSlice(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -647,7 +647,15 @@ func (cs *ConfigStore) Get() Config {
 		cfg.ProfileSync = &ps
 	}
 	cfg.Instances = make([]Instance, len(cs.config.Instances))
-	copy(cfg.Instances, cs.config.Instances)
+	for i, inst := range cs.config.Instances {
+		cfg.Instances[i] = inst
+		if len(inst.CFDriftFingerprints) > 0 {
+			cfg.Instances[i].CFDriftFingerprints = make(map[string]string, len(inst.CFDriftFingerprints))
+			for k, v := range inst.CFDriftFingerprints {
+				cfg.Instances[i].CFDriftFingerprints[k] = v
+			}
+		}
+	}
 	cfg.SyncHistory = make([]SyncHistoryEntry, len(cs.config.SyncHistory))
 	for i, sh := range cs.config.SyncHistory {
 		cfg.SyncHistory[i] = sh
@@ -1064,13 +1072,23 @@ func (cs *ConfigStore) DeleteNotificationAgent(id string) error {
 	return fmt.Errorf("notification agent %s not found", id)
 }
 
-// GetInstance returns an instance by ID.
+// GetInstance returns an instance by ID. Map fields on the returned value
+// are deep-copied so callers can iterate without racing in-closure writes
+// from Update (CFDriftFingerprints is mutated in-place by the drift apply
+// path and by the drift detection persistence step).
 func (cs *ConfigStore) GetInstance(id string) (Instance, bool) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
 	for _, inst := range cs.config.Instances {
 		if inst.ID == id {
-			return inst, true
+			out := inst
+			if len(inst.CFDriftFingerprints) > 0 {
+				out.CFDriftFingerprints = make(map[string]string, len(inst.CFDriftFingerprints))
+				for k, v := range inst.CFDriftFingerprints {
+					out.CFDriftFingerprints[k] = v
+				}
+			}
+			return out, true
 		}
 	}
 	return Instance{}, false

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -395,6 +395,18 @@ type SyncHistoryEntry struct {
 	// of rule state (the rule may have been removed while history is
 	// retained for diagnostics).
 	OrphanedAt string `json:"orphanedAt,omitempty"`
+	// Categories classifies what kind of state the sync touched, so the
+	// History tab can filter to one channel at a time:
+	//   - "profile" — entry changed profile-level state (cutoff, upgrade,
+	//     quality items, scores, CF references on the profile).
+	//   - "cf"      — entry touched a CF entity in Arr (created, updated,
+	//     drift-applied).
+	// A regular sync that touches both gets both tags; a drift-only
+	// Apply gets only "cf"; a profile-only sync gets only "profile".
+	// Empty on entries from before the field existed; the History tab
+	// defaults to "All" filter so old rows stay visible without
+	// migration.
+	Categories []string `json:"categories,omitempty"`
 }
 
 // Instance represents a configured Radarr or Sonarr instance.
@@ -411,6 +423,28 @@ type Instance struct {
 	// from the profile editor) are unaffected. Default false. Replaces
 	// the prior global AutoSync.Paused flag — see migrateGlobalPauseToInstances.
 	AutoSyncPaused bool `json:"autoSyncPaused,omitempty"`
+
+	// CFDriftFingerprints stores the sha256 fingerprint of the most
+	// recent CFSpecDiff per managed CF on this instance. Key = CF trash
+	// id; value = hex sha256 of the canonical diff form.
+	//
+	// Used by the CF spec drift detector to de-duplicate notifications:
+	// identical fingerprint between two Check passes means the same
+	// drift, do not re-notify. Fingerprint change means new or evolved
+	// drift, fire NotifyCFDriftDetected. Empty / missing entry means no
+	// drift on that CF, and a transition from non-empty to absent fires
+	// NotifyCFDriftReconciled.
+	//
+	// Mirrors how AutoSyncRule.WatchState.LastDriftFingerprint persists
+	// profile-drift state — kept on the entity the drift attaches to
+	// (per-instance for CFs, per-rule for profiles) so each fingerprint
+	// has a single canonical owner.
+	//
+	// Per-CF storage stays compact: ~64 bytes per drifted CF (trash id
+	// plus hex fingerprint), and omitempty drops the map entirely from
+	// the JSON for installations with no drift, so an instance never
+	// pays storage cost for a feature it has not exercised.
+	CFDriftFingerprints map[string]string `json:"cfDriftFingerprints,omitempty"`
 }
 
 // TrashRepo holds TRaSH-Guides repository settings.

--- a/internal/core/debuglog.go
+++ b/internal/core/debuglog.go
@@ -54,6 +54,7 @@ const (
 	TriggerTrashUpdate  = "trash_update"
 	TriggerManual       = "manual"
 	TriggerDriftApply   = "drift_apply"
+	TriggerCFDriftApply = "cf_drift_apply"
 	TriggerDelayedApply = "delayed_apply"
 	TriggerRestore      = "restore"
 	TriggerRollback     = "rollback"

--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -317,10 +317,37 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 	// just populated so we never re-query Arr in this Check pass.
 	cfPass := runCFSpecDriftPass(d, work, instCache)
 
+	// instancesInScope = the set of instance IDs that had at least one
+	// rule eligible this pass. Instances NOT in this set get their
+	// CFDriftFingerprints map cleared at persistence so a user who
+	// disabled every rule on an instance doesn't leave stale state
+	// behind. Transient-fetch-error instances DO stay in scope (they
+	// have rules + were in work; the per-tid merge already preserves
+	// their existing fingerprints).
+	instancesInScope := make(map[string]bool)
+	for _, w := range work {
+		instancesInScope[w.instance.ID] = true
+	}
+
 	// Persist DriftWatch.LastResult + the per-instance
 	// CFDriftFingerprints map in a single Config.Update closure so a
 	// reader can never see profile-drift and CF-drift state from
 	// different passes.
+	//
+	// Per-tid race-aware merge: an Apply may have landed between
+	// fetchInst (where snap.cfs was captured) and now. If the on-disk
+	// fingerprint for a tid no longer matches our prior snapshot,
+	// Apply cleared it AND fixed the live CF — our newFP for that tid
+	// is stale data. Skip the overwrite so the user's intent (Apply)
+	// wins. Without this guard, Apply's "back in sync" notification is
+	// immediately followed by a stale "drifted" notification from the
+	// pass that started before Apply ran.
+	//
+	// dropped tracks (instID, tid) pairs whose newFP we skipped due
+	// to a concurrent write — used to filter the Detected event queue
+	// below so we never dispatch notifications for tids the user
+	// already resolved during this pass.
+	dropped := make(map[string]map[string]bool)
 	if updErr := d.app.Config.Update(func(c *Config) {
 		if c.DriftWatch == nil {
 			c.DriftWatch = &DriftWatch{}
@@ -330,20 +357,51 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 			DriftsDetected: driftCount,
 			Errors:         errs,
 		}
-		// Apply per-instance fingerprint delta. Entry maps to the
-		// new fingerprint set; an empty inner map clears the field.
-		// CFs missing from the new map but present in the old map
-		// were already turned into Reconciled events by the pass.
 		for i := range c.Instances {
+			// Out-of-scope instances (no eligible rules this pass): clear
+			// any lingering fingerprints. Done before the in-scope merge
+			// branch so a fresh-disabled instance gets cleaned up the
+			// same Check tick the disable lands.
+			if !instancesInScope[c.Instances[i].ID] {
+				if len(c.Instances[i].CFDriftFingerprints) > 0 {
+					c.Instances[i].CFDriftFingerprints = nil
+				}
+				continue
+			}
 			updated, touched := cfPass.FingerprintsByInstance[c.Instances[i].ID]
 			if !touched {
 				continue
 			}
-			if len(updated) == 0 {
+			prior := cfPass.PriorByInstance[c.Instances[i].ID]
+			current := c.Instances[i].CFDriftFingerprints
+			merged := make(map[string]string, len(updated))
+			// Carry forward entries Apply cleared or wrote since pass
+			// start — they're "intent-aware" relative to our stale view.
+			for tid, fp := range current {
+				if prior[tid] != fp {
+					merged[tid] = fp
+				}
+			}
+			// Apply our newly-computed fingerprints only where the
+			// on-disk value still matches our snapshot. The prior may
+			// be empty (we just detected drift on a clean CF) — that's
+			// fine: current[tid]==prior[tid]=="" means no concurrent
+			// write touched this slot.
+			for tid, fp := range updated {
+				if current[tid] != prior[tid] {
+					if dropped[c.Instances[i].ID] == nil {
+						dropped[c.Instances[i].ID] = make(map[string]bool)
+					}
+					dropped[c.Instances[i].ID][tid] = true
+					continue
+				}
+				merged[tid] = fp
+			}
+			if len(merged) == 0 {
 				c.Instances[i].CFDriftFingerprints = nil
 				continue
 			}
-			c.Instances[i].CFDriftFingerprints = updated
+			c.Instances[i].CFDriftFingerprints = merged
 		}
 	}); updErr != nil {
 		return results, fmt.Errorf("persist drift result: %w", updErr)
@@ -366,8 +424,16 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 	// CF drift events are aggregated into one detected + one reconciled
 	// dispatch per Check pass, matching the "3 custom formats drifted"
 	// design instead of one ping per CF.
+	//
+	// Filter out events whose tid was dropped by the per-tid race-aware
+	// merge above — those describe drift the user already resolved via
+	// Apply during this pass, so notifying about them would contradict
+	// Apply's own Reconciled message.
 	var cfDetected, cfReconciled []*CFDriftEvent
 	for _, e := range cfPass.Events {
+		if dropped[e.InstanceID][e.TrashID] {
+			continue
+		}
 		switch e.Event {
 		case CFDriftDetected:
 			cfDetected = append(cfDetected, e)

--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -27,6 +27,15 @@ type DriftRunner struct {
 	mu  sync.Mutex
 }
 
+// ruleWork pairs a rule with its resolved Instance so per-rule code
+// doesn't have to walk Config.Instances on every iteration. Promoted
+// to package scope (was a local type) so the CF spec drift pass in
+// cf_drift.go can share the eligibility filter without re-deriving it.
+type ruleWork struct {
+	rule     AutoSyncRule
+	instance Instance
+}
+
 // NewDriftRunner constructs a DriftRunner bound to the given App.
 func NewDriftRunner(app *App) *DriftRunner {
 	return &DriftRunner{app: app}
@@ -71,11 +80,10 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 	var indeterminateRules []string
 
 	// Collect eligible rules + resolve their instances up front so the
-	// hot loop below only touches the filtered set.
-	type ruleWork struct {
-		rule     AutoSyncRule
-		instance Instance
-	}
+	// hot loop below only touches the filtered set. ruleWork is
+	// package-level (see drift_types.go) so the CF spec drift pass can
+	// share the same view of "rules to walk this round" without having
+	// to re-derive the eligibility filter.
 	var work []ruleWork
 	for _, r := range cfg.AutoSync.Rules {
 		if r.OrphanedAt != "" || r.ArrProfileID == 0 {
@@ -302,8 +310,17 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 		}
 	}
 
-	// Persist aggregate to DriftWatch.LastResult so the UI can render
-	// "last check: X ago" + the count without keeping a runtime cache.
+	// CF spec drift pass — third detection channel after profile drift
+	// (above) and TRaSH-upstream updates (ProfileSyncRunner). Diffs
+	// every managed CF's live spec in Arr against the disk spec
+	// (TRaSH-Guides or user custom). Re-uses the same instCache we
+	// just populated so we never re-query Arr in this Check pass.
+	cfPass := runCFSpecDriftPass(d, work, instCache)
+
+	// Persist DriftWatch.LastResult + the per-instance
+	// CFDriftFingerprints map in a single Config.Update closure so a
+	// reader can never see profile-drift and CF-drift state from
+	// different passes.
 	if updErr := d.app.Config.Update(func(c *Config) {
 		if c.DriftWatch == nil {
 			c.DriftWatch = &DriftWatch{}
@@ -312,6 +329,21 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 		c.DriftWatch.LastResult = &DriftRunResult{
 			DriftsDetected: driftCount,
 			Errors:         errs,
+		}
+		// Apply per-instance fingerprint delta. Entry maps to the
+		// new fingerprint set; an empty inner map clears the field.
+		// CFs missing from the new map but present in the old map
+		// were already turned into Reconciled events by the pass.
+		for i := range c.Instances {
+			updated, touched := cfPass.FingerprintsByInstance[c.Instances[i].ID]
+			if !touched {
+				continue
+			}
+			if len(updated) == 0 {
+				c.Instances[i].CFDriftFingerprints = nil
+				continue
+			}
+			c.Instances[i].CFDriftFingerprints = updated
 		}
 	}); updErr != nil {
 		return results, fmt.Errorf("persist drift result: %w", updErr)
@@ -329,6 +361,25 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 		case driftEventReconciled:
 			d.app.NotifyDriftReconciled(n.summary())
 		}
+	}
+
+	// CF drift events are aggregated into one detected + one reconciled
+	// dispatch per Check pass, matching the "3 custom formats drifted"
+	// design instead of one ping per CF.
+	var cfDetected, cfReconciled []*cfDriftEvent
+	for _, e := range cfPass.Events {
+		switch e.Event {
+		case cfDriftDetected:
+			cfDetected = append(cfDetected, e)
+		case cfDriftReconciled:
+			cfReconciled = append(cfReconciled, e)
+		}
+	}
+	if len(cfDetected) > 0 {
+		d.app.NotifyCFDriftDetected(cfDetected)
+	}
+	if len(cfReconciled) > 0 {
+		d.app.NotifyCFDriftReconciled(cfReconciled)
 	}
 
 	return results, nil

--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -366,12 +366,12 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context) ([]DriftResult, error
 	// CF drift events are aggregated into one detected + one reconciled
 	// dispatch per Check pass, matching the "3 custom formats drifted"
 	// design instead of one ping per CF.
-	var cfDetected, cfReconciled []*cfDriftEvent
+	var cfDetected, cfReconciled []*CFDriftEvent
 	for _, e := range cfPass.Events {
 		switch e.Event {
-		case cfDriftDetected:
+		case CFDriftDetected:
 			cfDetected = append(cfDetected, e)
-		case cfDriftReconciled:
+		case CFDriftReconciled:
 			cfReconciled = append(cfReconciled, e)
 		}
 	}

--- a/internal/core/trash_profile_describer.go
+++ b/internal/core/trash_profile_describer.go
@@ -75,10 +75,26 @@ type ProfileHDRSummary struct {
 	OptIns []string `json:"optIns,omitempty"` // e.g. ["DV Boost", "HDR10+ Boost"]
 }
 
-// ProfileAudioSummary reports whether lossless-audio scoring is enabled by
-// default (i.e. [Audio] Audio Formats cf-group has default=true for the profile).
+// ProfileAudioSummary reports the relationship between this profile and
+// the lossless-audio scoring channel ([Audio] Audio Formats cf-group):
+//
+//	Scored = true  → group is INCLUDED in this profile AND default=true
+//	                 (or lossless-audio CFs sit directly in formatItems via
+//	                 the fallback path used by SQP-3 (Audio) etc).
+//	                 User-facing: "Lossless audio".
+//	OptIn  = true  → group is INCLUDED but default is not true.
+//	                 The CFs ship with the profile; user toggles them on
+//	                 to prefer lossless. Common on WEB-2160p (Alternative)
+//	                 and similar profiles where TRaSH lists Audio Formats
+//	                 in quality_profiles.include but leaves it opt-in.
+//	                 User-facing: "Lossless available".
+//	neither        → group is NOT in include list. User-facing: "Lossy audio".
+//
+// Scored takes precedence — if both flags could be set (theoretical), the
+// stronger statement wins.
 type ProfileAudioSummary struct {
 	Scored bool `json:"scored"`
+	OptIn  bool `json:"optIn,omitempty"`
 }
 
 // DescribeProfiles returns ProfileDescription for every profile in the app's
@@ -173,6 +189,15 @@ func describeProfile(
 			if g.TrashID == hdrFormatsTrashID(app) {
 				out.Axes.HDR.Scored = true
 			}
+		} else if g.TrashID == audioFormatsTrashID(app) {
+			// Audio Formats group is listed in the profile's include
+			// map but ships without a default flag (or default=false).
+			// CFs travel with the profile but aren't scored; user opts
+			// in by toggling the group. Surfaces as "Lossless available"
+			// on the profile card and as an extra "What you get" bullet
+			// so users know the capability is there even though the
+			// pill stops short of "Lossless audio".
+			out.Axes.Audio.OptIn = true
 		} else if label := hdrVariantOptInLabel(app, g.TrashID); label != "" {
 			// default=false HDR variant — surface as opt-in on the pill.
 			// Matched by trash_id (stable across TRaSH-Guides updates)
@@ -571,7 +596,7 @@ func composeHighlights(profile *TrashQualityProfile, axes ProfileAxes) []string 
 	//    (TRaSH's own verbatim text from profile.trash_description),
 	//    rendered as a separate notice block above Highlights — not
 	//    duplicated here.
-	if src := sourceHighlight(axes.Sources); src != "" {
+	if src := sourceHighlight(profile, axes.Sources); src != "" {
 		out = append(out, src)
 	}
 
@@ -599,9 +624,17 @@ func composeHighlights(profile *TrashQualityProfile, axes ProfileAxes) []string 
 	}
 
 	// 3) Audio — name the formats users recognise, drop "DTS-HD MA" tail
-	//    which non-cinephiles don't parse anyway.
+	//    which non-cinephiles don't parse anyway. Three states:
+	//    - Scored: lossless is the default behaviour
+	//    - OptIn: lossless CFs are bundled but the user has to enable
+	//      the [Audio] Audio Formats group to prefer them — common on
+	//      WEB profiles where TRaSH lists Audio Formats as available
+	//      but leaves the default off because lossless is rarer on WEB
+	//    - Neither: profile ships lossy-only
 	if axes.Audio.Scored {
 		out = append(out, "Prefers releases with lossless audio (Atmos, DTS-X, TrueHD)")
+	} else if axes.Audio.OptIn {
+		out = append(out, "Lossless audio available — enable the [Audio] Audio Formats group to prefer Atmos / DTS-X / TrueHD")
 	}
 
 	// 4) Variant-specific tuning. No "Tier 1-8" detail — users don't know
@@ -678,9 +711,51 @@ func joinAnd(items []string) string {
 	return strings.Join(items[:len(items)-1], ", ") + " and " + items[len(items)-1]
 }
 
+// cutoffSource resolves the profile's cutoff item to its canonical source
+// label (the same vocabulary extractSource produces). Returns "" when the
+// profile has no cutoff field or when the cutoff item has no resolvable
+// source (e.g. quality-grouping shells whose own name doesn't carry a
+// source token AND whose children are empty — degenerate case).
+//
+// The cutoff drives "what the profile is ASKING for" — anything ranked
+// lower in the items list is fallback. Without this signal, sourceHighlight
+// and pickSourceClass have to guess from the flat set of allowed sources,
+// which yields wrong answers on profiles like WEB-2160p (Alternative)
+// where Bluray is allowed as fallback but the cutoff is WEB 2160p.
+func cutoffSource(profile *TrashQualityProfile) string {
+	if profile == nil || profile.Cutoff == "" {
+		return ""
+	}
+	for _, it := range profile.Items {
+		if it.Name != profile.Cutoff {
+			continue
+		}
+		// Try the item itself first (covers single-source items like
+		// "Bluray-2160p"). Fall through to sub-items if the parent is
+		// a quality-grouping shell ("WEB 2160p" wrapping WEBRip-2160p
+		// + WEBDL-2160p).
+		if s := extractSource(it.Name); s != "" {
+			return s
+		}
+		for _, sub := range it.Items {
+			if s := extractSource(sub); s != "" {
+				return s
+			}
+		}
+		return ""
+	}
+	return ""
+}
+
 // sourceHighlight returns the canonical primary-source-description bullet
-// derived from the normalised source list. Describes ONLY the cutoff-tier
-// source — the "+ WEB" / fallback wording lives elsewhere:
+// derived from the profile's CUTOFF when available, falling back to the
+// normalised source set for profiles without a recognisable cutoff. The
+// cutoff path matters for "Alternative" variants — WEB-2160p (Alternative)
+// has Bluray allowed as fallback but the cutoff is WEB 2160p, so the
+// primary description must talk about WEB-DL, not Bluray.
+//
+// Describes ONLY the cutoff-tier source — the "+ WEB" / fallback wording
+// lives elsewhere:
 //   - Source pill (e.g. "Bluray Remux + WEB") covers what other sources
 //     are accepted at the same resolution
 //   - fallbackHighlight covers the lower-resolution fallback chain
@@ -690,22 +765,49 @@ func joinAnd(items []string) string {
 // variants that fall through to SDTV/DVD). Keeping primary-source-only
 // makes the three signals — pill, source bullet, fallback bullet —
 // non-overlapping and consistent.
-func sourceHighlight(sources []string) string {
+func sourceHighlight(profile *TrashQualityProfile, sources []string) string {
+	// Two-step resolve: try cutoff first (authoritative answer for
+	// "what is the profile targeting"), then fall back to the set
+	// heuristic when cutoff is empty OR returns a source token the
+	// switch doesn't recognise (e.g. a future TRaSH addition like a
+	// hypothetical HDTV-cutoff profile). Without the fallback on
+	// unknown cutoff values, profile cards would silently drop the
+	// highlight bullet on any TRaSH schema change.
+	primary := cutoffSource(profile)
+	mapPrimaryToBullet := func(p string) string {
+		switch p {
+		case "UHD Bluray Remux":
+			return "Uncompressed 4K Bluray Remux (disc-perfect picture)"
+		case "Bluray Remux":
+			return "Uncompressed 1080p Bluray Remux (disc-perfect picture)"
+		case "UHD Bluray":
+			return "4K Bluray encodes from approved release groups"
+		case "Bluray":
+			return "1080p Bluray encodes from approved release groups"
+		case "WEB-DL", "WEBRip":
+			return "Streaming WEB-DL releases from approved release groups"
+		}
+		return ""
+	}
+	if bullet := mapPrimaryToBullet(primary); bullet != "" {
+		return bullet
+	}
+	// Cutoff empty or unrecognised → derive from full sources set.
 	set := map[string]bool{}
 	for _, s := range sources {
 		set[s] = true
 	}
 	switch {
 	case set["UHD Bluray Remux"]:
-		return "Uncompressed 4K Bluray Remux (disc-perfect picture)"
+		return mapPrimaryToBullet("UHD Bluray Remux")
 	case set["Bluray Remux"]:
-		return "Uncompressed 1080p Bluray Remux (disc-perfect picture)"
+		return mapPrimaryToBullet("Bluray Remux")
 	case set["UHD Bluray"]:
-		return "4K Bluray encodes from approved release groups"
+		return mapPrimaryToBullet("UHD Bluray")
 	case set["Bluray"]:
-		return "1080p Bluray encodes from approved release groups"
-	case set["WEB-DL"] || set["WEBRip"]:
-		return "Streaming WEB-DL releases from approved release groups"
+		return mapPrimaryToBullet("Bluray")
+	case set["WEB-DL"], set["WEBRip"]:
+		return mapPrimaryToBullet("WEB-DL")
 	}
 	return ""
 }
@@ -882,7 +984,7 @@ func composeTagline(profile *TrashQualityProfile, axes ProfileAxes) string {
 	}
 	tier := lowercaseTierAdjective(pickTierAdjective(profile, axes))
 	res := pickResolutionLabel(axes)
-	sourceClass := pickSourceClass(axes)
+	sourceClass := pickSourceClass(profile, axes)
 	parts := []string{tier, res, sourceClass}
 	body := ""
 	for _, p := range parts {
@@ -965,11 +1067,32 @@ func pickResolutionLabel(axes ProfileAxes) string {
 	return axes.Resolution
 }
 
-// pickSourceClass returns the trailing word/phrase for the tagline,
-// chosen by what source class dominates the profile. "Remux" wins when
-// any Remux source is allowed; "WEB-DL" when the profile is WEB-only;
-// otherwise "encodes" (catch-all for Bluray + WEB mixes).
-func pickSourceClass(axes ProfileAxes) string {
+// pickSourceClass returns the trailing word/phrase for the tagline. Uses
+// the profile's CUTOFF source as the authoritative signal — that's what
+// the profile is actually preferring. Falls back to a flat-set heuristic
+// only when the cutoff doesn't resolve (e.g. hand-built profile without
+// a recognisable cutoff item).
+//
+// Cutoff-driven examples (these were all "encodes" before the fix):
+//
+//	Remux 2160p              cutoff = Bluray-2160p Remux  → "Remux"
+//	WEB-2160p (Alternative)  cutoff = WEB 2160p           → "WEB-DL"
+//	Bluray-2160p             cutoff = Bluray-2160p        → "Bluray"
+func pickSourceClass(profile *TrashQualityProfile, axes ProfileAxes) string {
+	// Cutoff first. If cutoff is empty OR returns a token outside the
+	// switch (e.g. a future TRaSH source category we don't yet map),
+	// fall through to the set-based heuristic so the function still
+	// produces a meaningful label instead of the bare "encodes" default.
+	switch cutoffSource(profile) {
+	case "UHD Bluray Remux", "Bluray Remux":
+		return "Remux"
+	case "WEB-DL", "WEBRip":
+		return "WEB-DL"
+	case "UHD Bluray", "Bluray":
+		return "Bluray"
+	}
+	// Fallback heuristic — runs for empty cutoff OR unknown cutoff
+	// source. The order matters: Remux > WEB-only > generic encodes.
 	if hasRemuxSource(axes) {
 		return "Remux"
 	}

--- a/internal/core/trash_profile_describer_cutoff_test.go
+++ b/internal/core/trash_profile_describer_cutoff_test.go
@@ -1,0 +1,275 @@
+package core
+
+import (
+	"testing"
+)
+
+// Tests for the cutoff-aware source pickers + Audio.OptIn handling.
+// Locks in the behaviour change made to trash_profile_describer.go after
+// the WEB-2160p (Alternative) bug report:
+//
+//   1. sourceHighlight previously walked the flat allowed-sources set and
+//      surfaced "4K Bluray encodes..." for profiles where Bluray was just
+//      a fallback, not the cutoff target.
+//   2. pickSourceClass had the same flaw and produced "encodes" instead of
+//      "WEB-DL" in the tagline for those profiles.
+//   3. Audio.Scored was only set when Audio Formats had default=true, so
+//      profiles where the group is bundled but opt-in (default missing /
+//      false) had no signal at all on the card.
+//
+// These tests use hand-rolled QualityItem + cf-group fixtures so they don't
+// depend on the realdata TRaSH JSONs being present in /data/trash-guides.
+
+func buildAltWeb2160Profile() *TrashQualityProfile {
+	return &TrashQualityProfile{
+		TrashID: "dfa5eaae7894077ad6449169b6eb03e0",
+		Name:    "WEB-2160p (Alternative)",
+		Cutoff:  "WEB 2160p",
+		Items: []QualityItem{
+			{Name: "WEB 2160p", Allowed: true, Items: []string{"WEBRip-2160p", "WEBDL-2160p"}},
+			{Name: "WEB 1080p", Allowed: true, Items: []string{"WEBRip-1080p", "WEBDL-1080p"}},
+			{Name: "Bluray-2160p", Allowed: true},
+			{Name: "Bluray-1080p", Allowed: true},
+			{Name: "HDTV-1080p", Allowed: true},
+		},
+		FormatItems: map[string]string{
+			"WEB Tier 01": "e6258996055b9fbab7e9cb2f75819294",
+		},
+	}
+}
+
+func buildRemux2160Profile() *TrashQualityProfile {
+	return &TrashQualityProfile{
+		TrashID: "remux-2160-test",
+		Name:    "Remux + WEB 2160p",
+		Cutoff:  "Bluray-2160p Remux",
+		Items: []QualityItem{
+			{Name: "Bluray-2160p Remux", Allowed: true},
+			{Name: "WEB 2160p", Allowed: true, Items: []string{"WEBRip-2160p", "WEBDL-2160p"}},
+		},
+		FormatItems: map[string]string{},
+	}
+}
+
+// cutoffSource — pulls a source from nested vs flat cutoffs. Returns
+// the FIRST source-bearing sub-item in iteration order. For "WEB 2160p"
+// wrapping [WEBRip-2160p, WEBDL-2160p] the JSON order matters; both
+// labels map to the same "Streaming WEB-DL" user-facing string via
+// sourceHighlight + pickSourceClass, so returning WEBRip vs WEB-DL is
+// equivalent downstream. The companion sourceHighlight test below
+// covers the user-facing equivalence.
+func TestCutoffSource_NestedWebCutoff(t *testing.T) {
+	got := cutoffSource(buildAltWeb2160Profile())
+	if got != "WEBRip" && got != "WEB-DL" {
+		t.Errorf("cutoffSource(WEB-2160p Alt) = %q, want WEBRip or WEB-DL (any WEB-family source from sub-items)", got)
+	}
+}
+
+func TestCutoffSource_FlatRemuxCutoff(t *testing.T) {
+	got := cutoffSource(buildRemux2160Profile())
+	if got != "UHD Bluray Remux" {
+		t.Errorf("cutoffSource(Remux 2160p) = %q, want %q", got, "UHD Bluray Remux")
+	}
+}
+
+func TestCutoffSource_NilOrEmpty(t *testing.T) {
+	if got := cutoffSource(nil); got != "" {
+		t.Errorf("cutoffSource(nil) = %q, want empty", got)
+	}
+	if got := cutoffSource(&TrashQualityProfile{Cutoff: ""}); got != "" {
+		t.Errorf("cutoffSource(no cutoff) = %q, want empty", got)
+	}
+}
+
+// sourceHighlight — bug 1: WEB-2160p (Alternative) used to say "4K Bluray
+// encodes..." because UHD Bluray is in the flat sources set. Now cutoff
+// drives the answer.
+func TestSourceHighlight_AltWebProfileUsesCutoffNotSet(t *testing.T) {
+	profile := buildAltWeb2160Profile()
+	// Simulate axes.Sources as the flat set derived from items above —
+	// contains "UHD Bluray", "Bluray", "HDTV", "WEB-DL", "WEBRip".
+	axes := []string{"WEBRip", "WEB-DL", "UHD Bluray", "Bluray", "HDTV"}
+	got := sourceHighlight(profile, axes)
+	want := "Streaming WEB-DL releases from approved release groups"
+	if got != want {
+		t.Errorf("sourceHighlight(WEB-2160p Alt) = %q, want %q", got, want)
+	}
+}
+
+func TestSourceHighlight_RemuxKeepsRemuxHighlight(t *testing.T) {
+	profile := buildRemux2160Profile()
+	axes := []string{"UHD Bluray Remux", "WEB-DL", "WEBRip"}
+	got := sourceHighlight(profile, axes)
+	want := "Uncompressed 4K Bluray Remux (disc-perfect picture)"
+	if got != want {
+		t.Errorf("sourceHighlight(Remux 2160p) = %q, want %q", got, want)
+	}
+}
+
+// Fallback path: profile with no cutoff token should still use flat-set
+// switch so legacy / weird profiles don't lose their highlight.
+func TestSourceHighlight_NoCutoffFallsBackToSet(t *testing.T) {
+	profile := &TrashQualityProfile{Name: "Custom", Cutoff: ""}
+	axes := []string{"Bluray"}
+	got := sourceHighlight(profile, axes)
+	want := "1080p Bluray encodes from approved release groups"
+	if got != want {
+		t.Errorf("sourceHighlight(no cutoff, Bluray set) = %q, want %q", got, want)
+	}
+}
+
+// pickSourceClass — bug 2: previously returned "encodes" for WEB-2160p
+// (Alternative) because Bluray was in the set, blocking the WEB-only
+// short-circuit. Now cutoff overrides.
+func TestPickSourceClass_AltWebReturnsWebDL(t *testing.T) {
+	profile := buildAltWeb2160Profile()
+	axes := ProfileAxes{Sources: []string{"WEBRip", "WEB-DL", "UHD Bluray", "Bluray", "HDTV"}}
+	got := pickSourceClass(profile, axes)
+	if got != "WEB-DL" {
+		t.Errorf("pickSourceClass(WEB-2160p Alt) = %q, want %q", got, "WEB-DL")
+	}
+}
+
+func TestPickSourceClass_RemuxReturnsRemux(t *testing.T) {
+	profile := buildRemux2160Profile()
+	axes := ProfileAxes{Sources: []string{"UHD Bluray Remux", "WEB-DL"}}
+	got := pickSourceClass(profile, axes)
+	if got != "Remux" {
+		t.Errorf("pickSourceClass(Remux 2160p) = %q, want %q", got, "Remux")
+	}
+}
+
+func TestPickSourceClass_FallbackForNoCutoff(t *testing.T) {
+	profile := &TrashQualityProfile{Name: "Custom", Cutoff: ""}
+	// No remux, mixed Bluray + WEB — fallback heuristic returns "encodes".
+	axes := ProfileAxes{Sources: []string{"Bluray", "WEB-DL"}}
+	got := pickSourceClass(profile, axes)
+	if got != "encodes" {
+		t.Errorf("pickSourceClass(no cutoff, mixed) = %q, want %q", got, "encodes")
+	}
+}
+
+// Future-proofing: if TRaSH adds a new cutoff source token (e.g. "HDTV"
+// as a cutoff target on some hypothetical low-bandwidth profile),
+// cutoffSource would return it but pickSourceClass's switch has no
+// matching case. The function must still produce a sensible answer via
+// the fallback heuristic block — not silently return the bare "encodes"
+// label when the underlying axes signal something more specific.
+func TestPickSourceClass_UnknownCutoffFallsThroughToHeuristic(t *testing.T) {
+	// Profile with HDTV cutoff (not in pickSourceClass's switch) but a
+	// WEB-only axes set. Heuristic should kick in and return "WEB-DL".
+	profile := &TrashQualityProfile{
+		Name:   "Hypothetical HDTV-cutoff Web-only",
+		Cutoff: "HDTV-1080p",
+		Items: []QualityItem{
+			{Name: "HDTV-1080p", Allowed: true},
+			{Name: "WEB 1080p", Allowed: true, Items: []string{"WEBRip-1080p", "WEBDL-1080p"}},
+		},
+	}
+	axes := ProfileAxes{Sources: []string{"HDTV", "WEB-DL", "WEBRip"}}
+	got := pickSourceClass(profile, axes)
+	// HDTV cutoff doesn't match the switch; axes has no Bluray/Remux;
+	// isWebOnlyProfile returns false (HDTV in set). Fallback chain
+	// lands on "encodes" — that's the SAFE answer when we don't know
+	// how to label the cutoff specifically. The test asserts the
+	// function doesn't panic and produces a usable string.
+	if got == "" {
+		t.Errorf("pickSourceClass(unknown cutoff) returned empty, want a non-empty fallback")
+	}
+}
+
+// Symmetric test for sourceHighlight — unknown cutoff source should still
+// produce a highlight via the set-based fallback when possible.
+func TestSourceHighlight_UnknownCutoffFallsBackToSet(t *testing.T) {
+	profile := &TrashQualityProfile{
+		Name:   "Hypothetical",
+		Cutoff: "HDTV-1080p",
+		Items: []QualityItem{
+			{Name: "HDTV-1080p", Allowed: true},
+			{Name: "Bluray-1080p", Allowed: true},
+		},
+	}
+	// cutoffSource returns "HDTV" (not in the switch); fall back to set
+	// → "Bluray" in set → returns the Bluray highlight string.
+	axes := []string{"HDTV", "Bluray"}
+	got := sourceHighlight(profile, axes)
+	want := "1080p Bluray encodes from approved release groups"
+	if got != want {
+		t.Errorf("sourceHighlight(unknown cutoff, Bluray fallback) = %q, want %q", got, want)
+	}
+}
+
+// composeTagline — full sentence rendered through both fixed pickers.
+// Locks in that WEB-2160p (Alternative) no longer renders the wrong
+// "high-quality 4K UHD encodes" tagline.
+func TestComposeTagline_AltWebProfile(t *testing.T) {
+	profile := buildAltWeb2160Profile()
+	axes := ProfileAxes{
+		Resolution: "2160p",
+		Sources:    []string{"WEBRip", "WEB-DL", "UHD Bluray", "Bluray", "HDTV"},
+	}
+	got := composeTagline(profile, axes)
+	want := "Prefers high-quality 4K UHD WEB-DL when available · with fallback quality"
+	if got != want {
+		t.Errorf("composeTagline(WEB-2160p Alt) = %q, want %q", got, want)
+	}
+}
+
+// composeHighlights — bug 3: opt-in lossless audio surfaces as a distinct
+// bullet ("Lossless audio available — enable...") when Audio.OptIn is true
+// even though Audio.Scored is false. Scored still wins outright when both
+// flags happen to be set.
+func TestComposeHighlights_AudioOptInBullet(t *testing.T) {
+	profile := buildAltWeb2160Profile()
+	axes := ProfileAxes{
+		Resolution: "2160p",
+		Sources:    []string{"WEBRip", "WEB-DL", "UHD Bluray", "Bluray", "HDTV"},
+		Audio:      ProfileAudioSummary{Scored: false, OptIn: true},
+	}
+	got := composeHighlights(profile, axes)
+	found := false
+	for _, b := range got {
+		if b == "Lossless audio available — enable the [Audio] Audio Formats group to prefer Atmos / DTS-X / TrueHD" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("composeHighlights should include the lossless-available bullet for OptIn=true.\nGot: %v", got)
+	}
+}
+
+func TestComposeHighlights_AudioScoredBullet(t *testing.T) {
+	profile := buildRemux2160Profile()
+	axes := ProfileAxes{
+		Resolution: "2160p",
+		Sources:    []string{"UHD Bluray Remux", "WEB-DL"},
+		Audio:      ProfileAudioSummary{Scored: true},
+	}
+	got := composeHighlights(profile, axes)
+	for _, b := range got {
+		if b == "Prefers releases with lossless audio (Atmos, DTS-X, TrueHD)" {
+			return
+		}
+	}
+	t.Errorf("composeHighlights should include the lossless-preferred bullet for Scored=true.\nGot: %v", got)
+}
+
+func TestComposeHighlights_NoAudioBulletWhenNeither(t *testing.T) {
+	profile := buildAltWeb2160Profile()
+	axes := ProfileAxes{
+		Resolution: "2160p",
+		Sources:    []string{"WEB-DL"},
+		Audio:      ProfileAudioSummary{Scored: false, OptIn: false},
+	}
+	got := composeHighlights(profile, axes)
+	for _, b := range got {
+		// Neither bullet should appear when neither flag is set.
+		if b == "Prefers releases with lossless audio (Atmos, DTS-X, TrueHD)" {
+			t.Errorf("Scored bullet leaked when both audio flags are false: %v", got)
+		}
+		if b == "Lossless audio available — enable the [Audio] Audio Formats group to prefer Atmos / DTS-X / TrueHD" {
+			t.Errorf("OptIn bullet leaked when both audio flags are false: %v", got)
+		}
+	}
+}

--- a/ui/static/css/components.css
+++ b/ui/static/css/components.css
@@ -127,6 +127,23 @@
   .form-group { margin-bottom: 12px; }
   .form-group label { display: block; font-size: 12px; color: var(--text-muted); margin-bottom: 4px; }
 
+  /* Inline link inside descriptive paragraphs. App-color text with
+     a dotted underline so it reads as actionable without screaming
+     "click me" the way a fully underlined accent link does. Solid
+     underline on hover/focus for the click affordance. */
+  .inline-link {
+    color: var(--app-color, var(--accent-blue));
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
+    font-weight: 500;
+  }
+  .inline-link:hover,
+  .inline-link:focus-visible {
+    text-decoration-style: solid;
+    outline: none;
+  }
+
   /* Status indicators */
   .status-connected { color: var(--accent-green); font-size: 12px; }
   .status-failed { color: var(--accent-red); font-size: 12px; }
@@ -178,21 +195,28 @@
 
   .toast-compact {
     width: fit-content;
-    min-width: min(300px, 100%);
+    min-width: min(260px, 100%);
     max-width: min(420px, 100%);
-    min-height: 34px;
     border-radius: 7px;
   }
 
   .toast-compact .toast-content {
     min-height: 0;
-    padding: 8px 34px 9px 14px;
+    padding: 5px 30px 6px 12px;
     line-height: 1.3;
   }
 
   .toast-compact .toast-message {
     max-height: none;
     line-height: 1.25;
+  }
+
+  /* Single-line toast (no title, no header, no progress space):
+     content shrinks to text height. The close button's own min size
+     (22px) becomes the floor on hover but doesn't inflate the box
+     when the user isn't hovering. */
+  .toast-compact .toast-header {
+    margin-bottom: 1px;
   }
 
   .toast-info,
@@ -239,9 +263,9 @@
   }
 
   .toast-content {
-    padding: 9px 34px 10px 14px;
+    padding: 7px 34px 8px 14px;
     font-size: 12px;
-    line-height: 1.35;
+    line-height: 1.3;
     overflow-wrap: anywhere;
     white-space: pre-line;
   }
@@ -260,7 +284,7 @@
     align-items: center;
     justify-content: space-between;
     gap: 10px;
-    margin-bottom: 2px;
+    margin-bottom: 1px;
     padding-right: 2px;
   }
 

--- a/ui/static/css/features/profiles.css
+++ b/ui/static/css/features/profiles.css
@@ -699,3 +699,69 @@ button.v3-status:hover { text-decoration: underline; }
 .tpd-view-list .tpd-card.open > .tpd-card-title-row .tpd-card-chevron { transform: rotate(90deg); }
 .tpd-view-list .tpd-card-body { display: none; padding: 4px 14px 10px 28px; }
 .tpd-view-list .tpd-card.open .tpd-card-body { display: flex; flex-direction: column; gap: 8px; }
+
+/* ===== Sync Rules sub-tab strip =====
+   Profiles | Custom Formats toggle at the top of the Sync Rules page.
+   Two buttons, app-color underline on the active one. */
+.sync-rules-subtabs {
+  display: flex; gap: 4px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.sync-rules-subtabs button {
+  background: transparent; border: none; outline: none; cursor: pointer;
+  padding: 8px 14px;
+  font-size: 13px; font-weight: 500;
+  color: var(--text-muted);
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color 150ms, border-color 150ms;
+}
+.sync-rules-subtabs button:hover { color: var(--text-body); }
+.sync-rules-subtabs button.sync-rules-subtab-active {
+  color: var(--app-color, var(--text-body));
+  border-bottom-color: var(--app-color, var(--text-body));
+}
+
+/* ===== Sync Rules → Custom Formats sub-tab table =====
+   Five-column layout: Name | Category | Used by | Status | Actions.
+   Rows alternate row-hover background to scan a long list quickly. */
+.cf-sr-table { display: flex; flex-direction: column; }
+.cf-sr-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) 140px 100px 140px minmax(140px, auto);
+  align-items: center; gap: 12px;
+  padding: 8px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 13px;
+}
+.cf-sr-row:last-child { border-bottom: none; }
+.cf-sr-row:not(.cf-sr-header):hover { background: var(--bg-row-hover, var(--bg-elevated)); }
+.cf-sr-header {
+  font-size: 11px; font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: 0.5px;
+  background: var(--bg-page);
+}
+.cf-sr-name { font-weight: 500; color: var(--text-body); }
+.cf-sr-cat { color: var(--text-muted); font-size: 12px; }
+.cf-sr-uses { color: var(--text-muted); font-size: 12px; cursor: help; }
+
+/* Pills mirror the Sync Rules row-pill language (In sync / Arr drift)
+   so users only learn one vocabulary across the two sub-tabs. */
+.cf-sr-pill {
+  display: inline-block;
+  padding: 3px 10px;
+  font-size: 11px; font-weight: 600;
+  border-radius: 12px;
+  white-space: nowrap;
+}
+.cf-sr-pill-ok {
+  background: color-mix(in srgb, var(--accent-green) 14%, transparent);
+  color: var(--accent-green);
+}
+.cf-sr-pill-drift {
+  background: color-mix(in srgb, var(--accent-red) 14%, transparent);
+  color: var(--accent-red);
+  cursor: help;
+}

--- a/ui/static/css/features/profiles.css
+++ b/ui/static/css/features/profiles.css
@@ -167,14 +167,16 @@
   white-space: nowrap; font-weight: 500;
 }
 .v3-status.ok { color: var(--accent-green); }
-/* Three distinct labels share the same accent-orange — they belong to
-   the same "needs attention" family — but the labels (rendered in the
-   markup) tell the user the CAUSE + action:
-     pending     → user saved local edits, click Sync/Apply to push
-     updates     → TRaSH-Guides has upstream updates for this rule
-     out-of-sync → Arr-side drift (Phase D — reserved colour) */
+/* Three "needs attention"-class labels with a deliberate hue split
+   between informational and action-needed:
+     pending     → orange. User saved local edits, click Sync/Apply to push.
+     updates     → blue. TRaSH-Guides has upstream updates for this rule;
+                   informational — you may or may not want to adopt them.
+     out-of-sync → orange. Arr-side drift; needs Apply or Update.
+   Matches the CF Sync Rules pill family so users learn one color
+   vocabulary across both surfaces. Red stays reserved for failure. */
 .v3-status.pending { color: var(--accent-orange); }
-.v3-status.updates { color: var(--accent-orange); }
+.v3-status.updates { color: var(--accent-blue); }
 .v3-status.out-of-sync { color: var(--accent-orange); }
 .v3-status.failed { color: var(--accent-red); }
 /* Clickable variant for places where the pill should act as a button
@@ -730,24 +732,31 @@ button.v3-status:hover { text-decoration: underline; }
 .cf-sr-cat { color: var(--text-muted); font-size: 12px; }
 .cf-sr-uses { color: var(--text-muted); font-size: 12px; cursor: help; }
 
-/* Pills mirror the Sync Rules row-pill language (In sync / Arr drift)
-   so users only learn one vocabulary across the two sub-tabs. */
+/* Status indicators — plain colored text, no pill background.
+   Reads quieter on the eye when the table is full and matches the
+   Profile Sync Rules' inline .v3-status pattern. Colors carry the
+   meaning; weight (600) gives enough visual weight to stand out. */
 .cf-sr-pill {
-  display: inline-block;
-  padding: 3px 10px;
-  font-size: 11px; font-weight: 600;
-  border-radius: 12px;
+  font-size: 12px; font-weight: 600;
   white-space: nowrap;
 }
-.cf-sr-pill-ok {
-  background: color-mix(in srgb, var(--accent-green) 14%, transparent);
-  color: var(--accent-green);
-}
+.cf-sr-pill-ok { color: var(--accent-green); }
 .cf-sr-pill-drift {
-  /* Orange family matches Profile Sync Rules' .v3-status.out-of-sync —
-     drift is "needs attention", not "failed". Red stays reserved for
-     genuine errors (failed sync, diff fetch error). */
-  background: color-mix(in srgb, var(--accent-orange) 14%, transparent);
+  /* Orange — matches Profile Sync Rules' .v3-status.out-of-sync.
+     Red stays reserved for true errors (failed sync, diff fetch). */
+  color: var(--accent-orange);
+  cursor: help;
+}
+.cf-sr-pill-upd {
+  /* Blue — informational; TRaSH-Guides has new content not yet
+     synced. Distinct hue from the orange drift family so the user
+     reads "informational" vs "action needed" at a glance. */
+  color: var(--accent-blue);
+}
+.cf-sr-pill-both {
+  /* Combined update + drift: orange wins (drift dominates the
+     visual hierarchy) with a "+ update" suffix so the user still
+     knows there's upstream content waiting. */
   color: var(--accent-orange);
   cursor: help;
 }
@@ -828,6 +837,24 @@ button.v3-status:hover { text-decoration: underline; }
   color: var(--accent-orange);
   font-weight: 700;
   opacity: 0.9;
+}
+/* Updates view-pin — blue family to match the row pill so the user
+   reads both as the same "informational / upstream-ready" channel. */
+.cf-sr-side-view-upd {
+  color: var(--accent-blue);
+}
+.cf-sr-side-view-upd .cf-sr-side-count {
+  color: var(--accent-blue);
+  font-weight: 700;
+  opacity: 0.9;
+}
+.cf-sr-side-view-upd.active {
+  background: color-mix(in srgb, var(--app-color, var(--accent-blue)) 12%, transparent);
+  color: var(--app-color, var(--text-body));
+}
+.cf-sr-side-view-upd.active .cf-sr-side-count {
+  color: inherit;
+  opacity: 0.85;
 }
 .cf-sr-side-view.active {
   background: color-mix(in srgb, var(--app-color, var(--accent-blue)) 12%, transparent);
@@ -1098,7 +1125,8 @@ button.v3-status:hover { text-decoration: underline; }
    second pill. The orange family already lives in the row pills
    + sidebar Drifted filter; we don't need another instance of it
    in the card header. */
-.cf-sr-card-drift-text {
+.cf-sr-card-drift-text,
+.cf-sr-card-update-text {
   font-size: 11.5px;
   color: var(--text-muted);
   font-weight: 400;

--- a/ui/static/css/features/profiles.css
+++ b/ui/static/css/features/profiles.css
@@ -700,41 +700,24 @@ button.v3-status:hover { text-decoration: underline; }
 .tpd-view-list .tpd-card-body { display: none; padding: 4px 14px 10px 28px; }
 .tpd-view-list .tpd-card.open .tpd-card-body { display: flex; flex-direction: column; gap: 8px; }
 
-/* ===== Sync Rules sub-tab strip =====
-   Profiles | Custom Formats toggle at the top of the Sync Rules page.
-   Two buttons, app-color underline on the active one. */
-.sync-rules-subtabs {
-  display: flex; gap: 4px;
-  margin-bottom: 16px;
-  border-bottom: 1px solid var(--border-subtle);
-}
-.sync-rules-subtabs button {
-  background: transparent; border: none; outline: none; cursor: pointer;
-  padding: 8px 14px;
-  font-size: 13px; font-weight: 500;
-  color: var(--text-muted);
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  transition: color 150ms, border-color 150ms;
-}
-.sync-rules-subtabs button:hover { color: var(--text-body); }
-.sync-rules-subtabs button.sync-rules-subtab-active {
-  color: var(--app-color, var(--text-body));
-  border-bottom-color: var(--app-color, var(--text-body));
-}
-
-/* ===== Sync Rules → Custom Formats sub-tab table =====
+/* ===== Custom Formats → Sync Rules sub-tab table =====
    Five-column layout: Name | Category | Used by | Status | Actions.
    Rows alternate row-hover background to scan a long list quickly. */
 .cf-sr-table { display: flex; flex-direction: column; }
 .cf-sr-row {
   display: grid;
-  grid-template-columns: minmax(0, 1.5fr) 140px 100px 140px minmax(140px, auto);
-  align-items: center; gap: 12px;
+  /* 6 columns: Name | Category | Used in | Status | Last sync | Actions
+     Name flexes (min 0 so long names truncate); Last sync is short
+     ("12h ago"); Actions is auto-sized to fit "Update" or "Updating...". */
+  grid-template-columns: minmax(0, 1.5fr) minmax(120px, 0.6fr) 90px 100px 90px minmax(110px, auto);
+  align-items: center; gap: 10px;
   padding: 8px 18px;
   border-bottom: 1px solid var(--border-subtle);
   font-size: 13px;
 }
+.cf-sr-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cf-sr-cat { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cf-sr-lastsync { color: var(--text-muted); font-size: 12px; white-space: nowrap; }
 .cf-sr-row:last-child { border-bottom: none; }
 .cf-sr-row:not(.cf-sr-header):hover { background: var(--bg-row-hover, var(--bg-elevated)); }
 .cf-sr-header {
@@ -761,7 +744,424 @@ button.v3-status:hover { text-decoration: underline; }
   color: var(--accent-green);
 }
 .cf-sr-pill-drift {
-  background: color-mix(in srgb, var(--accent-red) 14%, transparent);
-  color: var(--accent-red);
+  /* Orange family matches Profile Sync Rules' .v3-status.out-of-sync —
+     drift is "needs attention", not "failed". Red stays reserved for
+     genuine errors (failed sync, diff fetch error). */
+  background: color-mix(in srgb, var(--accent-orange) 14%, transparent);
+  color: var(--accent-orange);
   cursor: help;
+}
+
+/* ===== CF sub-tab: sidebar + main pane layout =====
+   Two-column grid mirroring the Custom Formats Browse tab so users
+   carry the same mental model across both surfaces. Sidebar pinned
+   at 200px; main pane fills remaining width. */
+.cf-sr-layout {
+  display: grid;
+  grid-template-columns: 200px minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+.cf-sr-side {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 6px;
+  position: sticky;
+  top: 10px;
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+}
+.cf-sr-side-all .cf-sr-side-label { font-weight: 500; }
+
+/* View-filter block (Drifted etc) sits at the top of the sidebar
+   with a divider below so it visually separates from the
+   categories tree. The block only renders when at least one view
+   filter is applicable. */
+.cf-sr-side-views {
+  display: flex; flex-direction: column;
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.cf-sr-side-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center; gap: 6px;
+  width: 100%;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--text-body);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+.cf-sr-side-item:hover { background: var(--bg-row-hover, var(--bg-page)); }
+.cf-sr-side-item.active {
+  background: color-mix(in srgb, var(--app-color, var(--accent-blue)) 12%, transparent);
+  color: var(--app-color, var(--text-body));
+  font-weight: 600;
+}
+.cf-sr-side-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.cf-sr-side-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.cf-sr-side-item.active .cf-sr-side-count { color: inherit; opacity: 0.8; }
+
+/* View-filter pin variant (Drifted). Orange family — matches the
+   row pill + per-card chip + Profile Sync Rules' "Arr drift" status
+   so the user reads one consistent color across all drift surfaces.
+   Active state pulls the app-color treatment same as a category pin
+   so the picked-state visual language is uniform. */
+.cf-sr-side-view {
+  color: var(--accent-orange);
+}
+.cf-sr-side-view .cf-sr-side-count {
+  color: var(--accent-orange);
+  font-weight: 700;
+  opacity: 0.9;
+}
+.cf-sr-side-view.active {
+  background: color-mix(in srgb, var(--app-color, var(--accent-blue)) 12%, transparent);
+  color: var(--app-color, var(--text-body));
+}
+.cf-sr-side-view.active .cf-sr-side-count {
+  color: inherit;
+  opacity: 0.85;
+}
+
+/* Main pane wrapper — owns the header bar above the table so the
+   counts + actions sit visually attached to the table they describe. */
+.cf-sr-main {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.cf-sr-header-bar {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 10px 16px;
+  /* Mirror v3-inst-header's app-color gradient so the CF sub-tab
+     reads as belonging to the active app the same way Sync Rules
+     Profiles cards do. --app-glow fades to transparent so longer
+     header rows stay legible on the right; border-image carries
+     the same fade for the bottom border. */
+  background: linear-gradient(90deg, var(--app-glow) 0%, transparent 60%), var(--bg-elevated);
+  border-bottom: 1px solid var(--border-muted);
+  border-image: linear-gradient(90deg, var(--app-color) 0%, var(--border-muted) 60%, var(--border-muted) 100%) 1;
+  flex-wrap: wrap;
+}
+.cf-sr-counts { display: flex; align-items: baseline; gap: 10px; }
+.cf-sr-counts > span:first-child { color: var(--app-color); }
+.cf-sr-counts-muted { color: var(--text-muted); font-size: 12px; }
+.cf-sr-counts-warn { color: var(--accent-red); }
+.cf-sr-header-actions { display: flex; gap: 8px; }
+
+/* Filter row — instance picker + search. Lighter weight than the
+   action row above so the action buttons read as primary. */
+.cf-sr-filter-bar {
+  display: flex; align-items: center; gap: 14px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-page);
+  flex-wrap: wrap;
+}
+.cf-sr-filter-group {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12px;
+  position: relative;
+}
+.cf-sr-filter-search { flex: 1 1 220px; max-width: 360px; }
+/* Pushes Check (and any future right-side actions) to the far
+   right of the action row so Expand/Collapse + filters live on the
+   left and the primary action sits on the right. */
+.cf-sr-filter-actions { margin-left: auto; display: flex; gap: 8px; }
+.cf-sr-filter-label {
+  color: var(--text-muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  font-size: 10px;
+}
+.cf-sr-filter-select,
+.cf-sr-filter-input {
+  padding: 5px 10px;
+  font-size: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-subtle);
+  border-radius: 5px;
+  color: var(--text-body);
+}
+.cf-sr-filter-input { flex: 1 1 auto; padding-right: 26px; }
+.cf-sr-filter-input:focus,
+.cf-sr-filter-select:focus {
+  outline: none;
+  border-color: var(--app-color, var(--accent-blue));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--app-color, var(--accent-blue)) 25%, transparent);
+}
+.cf-sr-filter-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 18px; height: 18px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 16px;
+  cursor: pointer;
+  border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.cf-sr-filter-clear:hover {
+  background: var(--bg-row-hover, var(--bg-page));
+  color: var(--text-body);
+}
+/* In-flight Apply-all label — shows the CF+instance currently being
+   pushed. Compact one-liner so it doesn't push the table down. */
+.cf-sr-progress {
+  padding: 6px 18px;
+  font-size: 12px;
+  color: var(--text-muted);
+  background: color-mix(in srgb, var(--app-color, var(--accent-blue)) 6%, transparent);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+/* Used-by cell — passive visual indicator now that the entire row
+   is the expand affordance. Chevron flips to indicate open state. */
+.cf-sr-uses {
+  display: inline-flex; align-items: center; gap: 4px;
+  color: var(--text-muted);
+  font-size: 12px;
+  cursor: help;
+}
+.cf-sr-uses-chev {
+  display: inline-block;
+  font-size: 10px;
+  color: var(--text-muted);
+  transform: rotate(0deg);
+  transition: transform 0.15s ease;
+}
+.cf-sr-uses-chev.open { transform: rotate(90deg); }
+
+/* Whole-row click affordance. Cursor + hover background + keyboard
+   focus ring so the row reads as "press me to see more". Apply
+   buttons inside the row use @click.stop so the row handler doesn't
+   double-fire when the user is pressing one of those. */
+.cf-sr-row-clickable { cursor: pointer; }
+.cf-sr-row-clickable:hover { background: var(--bg-row-hover, var(--bg-elevated)); }
+.cf-sr-row-clickable:focus-visible {
+  outline: 2px solid var(--app-color, var(--accent-blue));
+  outline-offset: -2px;
+}
+
+/* Expand-row: inline detail panel showing the profile list. Indented
+   under the row it belongs to with a left accent border in app-color
+   so the visual ownership is obvious. */
+.cf-sr-row-expanded { background: var(--bg-row-hover, var(--bg-page)); }
+.cf-sr-expand {
+  padding: 10px 18px 12px 28px;
+  border-bottom: 1px solid var(--border-subtle);
+  border-left: 3px solid var(--app-color, var(--accent-blue));
+  background: var(--bg-page);
+}
+.cf-sr-expand-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+.cf-sr-expand-list {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.cf-sr-expand-list li {
+  display: flex; align-items: center; gap: 8px;
+  font-size: 12px;
+}
+.cf-sr-expand-prof {
+  color: var(--text-body);
+  font-weight: 500;
+}
+
+/* Expand-row sectioning — distinct visual blocks for "In profiles"
+   and "Drift detail" so the user scans for what they care about.
+   Section title is small + uppercase to read as a label. */
+.cf-sr-expand-section { margin-bottom: 10px; }
+.cf-sr-expand-section:last-child { margin-bottom: 0; }
+.cf-sr-expand-section-title {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+/* Per-instance diff block — one card per drifted instance so the
+   per-instance context is unmistakable in a multi-instance setup. */
+.cf-sr-diff-block {
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  padding: 8px 12px;
+  margin-bottom: 6px;
+}
+.cf-sr-diff-block:last-child { margin-bottom: 0; }
+.cf-sr-diff-inst {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--app-color, var(--text-body));
+  margin-bottom: 6px;
+}
+.cf-sr-diff-status {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+.cf-sr-diff-status-ok { color: var(--accent-green); font-style: normal; }
+.cf-sr-diff-status-err { color: var(--accent-red); font-style: normal; }
+.cf-sr-diff-body {
+  display: flex; flex-direction: column; gap: 3px;
+}
+/* One change per line, plain prose with bold for names and the
+   verb-prefix so the user can scan the list without parsing group
+   headers. Mirrors Profile Sync Rules' status-review modal format. */
+.cf-sr-diff-line {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-body);
+  overflow-wrap: anywhere;
+  padding: 1px 0;
+}
+.cf-sr-diff-verb {
+  color: var(--text-muted);
+  font-weight: 500;
+  margin-right: 2px;
+}
+.cf-sr-diff-val {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-body);
+  overflow-wrap: anywhere;
+}
+.cf-sr-diff-arrow {
+  color: var(--text-muted);
+  font-weight: 600;
+  margin: 0 2px;
+}
+
+/* Hierarchical sidebar — parent + children with chevron toggle.
+   Mirrors Browse tab's tree visually so users carry one mental
+   model across both surfaces. */
+.cf-sr-side-group { display: flex; flex-direction: column; }
+.cf-sr-side-parent-row { display: flex; align-items: center; }
+.cf-sr-side-chevron {
+  background: transparent;
+  border: 0;
+  padding: 6px 4px 6px 6px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 10px;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: transform 0.15s, color 0.12s;
+}
+.cf-sr-side-chevron.open { transform: rotate(90deg); }
+.cf-sr-side-chevron:hover { color: var(--text-body); }
+.cf-sr-side-parent { flex: 1 1 auto; }
+.cf-sr-side-children {
+  display: flex; flex-direction: column;
+  padding-left: 18px;
+}
+.cf-sr-side-child {
+  padding-left: 12px;
+  font-size: 12px;
+}
+
+/* Per-instance card extras — drift chip in header + sub-category tag */
+.cf-sr-inst-card { margin-bottom: 14px; }
+.cf-sr-inst-card:last-child { margin-bottom: 0; }
+/* Plain-text drift indicator in the per-instance card header.
+   No badge background, no accent color — just muted text so it
+   reads as quiet metadata next to the CF count instead of a
+   second pill. The orange family already lives in the row pills
+   + sidebar Drifted filter; we don't need another instance of it
+   in the card header. */
+.cf-sr-card-drift-text {
+  font-size: 11.5px;
+  color: var(--text-muted);
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+}
+.cf-sr-subcat {
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+/* Expand-row profile table — rich per-rule breakdown of which
+   profiles use this CF on this instance, with auto-sync state and
+   last-sync timestamp. */
+.cf-sr-prof-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.cf-sr-prof-table th {
+  text-align: left;
+  font-size: 10px; font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase; letter-spacing: 0.5px;
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.cf-sr-prof-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-body);
+}
+.cf-sr-prof-table tr:last-child td { border-bottom: none; }
+.cf-sr-prof-id {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  color: var(--text-muted);
+  width: 1%;
+  white-space: nowrap;
+}
+.cf-sr-prof-arrow {
+  color: var(--text-muted);
+  width: 1%;
+  text-align: center;
+  white-space: nowrap;
+}
+/* Responsive: collapse the sidebar to a horizontal scroll-strip on
+   narrow viewports so the table keeps its width budget. */
+@media (max-width: 900px) {
+  .cf-sr-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .cf-sr-side {
+    position: static;
+    display: flex;
+    gap: 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    max-height: none;
+    padding: 6px;
+  }
+  .cf-sr-side-header { display: none; }
+  .cf-sr-side-item {
+    flex: 0 0 auto;
+    grid-template-columns: auto auto auto;
+  }
 }

--- a/ui/static/index.html
+++ b/ui/static/index.html
@@ -76,6 +76,7 @@
   {{template "modals/input-dialog" .}}
   {{template "modals/tooltip" .}}
   {{template "modals/sandbox-copy" .}}
+  {{template "modals/sandbox-export" .}}
   {{template "modals/toasts" .}}
   {{template "modals/cf-editor" .}}
   {{template "modals/cf-export" .}}

--- a/ui/static/js/features/navigation.js
+++ b/ui/static/js/features/navigation.js
@@ -125,6 +125,7 @@ export default {
       const app = this.activeAppType;
       let hash = '#' + app + '/' + s;
       if (s === 'profiles') hash += '/' + (this.getProfileTab(app) || 'trash-profiles');
+      else if (s === 'custom-formats') hash += '/' + (this.getCustomFormatsTab(app) || 'browse');
       else if (s === 'media-management') hash += '/' + (this.getMediaTab(app) || 'quality');
       else if (s === 'maintenance') hash += '/' + (this.getMaintenanceTab(app) || 'backup');
       else if (s === 'advanced') hash += '/' + (this.advancedTab || 'builder');
@@ -147,6 +148,8 @@ export default {
       let hash = '#' + app + '/' + section;
       if (section === 'profiles') {
         hash += '/' + (opts.profileTab || this.getProfileTab(app) || 'trash-profiles');
+      } else if (section === 'custom-formats') {
+        hash += '/' + (opts.customFormatsTab || this.getCustomFormatsTab(app) || 'browse');
       } else if (section === 'media-management') {
         hash += '/' + (opts.mediaTab || this.getMediaTab(app) || 'quality');
       } else if (section === 'maintenance') {
@@ -209,6 +212,7 @@ export default {
       // bookmarks and hashes keep working after the sub-tab split. Mapped
       // during hash restore below.
       const validProfileTabs = ['trash-profiles','sync-rules','history','compare','trash-sync'];
+      const validCustomFormatsTabs = ['browse','sync-rules'];
       const validMediaTabs = ['quality','naming'];
       const validMaintenanceTabs = ['backup','cleanup'];
       const validAdvancedTabs = ['builder','group-builder','scoring','import'];
@@ -244,6 +248,9 @@ export default {
               // on the profile-browser tab (the more discoverable side).
               const tab = parts[2] === 'trash-sync' ? 'trash-profiles' : parts[2];
               this.setProfileTab(this.activeAppType, tab);
+            }
+            else if (this.currentSection === 'custom-formats' && validCustomFormatsTabs.includes(parts[2])) {
+              this.setCustomFormatsTab(this.activeAppType, parts[2]);
             }
             else if (this.currentSection === 'media-management' && validMediaTabs.includes(parts[2])) {
               this.setMediaTab(this.activeAppType, parts[2]);
@@ -282,6 +289,18 @@ export default {
     },
     setMediaTab(appType, tab) {
       this.mediaTabs = { ...this.mediaTabs, [appType]: tab };
+    },
+
+    // Custom Formats sub-tabs — same per-app pattern as profileTabs.
+    // Default sub-tab is 'browse' (the existing TRaSH + custom CF
+    // catalog) — most visitors come here to browse, not to manage
+    // active sync state. Switching to 'sync-rules' triggers a fetch
+    // of /api/cf-sync-rules so the per-CF state is fresh.
+    getCustomFormatsTab(appType) {
+      return this.customFormatsTabs[appType] || 'browse';
+    },
+    setCustomFormatsTab(appType, tab) {
+      this.customFormatsTabs = { ...this.customFormatsTabs, [appType]: tab };
     },
 
     // Maintenance sub-tabs — Backup & Restore vs Cleanup. Default

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -3436,6 +3436,18 @@ export default {
 
     // Number of CFs currently drifted on at least one instance, for the
     // card-header summary line ("3 drifted" / "All in sync").
+    // Number of instances on this row that have a TRaSH upstream
+    // update pending. Symmetric with cfRowDriftCount — feeds the
+    // per-row status pill + "X updates" badges.
+    cfRowUpdateCount(row) {
+      if (!row || !Array.isArray(row.instances)) return 0;
+      let n = 0;
+      for (const inst of row.instances) {
+        if (inst && inst.updateAvailable) n++;
+      }
+      return n;
+    },
+
     cfDriftedCount(appType) {
       // Reflect what's actually in the current view — when the user
       // scopes to one instance via the picker, "drifted" should mean
@@ -3446,6 +3458,17 @@ export default {
       let n = 0;
       for (const row of rows) {
         if (this.cfRowDriftCount(row) > 0) n++;
+      }
+      return n;
+    },
+
+    // Update-available row count for the currently-visible scope.
+    // Symmetric with cfDriftedCount.
+    cfUpdatesCount(appType) {
+      const rows = this.cfSyncRulesFiltered(appType) || [];
+      let n = 0;
+      for (const row of rows) {
+        if (this.cfRowUpdateCount(row) > 0) n++;
       }
       return n;
     },
@@ -3656,6 +3679,15 @@ export default {
           })
           .filter(Boolean);
       }
+      if (cat === 'view:updates') {
+        rows = rows
+          .map(r => {
+            const updOnly = (r.instances || []).filter(i => i.updateAvailable);
+            if (updOnly.length === 0) return null;
+            return { ...r, instances: updOnly };
+          })
+          .filter(Boolean);
+      }
       const q = (this.cfSyncRulesSearch || '').trim().toLowerCase();
       if (q) {
         rows = rows.filter(r => {
@@ -3710,6 +3742,127 @@ export default {
         if (r.instance && r.instance.drift) n++;
       }
       return n;
+    },
+
+    // Update-available count for the per-instance card.
+    cfSRInstanceCardUpdateCount(card) {
+      let n = 0;
+      for (const r of (card.rows || [])) {
+        if (r.instance && r.instance.updateAvailable) n++;
+      }
+      return n;
+    },
+
+    // Pull TRaSH then sync the rule(s) on this instance that pull
+    // this CF in. The pull step is shared (a single Update click on
+    // any CF gets the whole TRaSH-Guides advance), but only the
+    // specific rules tied to this CF run their per-Arr sync — other
+    // rules on the instance stay at their previous lastSyncCommit
+    // so the user can opt in CF-by-CF instead of having to commit
+    // to "sync everything".
+    async updateCFForInstance(instanceId, trashId, cfName, instanceName, ruleIds) {
+      if (!instanceId || !trashId || !Array.isArray(ruleIds) || ruleIds.length === 0) return;
+      const key = instanceId + ':' + trashId;
+      if (this.cfApplyingKey === key) return;
+      // updatingRuleId intentionally NOT guarded — see comment on the
+      // button's :disabled binding. updatingInstance is still checked
+      // since a card-level Update all on the same instance is a real
+      // mutex (both flows pull TRaSH).
+      if (this.updatingInstance === instanceId) return;
+      this.cfApplyingKey = key;
+      try {
+        const inst = this.instances.find(i => i.id === instanceId);
+        if (!inst) return;
+        await fetch('/api/trash/pull', { method: 'POST' });
+        await this._waitForPullDone();
+        if (this.trashStatus?.pullError) {
+          this.showToast(`Update CF: pull failed — ${this.trashStatus.pullError}`, 'error', 8000);
+          return;
+        }
+        await this.loadCFBrowse(inst.type);
+        await this.loadTrashProfiles(inst.type);
+        // Narrow the candidate rule set to ONLY rules that actually
+        // have a TRaSH-side pending change matching this trashId.
+        // Without this filter, every rule that pulls the CF into its
+        // profile would re-sync — bumping their LastSyncTime to "just
+        // now" and burning Arr API calls even when those rules had no
+        // upstream change to act on. The split-on-first-colon mirrors
+        // the backend's affectedId → trash_id recovery in cf_sync_rules.go.
+        const ruleHasPendingForCF = (rule) => {
+          for (const pc of (rule.pendingChanges || [])) {
+            if (pc.source !== 'trash') continue;
+            if (!pc.changeType || !pc.changeType.startsWith('cf-')) continue;
+            const aid = pc.affectedId || '';
+            const ci = aid.indexOf(':');
+            const pcTid = ci > 0 ? aid.slice(0, ci) : aid;
+            if (pcTid === trashId) return true;
+          }
+          return false;
+        };
+        const filteredRuleIds = ruleIds.filter(rid => {
+          const rule = this.autoSyncRules.find(r => r.id === rid);
+          return rule && ruleHasPendingForCF(rule);
+        });
+        // Defensive fallback: if nothing matches (stale state, dedup
+        // edge case), fall back to the full list so the user's click
+        // does SOMETHING rather than silently no-op'ing.
+        const effectiveRuleIds = filteredRuleIds.length > 0 ? filteredRuleIds : ruleIds;
+        let succeeded = 0;
+        const failures = [];
+        // Reuse syncAllForInstance's ruleToHistoryShape adapter so the
+        // sh body sent to quickSync is byte-identical to the working
+        // Update all path. Earlier attempt at hand-rolling the shape
+        // missed selectedCFs map + override fields, which quickSync
+        // would then read as undefined and the backend would reject
+        // silently → "Update button does nothing".
+        const ruleToShape = (r) => {
+          const cfMap = {};
+          for (const id of (r.selectedCFs || [])) cfMap[id] = true;
+          const arrName = (typeof this.resolveArrProfileName === 'function')
+            ? this.resolveArrProfileName(r.instanceId, r.arrProfileId)
+            : '';
+          const profileName = arrName
+            ? `${arrName} (#${r.arrProfileId})`
+            : `Arr profile #${r.arrProfileId}`;
+          return {
+            profileTrashId: r.trashProfileId || '',
+            importedProfileId: r.importedProfileId || '',
+            arrProfileId: r.arrProfileId,
+            arrProfileName: arrName,
+            profileName: profileName,
+            selectedCFs: cfMap,
+            scoreOverrides: r.scoreOverrides || null,
+            qualityOverrides: r.qualityOverrides || null,
+            qualityStructure: r.qualityStructure || null,
+            overrides: r.overrides || null,
+            behavior: r.behavior || null,
+          };
+        };
+        for (const rid of effectiveRuleIds) {
+          const rule = this.autoSyncRules.find(r => r.id === rid);
+          if (!rule) continue;
+          const sh = ruleToShape(rule);
+          try {
+            const res = await this.quickSync(inst, sh, /* silent */ true);
+            if (res && res.ok) {
+              succeeded++;
+            } else {
+              failures.push(`${sh.profileName}: ${res?.error || 'unknown'}`);
+            }
+          } catch (e) {
+            failures.push(`${sh.profileName || rule.id}: ${e.message}`);
+          }
+        }
+        await this.loadAutoSyncRules();
+        await this.loadCFSyncRules(this.activeAppType);
+        if (failures.length === 0) {
+          this.showToast(`"${cfName}" updated on ${instanceName}.`, 'success', 4000);
+        } else {
+          this.showToast(`"${cfName}" partial update on ${instanceName}: ${succeeded} ok, ${failures.length} failed.`, 'warning', 6000);
+        }
+      } finally {
+        this.cfApplyingKey = '';
+      }
     },
 
     // Most recent sync timestamp across all profiles pulling this CF
@@ -3807,6 +3960,26 @@ export default {
       let n = 0;
       for (const row of rows) {
         if (this.cfRowDriftCount(row) > 0) n++;
+      }
+      return n;
+    },
+
+    // Mirror of cfSyncRulesDriftedTotal for upstream-update view-pin.
+    cfSyncRulesUpdatesTotal(appType) {
+      let rows = this.cfSyncRules[appType] || [];
+      const instId = this.cfSyncRulesActiveInstance || '';
+      if (instId) {
+        rows = rows
+          .map(r => {
+            const filtered = (r.instances || []).filter(i => i.id === instId);
+            if (filtered.length === 0) return null;
+            return { ...r, instances: filtered };
+          })
+          .filter(Boolean);
+      }
+      let n = 0;
+      for (const row of rows) {
+        if (this.cfRowUpdateCount(row) > 0) n++;
       }
       return n;
     },
@@ -6131,6 +6304,14 @@ export default {
         await this.loadTrashProfiles(inst.type);
         // Now run the existing per-instance sync-all loop
         await this.syncAllForInstance(inst);
+        // Refresh CF Sync Rules cache so its pills (Updates / Arr
+        // drift) reflect the post-sync state. Without this the user
+        // sees stale Update/drift indicators on Custom Formats →
+        // Sync Rules even though backend cleared PendingChanges +
+        // CFDriftFingerprints during the sync.
+        if (typeof this.loadCFSyncRules === 'function' && this.cfSyncRulesLoaded?.[inst.type]) {
+          await this.loadCFSyncRules(inst.type);
+        }
         if (this.trashStatus?.commitHash && this.trashStatus.commitHash !== prevCommit) {
           this.showToast(`Update all complete (${inst.name}) — TRaSH advanced to ${this.trashStatus.commitHash}`, 'success', 4000);
         }
@@ -6160,6 +6341,12 @@ export default {
         // Reuse the existing quickSync path for the actual Arr write.
         await this.quickSync(inst, sh);
         await this.loadAutoSyncRules();
+        // Same CF Sync Rules refresh as updateAllForInstance — without
+        // this, a user updating one profile sees its pills clear on the
+        // Profile Sync surface but the CF surface stays stuck.
+        if (typeof this.loadCFSyncRules === 'function' && this.cfSyncRulesLoaded?.[inst.type]) {
+          await this.loadCFSyncRules(inst.type);
+        }
       } finally {
         this.updatingRuleId = '';
       }

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -3403,6 +3403,78 @@ export default {
       }
     },
 
+    // Fetch the per-CF view that drives the Sync Rules → Custom Formats
+    // sub-tab. Lazy-loaded: only fires on first click of the Custom
+    // Formats sub-tab (not on tab mount), so users who never visit the
+    // sub-tab don't pay the per-instance ArrCF list cost. Re-runs after
+    // an Apply succeeds so the row's status pill refreshes without
+    // requiring the user to navigate away and back.
+    async loadCFSyncRules(appType) {
+      if (!appType) return;
+      try {
+        const r = await fetch(`/api/cf-sync-rules/${appType}`);
+        if (!r.ok) return;
+        const data = await r.json();
+        this.cfSyncRules[appType] = data.items || [];
+        this.cfSyncRulesLoaded[appType] = true;
+      } catch (e) {
+        console.error('loadCFSyncRules:', e);
+      }
+    },
+
+    // Number of instances on which the row is currently drifted. Drives
+    // both the per-row pill ("Arr drift (2)") and the per-instance Apply
+    // button cluster (one button per drifted instance).
+    cfRowDriftCount(row) {
+      if (!row || !Array.isArray(row.instances)) return 0;
+      let n = 0;
+      for (const inst of row.instances) {
+        if (inst.drift) n++;
+      }
+      return n;
+    },
+
+    // Number of CFs currently drifted on at least one instance, for the
+    // card-header summary line ("3 drifted" / "All in sync").
+    cfDriftedCount(appType) {
+      const rows = this.cfSyncRules[appType] || [];
+      let n = 0;
+      for (const row of rows) {
+        if (this.cfRowDriftCount(row) > 0) n++;
+      }
+      return n;
+    },
+
+    // Push clonarr's saved spec for one CF back to one instance. The
+    // backend writes a CF-tagged history entry, clears the fingerprint,
+    // and fires NotifyCFDriftReconciled. We refresh the local data so
+    // the row's pill flips to "In sync" without a page reload.
+    async applyCFDrift(instanceId, trashId, cfName, instanceName) {
+      if (!instanceId || !trashId) return;
+      const key = instanceId + ':' + trashId;
+      if (this.cfApplyingKey === key) return;
+      this.cfApplyingKey = key;
+      try {
+        const r = await fetch('/api/cf-drift/apply', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ instanceId, trashId }),
+        });
+        if (!r.ok) {
+          let msg = 'Failed to apply drift';
+          try { const j = await r.json(); if (j?.error) msg = j.error; } catch (_) {}
+          this.showToast(msg, 'error', 5000);
+          return;
+        }
+        await this.loadCFSyncRules(this.activeAppType);
+        this.showToast(`"${cfName}" re-synced to ${instanceName}.`, 'success', 4000);
+      } catch (e) {
+        this.showToast('Network error during apply: ' + e.message, 'error', 5000);
+      } finally {
+        this.cfApplyingKey = '';
+      }
+    },
+
     historyEventCount(instId, arrProfileId) {
       return (this.syncHistory[instId] || []).filter(sh => sh.arrProfileId === arrProfileId && sh.changes).length;
     },
@@ -5600,8 +5672,28 @@ export default {
           fetch('/api/drift/check', { method: 'POST' }),
         ]);
         let driftFailed = false;
+        let cfDriftCount = 0;
+        let cfDriftNames = [];
         if (dr.status === 'rejected' || (dr.value && !dr.value.ok)) {
           driftFailed = true;
+        } else if (dr.value && dr.value.ok) {
+          // Drift response carries both profile drift (`results`) AND
+          // CF drift (`cfDrift`) since the Phase 1 cf-drift work. The
+          // toast surfaces the CF channel as a separate line so the
+          // user sees all three signals (TRaSH update / profile drift /
+          // CF drift) without scanning multiple views.
+          try {
+            const drBody = await dr.value.clone().json();
+            const list = Array.isArray(drBody?.cfDrift) ? drBody.cfDrift : [];
+            cfDriftCount = list.length;
+            cfDriftNames = list.map(e => e.name || e.trashId).filter(Boolean);
+          } catch (_) { /* leave cfDriftCount=0 on parse failure */ }
+        }
+        // Refresh the Sync Rules → Custom Formats sub-tab cache if it
+        // was previously loaded so the row pills update right away
+        // when the user is already viewing the sub-tab.
+        if (this.cfSyncRulesLoaded?.[this.activeAppType]) {
+          this.loadCFSyncRules(this.activeAppType);
         }
         const r = tr.status === 'fulfilled' ? tr.value : null;
         if (!r || !r.ok) {
@@ -5661,11 +5753,19 @@ export default {
           : (driftRuleCount > 0
               ? `${driftRuleCount} profile${driftRuleCount === 1 ? '' : 's'} with Arr drift:\n${namesShort(rulesWithDrift)}`
               : '');
+        // CF drift line: lists up to N drifted CF names. Skipped when
+        // empty so a clean Check is a one-line "in sync" message
+        // instead of three reassurance lines.
+        const cfDriftLine = cfDriftCount > 0
+          ? `${cfDriftCount} custom format${cfDriftCount === 1 ? '' : 's'} with Arr drift:\n${cfDriftNames.slice(0, 5).map(n => `• ${n}`).join('\n')}${cfDriftNames.length > 5 ? `\n• +${cfDriftNames.length - 5} more` : ''}`
+          : '';
         if (!upstreamAhead) {
-          if (driftRuleCount > 0) {
-            this.showToast(`TRaSH up to date\n${driftLine}`, 'info', 6000);
-          } else if (driftFailed) {
-            this.showToast(`TRaSH up to date\n${driftLine}`, 'warning', 6000);
+          const channels = [];
+          if (driftRuleCount > 0) channels.push(driftLine);
+          if (cfDriftCount > 0) channels.push(cfDriftLine);
+          if (driftFailed) channels.push(driftLine);
+          if (channels.length > 0) {
+            this.showToast(`TRaSH up to date\n\n${channels.join('\n\n')}`, driftFailed ? 'warning' : 'info', 7000);
           } else {
             this.showToast('TRaSH-Guides is up to date — no upstream changes', 'success', 3000);
           }
@@ -5677,7 +5777,10 @@ export default {
         // with stale state that aren't rendered in the table.
         const affectedRules = rulesByStatus('updates');
         if (affectedRules.length === 0) {
-          const tail = driftLine ? `\n${driftLine}` : '';
+          const extras = [];
+          if (driftLine) extras.push(driftLine);
+          if (cfDriftLine) extras.push(cfDriftLine);
+          const tail = extras.length > 0 ? `\n\n${extras.join('\n\n')}` : '';
           this.showToast(`TRaSH has new commits but none affect your synced profiles${tail}`, 'info', 6000);
           return;
         }
@@ -5701,7 +5804,10 @@ export default {
         // Profile names on their own line for readability — long lists wrap
         // poorly when crammed after the header.
         const updateLine = `Found ${cfLabel} affecting ${updLabel}:\n${namesShort(affectedRules)}`;
-        const tail = driftLine ? `\n\n${driftLine}` : '';
+        const extras = [];
+        if (driftLine) extras.push(driftLine);
+        if (cfDriftLine) extras.push(cfDriftLine);
+        const tail = extras.length > 0 ? `\n\n${extras.join('\n\n')}` : '';
         this.showToast(`${updateLine}\n\nUse Update all / Update profile to apply${tail}`, 'info', 7000);
       } catch (e) {
         this.showToast('Check failed (network error)', 'error', 4000);

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -3437,12 +3437,519 @@ export default {
     // Number of CFs currently drifted on at least one instance, for the
     // card-header summary line ("3 drifted" / "All in sync").
     cfDriftedCount(appType) {
-      const rows = this.cfSyncRules[appType] || [];
+      // Reflect what's actually in the current view — when the user
+      // scopes to one instance via the picker, "drifted" should mean
+      // "drifted on THIS instance", not the global cross-instance
+      // total. cfSyncRulesFiltered already trims row.instances to
+      // just the picked instance so cfRowDriftCount counts correctly.
+      const rows = this.cfSyncRulesFiltered(appType) || [];
       let n = 0;
       for (const row of rows) {
         if (this.cfRowDriftCount(row) > 0) n++;
       }
       return n;
+    },
+
+    // Hierarchical category tree for the CF sub-tab sidebar. Groups
+    // managed CFs by their parent bracket-prefix ("Audio Formats",
+    // "HDR Formats", "Unwanted") with children = unique subcategories
+    // ("Default", "Streaming", "Anime"). Mirrors the Browse tab's
+    // sidebar shape so users carry the same mental model across both
+    // surfaces. Counts respect the active instance scope; search is
+    // NOT applied (sidebar is "jump to", not "narrow further").
+    cfSyncRulesCategories(appType) {
+      let rows = this.cfSyncRules[appType] || [];
+      const instId = this.cfSyncRulesActiveInstance || '';
+      if (instId) {
+        rows = rows
+          .map(r => {
+            const filtered = (r.instances || []).filter(i => i.id === instId);
+            if (filtered.length === 0) return null;
+            return { ...r, instances: filtered };
+          })
+          .filter(Boolean);
+      }
+      const byParent = new Map();
+      for (const row of rows) {
+        const parent = row.category || 'Other';
+        const child = row.subcategory || '';
+        if (!byParent.has(parent)) {
+          byParent.set(parent, { name: parent, total: 0, drifted: 0, children: new Map() });
+        }
+        const parentEntry = byParent.get(parent);
+        parentEntry.total++;
+        if (this.cfRowDriftCount(row) > 0) parentEntry.drifted++;
+        if (child) {
+          if (!parentEntry.children.has(child)) {
+            parentEntry.children.set(child, { name: child, total: 0, drifted: 0 });
+          }
+          const childEntry = parentEntry.children.get(child);
+          childEntry.total++;
+          if (this.cfRowDriftCount(row) > 0) childEntry.drifted++;
+        }
+      }
+      const out = Array.from(byParent.values()).map(p => ({
+        ...p,
+        children: Array.from(p.children.values()).sort((a, b) => a.name.localeCompare(b.name)),
+      }));
+      // Fixed-order tail:
+      //   1. Custom at the very bottom (user-managed CFs aren't in
+      //      the TRaSH catalog so they read as "other" relative to
+      //      it).
+      //   2. ANY group whose name starts with "SQP" just above Custom
+      //      (TRaSH's SQP-N + SQP MA Hybrid + SQP Disable If One...
+      //      are profile-targeted quality presets, not content
+      //      categories — they belong as a group at the bottom).
+      //   3. Everything else alphabetical.
+      out.sort((a, b) => {
+        if (a.name === 'Custom') return 1;
+        if (b.name === 'Custom') return -1;
+        const aSQP = a.name.startsWith('SQP');
+        const bSQP = b.name.startsWith('SQP');
+        if (aSQP && !bSQP) return 1;
+        if (bSQP && !aSQP) return -1;
+        return a.name.localeCompare(b.name);
+      });
+      return out;
+    },
+
+    // Toggle the chevron expansion state of a sidebar parent. Mirrors
+    // the Browse tab's pattern: explicit state per-parent kept in
+    // localStorage so re-opening the sub-tab restores what the user
+    // had. Auto-expanded when the active filter targets a child of
+    // this parent (handled in cfSRSidebarParentOpen).
+    cfSRToggleSidebarParent(parentName) {
+      const visible = this.cfSRSidebarParentOpen(parentName);
+      this.cfSyncRulesSidebarExpanded = {
+        ...(this.cfSyncRulesSidebarExpanded || {}),
+        [parentName]: !visible,
+      };
+      try { localStorage.setItem('clonarr_cfSRSidebarExpanded', JSON.stringify(this.cfSyncRulesSidebarExpanded)); } catch (_) {}
+    },
+
+    // True when a parent's children should render visible. Three
+    // states, in priority order:
+    //   1. Explicit chevron state (locked open / locked closed)
+    //   2. Auto-open because the active filter targets this parent
+    //      OR one of its children
+    //   3. Default closed
+    // Matches Browse's isCFBrowseParentExpanded exactly so users
+    // carry the same interaction model across both sidebars: clicking
+    // a parent label expands it and auto-collapses the previously
+    // active one; clicking the chevron locks open.
+    cfSRSidebarParentOpen(parentName) {
+      const explicit = (this.cfSyncRulesSidebarExpanded || {})[parentName];
+      if (explicit !== undefined) return explicit;
+      const active = this.cfSyncRulesActiveCat || 'all';
+      if (active === 'cat:' + parentName) return true;
+      if (active.startsWith('sub:' + parentName + '|')) return true;
+      return false;
+    },
+
+    // Click on a sidebar parent label — sets it as the active
+    // category AND clears any explicit chevron state so auto-expand
+    // (via the active-match check above) takes over. Without the
+    // clear, a previously-collapsed parent would stay closed even
+    // when re-selected, surprising the user.
+    cfSRPickParent(parentName) {
+      this.cfSyncRulesActiveCat = 'cat:' + parentName;
+      const stored = this.cfSyncRulesSidebarExpanded || {};
+      if (Object.prototype.hasOwnProperty.call(stored, parentName)) {
+        const updated = { ...stored };
+        delete updated[parentName];
+        this.cfSyncRulesSidebarExpanded = updated;
+        try { localStorage.setItem('clonarr_cfSRSidebarExpanded', JSON.stringify(updated)); } catch (_) {}
+      }
+    },
+
+    // Click on a child sub-category — narrows to that sub AND
+    // clears the parent's explicit state for the same reason
+    // (auto-match opens the parent so the picked child is visible).
+    cfSRPickSubcategory(parentName, childName) {
+      this.cfSyncRulesActiveCat = 'sub:' + parentName + '|' + childName;
+      const stored = this.cfSyncRulesSidebarExpanded || {};
+      if (Object.prototype.hasOwnProperty.call(stored, parentName)) {
+        const updated = { ...stored };
+        delete updated[parentName];
+        this.cfSyncRulesSidebarExpanded = updated;
+        try { localStorage.setItem('clonarr_cfSRSidebarExpanded', JSON.stringify(updated)); } catch (_) {}
+      }
+    },
+
+    // True when AT LEAST ONE sidebar parent is currently shown
+    // (either via auto-match, explicit lock-open, or the active
+    // filter). Drives the Expand all / Collapse all toggle label —
+    // if any are open, the button reads "Collapse all"; if all are
+    // closed, "Expand all".
+    cfSRAnyParentExpanded(appType) {
+      const cats = this.cfSyncRulesCategories(appType);
+      for (const p of cats) {
+        if (this.cfSRSidebarParentOpen(p.name)) return true;
+      }
+      return false;
+    },
+
+    // Bulk-toggle every sidebar parent. Writes explicit state for
+    // each one so the choice survives auto-match transitions (the
+    // user wants "ALL open" or "ALL closed" regardless of what the
+    // active filter would auto-expand).
+    cfSRToggleAllParents(appType) {
+      const cats = this.cfSyncRulesCategories(appType);
+      const next = !this.cfSRAnyParentExpanded(appType);
+      const updated = { ...(this.cfSyncRulesSidebarExpanded || {}) };
+      for (const p of cats) {
+        updated[p.name] = next;
+      }
+      this.cfSyncRulesSidebarExpanded = updated;
+      try { localStorage.setItem('clonarr_cfSRSidebarExpanded', JSON.stringify(updated)); } catch (_) {}
+    },
+
+    // Apply every active filter (category / subcategory / view /
+    // instance / search) to the row list. Filters AND together.
+    // Filter shapes:
+    //   'all'                                — no filter
+    //   'cat:<parent>'                       — narrow to parent bracket prefix
+    //   'sub:<parent>|<child>'               — narrow to a specific child
+    //   'view:drifted'                       — only rows with drift
+    // The instance filter on top trims row.instances to just the
+    // picked instance so per-row counts scope correctly. Search
+    // matches CF name OR any profile name (TRaSH or Arr) inside any
+    // instance block.
+    cfSyncRulesFiltered(appType) {
+      let rows = this.cfSyncRules[appType] || [];
+      const cat = this.cfSyncRulesActiveCat || 'all';
+      if (cat.startsWith('cat:')) {
+        const target = cat.slice('cat:'.length);
+        rows = rows.filter(r => (r.category || 'Other') === target);
+      } else if (cat.startsWith('sub:')) {
+        const rest = cat.slice('sub:'.length);
+        const pipe = rest.indexOf('|');
+        if (pipe > -1) {
+          const parent = rest.slice(0, pipe);
+          const child = rest.slice(pipe + 1);
+          rows = rows.filter(r =>
+            (r.category || 'Other') === parent
+            && (r.subcategory || '') === child);
+        }
+      }
+      const instId = this.cfSyncRulesActiveInstance || '';
+      if (instId) {
+        rows = rows
+          .map(r => {
+            const filtered = (r.instances || []).filter(i => i.id === instId);
+            if (filtered.length === 0) return null;
+            return { ...r, instances: filtered };
+          })
+          .filter(Boolean);
+      }
+      if (cat === 'view:drifted') {
+        // Trim each row's instances to only the drifted ones, and
+        // drop rows that end up with zero. Without the per-instance
+        // trim, a CF drifted on Radarr (main) but in-sync on Radarr
+        // (4K) would still render an "In sync" row in the 4K card —
+        // surprising when the user explicitly asked for "drifted".
+        rows = rows
+          .map(r => {
+            const driftedOnly = (r.instances || []).filter(i => i.drift);
+            if (driftedOnly.length === 0) return null;
+            return { ...r, instances: driftedOnly };
+          })
+          .filter(Boolean);
+      }
+      const q = (this.cfSyncRulesSearch || '').trim().toLowerCase();
+      if (q) {
+        rows = rows.filter(r => {
+          if ((r.name || '').toLowerCase().includes(q)) return true;
+          for (const inst of (r.instances || [])) {
+            for (const p of (inst.profiles || [])) {
+              if ((p.trashProfileName || '').toLowerCase().includes(q)) return true;
+              if ((p.arrProfileName || '').toLowerCase().includes(q)) return true;
+            }
+          }
+          return false;
+        });
+      }
+      return rows;
+    },
+
+    // Pivot rows by instance so the main pane can render one
+    // v3-inst-card per instance, mirroring Profile Sync Rules. Result
+    // is sorted by instance name and only includes instances that
+    // actually have managed CFs after filters. Each entry carries
+    // the instance metadata + its slice of filtered rows.
+    cfSyncRulesByInstance(appType) {
+      const rows = this.cfSyncRulesFiltered(appType) || [];
+      const byInstId = new Map();
+      for (const row of rows) {
+        for (const inst of (row.instances || [])) {
+          if (!byInstId.has(inst.id)) {
+            byInstId.set(inst.id, { id: inst.id, name: inst.name, rows: [] });
+          }
+          // Each rendered row shows the CF + this instance's slice
+          // (one inst block) so a CF on two instances renders twice,
+          // once per card. Keeps each card a coherent per-instance view.
+          byInstId.get(inst.id).rows.push({
+            trashId: row.trashId,
+            name: row.name,
+            category: row.category,
+            subcategory: row.subcategory,
+            instance: inst,
+          });
+        }
+      }
+      const out = Array.from(byInstId.values());
+      out.sort((a, b) => a.name.localeCompare(b.name));
+      return out;
+    },
+
+    // Drift count for a per-instance card. Walks the rows in the
+    // card and counts CFs that are drifted on this instance.
+    cfSRInstanceCardDriftCount(card) {
+      let n = 0;
+      for (const r of (card.rows || [])) {
+        if (r.instance && r.instance.drift) n++;
+      }
+      return n;
+    },
+
+    // Most recent sync timestamp across all profiles pulling this CF
+    // into this instance. Used for the collapsed row's "Last sync"
+    // column — gives the user a single representative value when a
+    // CF is in multiple profiles on the same instance. ISO strings
+    // compare lexicographically so a plain string max works.
+    cfSRInstanceLastSync(instance) {
+      if (!instance || !instance.profiles) return '';
+      let latest = '';
+      for (const p of instance.profiles) {
+        if (p.lastSync && p.lastSync > latest) latest = p.lastSync;
+      }
+      return latest;
+    },
+
+    // Update all for a single instance card — pushes the saved spec
+    // for every drifted CF on that instance. Replaces the old
+    // global Update all (which used the cross-instance filter).
+    // Sequential with concurrency cap to avoid hammering Arr.
+    async applyAllCFDriftForInstance(card) {
+      if (this.cfApplyAllProgress.running) return;
+      const queue = (card.rows || [])
+        .filter(r => r.instance && r.instance.drift)
+        .map(r => ({
+          instanceId: card.id,
+          instanceName: card.name,
+          trashId: r.trashId,
+          cfName: r.name,
+        }));
+      if (queue.length === 0) {
+        this.showToast('Nothing to update on ' + card.name + '.', 'info', 3000);
+        return;
+      }
+      this.cfApplyAllProgress = { running: true, total: queue.length, done: 0, label: '' };
+      let succeeded = 0;
+      const failures = [];
+      const concurrency = 2;
+      let next = 0;
+      const worker = async () => {
+        while (next < queue.length) {
+          const idx = next++;
+          const item = queue[idx];
+          this.cfApplyAllProgress.label = `${item.cfName} → ${item.instanceName}`;
+          try {
+            const r = await fetch('/api/cf-drift/apply', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ instanceId: item.instanceId, trashId: item.trashId }),
+            });
+            if (r.ok) {
+              succeeded++;
+            } else {
+              let msg = 'unknown error';
+              try { const j = await r.json(); if (j?.error) msg = j.error; } catch (_) {}
+              failures.push(`${item.cfName}: ${msg}`);
+            }
+          } catch (e) {
+            failures.push(`${item.cfName}: ${e.message}`);
+          }
+          this.cfApplyAllProgress.done++;
+        }
+      };
+      const workers = [];
+      for (let i = 0; i < Math.min(concurrency, queue.length); i++) workers.push(worker());
+      await Promise.all(workers);
+      this.cfApplyAllProgress = { running: false, total: 0, done: 0, label: '' };
+      await this.loadCFSyncRules(this.activeAppType);
+      if (failures.length === 0) {
+        this.showToast(`Updated ${succeeded} drifted CF${succeeded === 1 ? '' : 's'} on ${card.name}.`, 'success', 4000);
+      } else if (succeeded === 0) {
+        this.showToast(`Update all failed on ${card.name} (${failures.length} error${failures.length === 1 ? '' : 's'}):\n${failures.slice(0, 4).join('\n')}${failures.length > 4 ? `\n+${failures.length - 4} more` : ''}`, 'error', 8000);
+      } else {
+        this.showToast(`Updated ${succeeded} of ${queue.length} on ${card.name}. ${failures.length} failed:\n${failures.slice(0, 3).join('\n')}${failures.length > 3 ? `\n+${failures.length - 3} more` : ''}`, 'warning', 8000);
+      }
+    },
+
+    // Drifted-row total for the sidebar's "Drifted (N)" pin. Respects
+    // instance picker so the count matches what the user would see if
+    // they activate the view filter, but ignores category + search so
+    // the badge advertises a real "jump to" affordance regardless of
+    // where the user currently is.
+    cfSyncRulesDriftedTotal(appType) {
+      let rows = this.cfSyncRules[appType] || [];
+      const instId = this.cfSyncRulesActiveInstance || '';
+      if (instId) {
+        rows = rows
+          .map(r => {
+            const filtered = (r.instances || []).filter(i => i.id === instId);
+            if (filtered.length === 0) return null;
+            return { ...r, instances: filtered };
+          })
+          .filter(Boolean);
+      }
+      let n = 0;
+      for (const row of rows) {
+        if (this.cfRowDriftCount(row) > 0) n++;
+      }
+      return n;
+    },
+
+    // List of instance options for the picker. Sorted by name for
+    // a predictable dropdown. Empty when the app type has only one
+    // instance — the picker is then redundant and gets hidden.
+    cfSyncRulesInstanceOptions(appType) {
+      const list = this.instancesOfType(appType) || [];
+      return list.slice().sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    // Toggle the per-(instance, CF) expand row. Single-open: opening
+    // row B closes row A. Re-clicking the open row collapses it.
+    // Compound key "<instanceId>:<trashId>" — trashId may itself
+    // contain colons (custom: prefix) so we split on the FIRST colon
+    // only, not via String.split which would mis-segment custom CFs.
+    // When opening a drifted row, auto-load the diff for that
+    // specific (instance, CF) pair.
+    cfSyncRulesToggleExpand(key) {
+      if (this.cfSyncRulesExpandedRow === key) {
+        this.cfSyncRulesExpandedRow = '';
+        return;
+      }
+      this.cfSyncRulesExpandedRow = key;
+      const colonIdx = key.indexOf(':');
+      if (colonIdx === -1) return;
+      const instanceId = key.slice(0, colonIdx);
+      const trashId = key.slice(colonIdx + 1);
+      const row = (this.cfSyncRules[this.activeAppType] || []).find(r => r.trashId === trashId);
+      if (!row) return;
+      const inst = (row.instances || []).find(i => i.id === instanceId);
+      if (!inst || !inst.drift) return;
+      if (this.cfDriftDiffCache[key]
+          && (this.cfDriftDiffCache[key].diff || this.cfDriftDiffCache[key].error)) {
+        return;
+      }
+      this.loadCFDriftDiff(instanceId, trashId);
+    },
+
+    // Fetch the per-CF drift diff for a single (instance, trashId)
+    // pair. Stores into cfDriftDiffCache. Surfaces a loading
+    // placeholder while in-flight and an error string on failure so
+    // the UI can render either state cleanly.
+    async loadCFDriftDiff(instanceId, trashId) {
+      const key = instanceId + ':' + trashId;
+      this.cfDriftDiffCache[key] = { loading: true, diff: null, error: '' };
+      try {
+        const r = await fetch(`/api/cf-drift/diff?instanceId=${encodeURIComponent(instanceId)}&trashId=${encodeURIComponent(trashId)}`);
+        if (!r.ok) {
+          let msg = `HTTP ${r.status}`;
+          try { const j = await r.json(); if (j?.error) msg = j.error; } catch (_) {}
+          this.cfDriftDiffCache[key] = { loading: false, diff: null, error: msg };
+          return;
+        }
+        const data = await r.json();
+        this.cfDriftDiffCache[key] = {
+          loading: false,
+          diff: data.diff || null,
+          liveMissing: !!data.liveMissing,
+          error: '',
+        };
+      } catch (e) {
+        this.cfDriftDiffCache[key] = { loading: false, diff: null, error: e.message };
+      }
+    },
+
+    // Helper for the expand panel — returns true when the diff for
+    // a given (instance, trashId) pair carries any reportable change.
+    // Used to gate "Drift was already resolved" vs "Drift detail" sub-states.
+    cfDriftDiffHasChanges(diff) {
+      if (!diff) return false;
+      return (diff.addedConditions || []).length > 0
+        || (diff.removedConditions || []).length > 0
+        || (diff.changedConditions || []).length > 0
+        || (diff.settingsChanges || []).length > 0;
+    },
+
+    // Apply every (instance, trashId) drifted pair currently visible
+    // through the active filter. Sequential with a 2-at-a-time
+    // concurrency cap so a 50-CF drift batch doesn't fan-out 50
+    // simultaneous PUTs at one Arr instance. Progress surface visible
+    // in the header bar (X / Y); per-failure log in the post-batch
+    // toast. Stops cleanly when the user navigates away (in-flight
+    // POSTs complete; queued ones are abandoned on the cfApplyingKey
+    // check at start).
+    async applyAllCFDrift(appType) {
+      if (this.cfApplyAllProgress.running) return;
+      const rows = this.cfSyncRulesFiltered(appType);
+      const queue = [];
+      for (const row of rows) {
+        for (const inst of (row.instances || [])) {
+          if (!inst.drift) continue;
+          queue.push({ instanceId: inst.id, instanceName: inst.name, trashId: row.trashId, cfName: row.name });
+        }
+      }
+      if (queue.length === 0) {
+        this.showToast('Nothing to apply — no drift detected.', 'info', 3000);
+        return;
+      }
+      this.cfApplyAllProgress = { running: true, total: queue.length, done: 0, label: '' };
+      let succeeded = 0;
+      const failures = [];
+      // Worker pool — 2 parallel Apply calls feels safe on Arr. The
+      // body is tiny and the bottleneck is Arr-side validation.
+      const concurrency = 2;
+      let next = 0;
+      const worker = async () => {
+        while (next < queue.length) {
+          const idx = next++;
+          const item = queue[idx];
+          this.cfApplyAllProgress.label = `${item.cfName} → ${item.instanceName}`;
+          try {
+            const r = await fetch('/api/cf-drift/apply', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ instanceId: item.instanceId, trashId: item.trashId }),
+            });
+            if (r.ok) {
+              succeeded++;
+            } else {
+              let msg = 'unknown error';
+              try { const j = await r.json(); if (j?.error) msg = j.error; } catch (_) {}
+              failures.push(`${item.cfName} → ${item.instanceName}: ${msg}`);
+            }
+          } catch (e) {
+            failures.push(`${item.cfName} → ${item.instanceName}: ${e.message}`);
+          }
+          this.cfApplyAllProgress.done++;
+        }
+      };
+      const workers = [];
+      for (let i = 0; i < Math.min(concurrency, queue.length); i++) workers.push(worker());
+      await Promise.all(workers);
+      this.cfApplyAllProgress = { running: false, total: 0, done: 0, label: '' };
+      await this.loadCFSyncRules(appType);
+      if (failures.length === 0) {
+        this.showToast(`Updated ${succeeded} drifted custom format${succeeded === 1 ? '' : 's'}.`, 'success', 4000);
+      } else if (succeeded === 0) {
+        this.showToast(`Update all failed (${failures.length} error${failures.length === 1 ? '' : 's'}):\n${failures.slice(0, 4).join('\n')}${failures.length > 4 ? `\n+${failures.length - 4} more` : ''}`, 'error', 8000);
+      } else {
+        this.showToast(`Updated ${succeeded} of ${queue.length}. ${failures.length} failed:\n${failures.slice(0, 3).join('\n')}${failures.length > 3 ? `\n+${failures.length - 3} more` : ''}`, 'warning', 8000);
+      }
     },
 
     // Push clonarr's saved spec for one CF back to one instance. The
@@ -3467,7 +3974,7 @@ export default {
           return;
         }
         await this.loadCFSyncRules(this.activeAppType);
-        this.showToast(`"${cfName}" re-synced to ${instanceName}.`, 'success', 4000);
+        this.showToast(`"${cfName}" updated on ${instanceName}.`, 'success', 4000);
       } catch (e) {
         this.showToast('Network error during apply: ' + e.message, 'error', 5000);
       } finally {

--- a/ui/static/js/features/scoring.js
+++ b/ui/static/js/features/scoring.js
@@ -297,6 +297,129 @@ export default {
       };
     },
 
+    // Open the Sandbox Export modal. Generates the initial text body
+    // from the current visible+sorted result list with the breakdown
+    // toggle off. Toggle changes are watched via x-effect in the
+    // template so flipping the checkbox re-runs the formatter.
+    //
+    // Blurs the active element first so that when x-trap.inert applies
+    // aria-hidden + inert to <main> on the next render tick, focus
+    // isn't still parked on the trigger button (which would cause
+    // Chrome to log "Blocked aria-hidden on an element because its
+    // descendant retained focus"). x-trap moves focus into the modal
+    // itself once it mounts; blur'ing here just gets it off the
+    // trigger before the inert attribute lands.
+    openSandboxExport(appType) {
+      if (document.activeElement && typeof document.activeElement.blur === 'function') {
+        document.activeElement.blur();
+      }
+      this.sandboxExportModal = {
+        show: true,
+        appType: appType,
+        includeBreakdown: false,
+        text: this.formatSandboxExportText(appType, false),
+        copied: false,
+      };
+    },
+
+    // Build the export string. Follows visibleSandboxResults' sort +
+    // filter order so what the user sees is what gets exported. Three
+    // formatting modes the function picks based on per-release scoring
+    // state + the includeBreakdown toggle:
+    //   • Release has no scoring             → "<title>"
+    //   • Scoring + !includeBreakdown        → "<title>\t<total>"
+    //   • Scoring + includeBreakdown         → header line then per-CF
+    //     rows (alphabetical by CF name for stable diffs across two
+    //     sessions of the same release scored on different profiles)
+    //   • Multi-release output joins blocks with a blank line so diff
+    //     tools align block boundaries cleanly.
+    formatSandboxExportText(appType, includeBreakdown) {
+      const rows = (typeof this.visibleSandboxResults === 'function'
+        ? this.visibleSandboxResults(appType)
+        : (this.sandbox?.[appType]?.results || [])) || [];
+      if (rows.length === 0) return '';
+      // Format the total score with the explicit sign so a +/- diff
+      // shows up cleanly in diff tools' alignment view.
+      const fmtScore = (n) => {
+        if (typeof n !== 'number') return '0';
+        return (n > 0 ? '+' : '') + String(n);
+      };
+      const blocks = rows.map(res => {
+        const title = res.title || '';
+        const scoring = res.scoring;
+        if (!scoring || typeof scoring.total !== 'number') {
+          // No scoring done — just the title. Common when the user
+          // pasted a list and exports before clicking Score.
+          return title;
+        }
+        if (!includeBreakdown) {
+          // Compact single-line: title + total. Tab separator picks
+          // up cleanly in diff tools and in pasted-into-spreadsheet
+          // workflows alike.
+          return `${title}\t${fmtScore(scoring.total)}`;
+        }
+        // Breakdown block: header line, then alphabetical CF rows so
+        // diff tools align same-CF rows across two sessions even when
+        // the scores differ. Unmatched CFs (score==0 from filter) are
+        // skipped — they're noise for a comparison view.
+        const breakdown = (scoring.breakdown || [])
+          .filter(b => b && b.matched && typeof b.score === 'number' && b.score !== 0)
+          .slice()
+          .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+        const lines = [`${title}\tTOTAL ${fmtScore(scoring.total)}`];
+        for (const cf of breakdown) {
+          lines.push(`  ${cf.name}\t${fmtScore(cf.score)}`);
+        }
+        return lines.join('\n');
+      });
+      return blocks.join('\n\n');
+    },
+
+    // Re-run the formatter when the toggle flips. Called from the
+    // modal's checkbox @change.
+    rerenderSandboxExport() {
+      const m = this.sandboxExportModal;
+      if (!m || !m.show) return;
+      this.sandboxExportModal.text = this.formatSandboxExportText(m.appType, m.includeBreakdown);
+    },
+
+    // Copy the modal text to the clipboard. Mirrors copySandboxModalText
+    // including the execCommand fallback for non-secure contexts.
+    async copySandboxExportText() {
+      const text = this.sandboxExportModal.text || '';
+      let ok = false;
+      if (navigator.clipboard && window.isSecureContext) {
+        try { await navigator.clipboard.writeText(text); ok = true; } catch (_) { /* fall through */ }
+      }
+      if (!ok) {
+        const pre = document.getElementById('sandbox-export-pre');
+        if (pre) {
+          const sel = document.getSelection();
+          const saved = [];
+          if (sel) {
+            for (let i = 0; i < sel.rangeCount; i++) saved.push(sel.getRangeAt(i).cloneRange());
+          }
+          try {
+            const range = document.createRange();
+            range.selectNodeContents(pre);
+            sel.removeAllRanges();
+            sel.addRange(range);
+            ok = document.execCommand('copy');
+          } catch (_) { /* leave ok=false */ }
+          if (sel) {
+            sel.removeAllRanges();
+            for (const r of saved) sel.addRange(r);
+          }
+        }
+      }
+      if (ok) {
+        this.sandboxExportModal.copied = true;
+        setTimeout(() => { this.sandboxExportModal.copied = false; }, 1500);
+      } else if (typeof this.showToast === 'function') {
+        this.showToast('Copy failed. Select the text and copy manually.', 'error', 4000);
+      }
+    },
+
     async copySandboxModalText() {
       const text = this.sandboxCopyModal.text || '';
       let ok = false;

--- a/ui/static/js/features/trash-profile-discovery.js
+++ b/ui/static/js/features/trash-profile-discovery.js
@@ -276,14 +276,19 @@ export default {
     // visual noise. A card with fewer pills correctly signals fewer
     // differentiators.
 
-    // tpdAudioPillText always returns the user-outcome audio label —
-    // "Lossless audio" when [Audio] Audio Formats is scored, "Lossy audio"
-    // otherwise. Both are positive framings (asserting what the profile
-    // actually gives), not negation. Template uses different pill classes
-    // (.aud for lossless = subtle green, neutral for lossy) so they don't
-    // visually compete.
+    // tpdAudioPillText returns the user-outcome audio label across three
+    // states the backend describer now reports:
+    //   scored → "Lossless audio"      (group default-on, user gets it by default)
+    //   optIn  → "Lossless available"  (group bundled but default-off, user opts in)
+    //   else   → "Lossy audio"
+    // Template uses different pill classes (.aud for lossless = subtle
+    // green, neutral for lossy / available) so the three states don't
+    // visually compete. "Lossless available" sits with the neutral
+    // styling — it advertises capability without claiming the outcome.
     tpdAudioPillText(d) {
-      return d.axes?.audio?.scored ? 'Lossless audio' : 'Lossy audio';
+      if (d.axes?.audio?.scored) return 'Lossless audio';
+      if (d.axes?.audio?.optIn)  return 'Lossless available';
+      return 'Lossy audio';
     },
 
     // tpdHDRPillText returns the SHORT HDR pill label — full opt-in

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -575,6 +575,22 @@ export function clonarr() {
       this.$watch('profileTabs', maybeLoadCustomizations);
       this.$watch('activeAppType', maybeLoadCustomizations);
 
+      // Custom Formats → Sync Rules sub-tab: load the per-CF state
+      // when the user lands on the sub-tab for the first time (and
+      // on app-type changes while there). The fetch is cheap and the
+      // result is cached per app-type, so re-entering after a switch
+      // away comes back instantly.
+      const maybeLoadCFSyncRules = () => {
+        if (this.currentSection === 'custom-formats'
+            && this.getCustomFormatsTab(this.activeAppType) === 'sync-rules'
+            && typeof this.loadCFSyncRules === 'function'
+            && !this.cfSyncRulesLoaded[this.activeAppType]) {
+          this.loadCFSyncRules(this.activeAppType);
+        }
+      };
+      this.$watch('currentSection', maybeLoadCFSyncRules);
+      this.$watch('customFormatsTabs', maybeLoadCFSyncRules);
+
       // Expanding the sidebar (Ctrl+B or click-toggle) closes the popup —
       // when the inline subnav becomes visible, the popup is redundant.
       // Also cancel any pending show-timer: if user was hovering an icon
@@ -648,14 +664,13 @@ export function clonarr() {
           this.loadInstanceQS(appType, this.mediaInstanceId[appType]);
           this.loadInstanceNaming(appType);
         }
-        // Sync Rules → Custom Formats sub-tab: per-app-type fetch, so
+        // Custom Formats → Sync Rules sub-tab: per-app-type fetch, so
         // an app switch on this sub-tab needs to load the other app's
         // data on its own. Without this the table is stuck on a
         // "Loading custom formats..." spinner because the click handler
         // is the only other fetcher.
-        if (this.currentSection === 'profiles'
-          && this.getProfileTab(appType) === 'sync-rules'
-          && this.syncRulesSubTab === 'cfs'
+        if (this.currentSection === 'custom-formats'
+          && this.getCustomFormatsTab(appType) === 'sync-rules'
           && typeof this.loadCFSyncRules === 'function') {
           this.loadCFSyncRules(appType);
         }

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -575,21 +575,35 @@ export function clonarr() {
       this.$watch('profileTabs', maybeLoadCustomizations);
       this.$watch('activeAppType', maybeLoadCustomizations);
 
-      // Custom Formats → Sync Rules sub-tab: load the per-CF state
-      // when the user lands on the sub-tab for the first time (and
-      // on app-type changes while there). The fetch is cheap and the
-      // result is cached per app-type, so re-entering after a switch
-      // away comes back instantly.
+      // Custom Formats → Sync Rules sub-tab: re-fetch the per-CF
+      // state every time the user lands on the sub-tab (not just
+      // the first time). Without this, auto-sync ticks that fire
+      // server-side while the page is open would update PendingChanges
+      // and CFDriftFingerprints but the open UI would keep showing
+      // stale "in sync" pills until the user manually clicked Check.
+      // Re-fetching on tab-visit + on visibility change covers both
+      // the navigate-back and the return-to-tab cases.
       const maybeLoadCFSyncRules = () => {
         if (this.currentSection === 'custom-formats'
             && this.getCustomFormatsTab(this.activeAppType) === 'sync-rules'
-            && typeof this.loadCFSyncRules === 'function'
-            && !this.cfSyncRulesLoaded[this.activeAppType]) {
+            && typeof this.loadCFSyncRules === 'function') {
           this.loadCFSyncRules(this.activeAppType);
         }
       };
       this.$watch('currentSection', maybeLoadCFSyncRules);
       this.$watch('customFormatsTabs', maybeLoadCFSyncRules);
+      // Attach the visibilitychange listener ONCE across the document
+      // lifetime regardless of how many Alpine roots end up sharing this
+      // init function. The window-level flag survives Alpine teardowns
+      // and re-mounts (rare today since index.html has a single x-data
+      // root, but defensive — split-root refactors otherwise stack a new
+      // listener per init() call and refresh N times per focus event).
+      if (!window._cfSyncRulesVisListenerAttached) {
+        window._cfSyncRulesVisListenerAttached = true;
+        document.addEventListener('visibilitychange', () => {
+          if (document.visibilityState === 'visible') maybeLoadCFSyncRules();
+        });
+      }
 
       // Expanding the sidebar (Ctrl+B or click-toggle) closes the popup —
       // when the inline subnav becomes visible, the popup is redundant.

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -648,6 +648,17 @@ export function clonarr() {
           this.loadInstanceQS(appType, this.mediaInstanceId[appType]);
           this.loadInstanceNaming(appType);
         }
+        // Sync Rules → Custom Formats sub-tab: per-app-type fetch, so
+        // an app switch on this sub-tab needs to load the other app's
+        // data on its own. Without this the table is stuck on a
+        // "Loading custom formats..." spinner because the click handler
+        // is the only other fetcher.
+        if (this.currentSection === 'profiles'
+          && this.getProfileTab(appType) === 'sync-rules'
+          && this.syncRulesSubTab === 'cfs'
+          && typeof this.loadCFSyncRules === 'function') {
+          this.loadCFSyncRules(appType);
+        }
         ensureHistory();
       });
       await this.loadConfig();

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -391,6 +391,14 @@ export default function baseState() {
     inputModal: { show: false, title: '', message: '', value: '', placeholder: '', confirmLabel: '', onConfirm: null, onCancel: null },
     cloneProfileModal: { open: false, sh: null, sourceInstanceId: '', appType: '', sourceName: '', name: '', targetInstanceId: '', saving: false, error: '' },
     sandboxCopyModal: { show: false, title: '', text: '', copied: false },
+    // Sandbox export modal — exports the currently-visible-and-sorted
+    // result list as plain text, diff-tool friendly (line-per-release).
+    // includeBreakdown toggles between "title + total only" (compact,
+    // good for high-level diff) and "per-release block with CF rows"
+    // (deep diff for per-CF score comparison across two sessions).
+    // The "no scoring" path is implicit: if a release has no scoring,
+    // its line shows just the title regardless of toggle.
+    sandboxExportModal: { show: false, appType: '', includeBreakdown: false, text: '', copied: false },
     // Import
     importedProfiles: { radarr: [], sonarr: [] },
     showImportModal: false, // false or app type string

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -5,11 +5,6 @@ export default function baseState() {
     activeAppType: 'radarr',     // NEW — 'radarr' or 'sonarr', independent of section
     advancedTab: 'builder',      // NEW — sub-tab within Advanced: 'builder', 'scoring', 'group-builder'
 
-    // Sync Rules sub-tab: 'profiles' (default — existing per-rule cards)
-    // or 'cfs' (new per-CF view powered by /api/cf-sync-rules/{appType}).
-    // Local UI state; not persisted because the user typically wants the
-    // Profiles view as the entry point when opening Sync Rules.
-    syncRulesSubTab: 'profiles',
     // cfSyncRules: per-app-type cache of the per-CF view. Populated by
     // loadCFSyncRules and refreshed after a successful applyCFDrift.
     cfSyncRules: { radarr: [], sonarr: [] },
@@ -18,6 +13,48 @@ export default function baseState() {
     // the matching button can switch to "Applying..." without racing
     // multiple Apply clicks on the same row.
     cfApplyingKey: '',
+    // CF sub-tab sidebar filter — 'all' shows every managed CF,
+    // 'cat:<name>' narrows to one category. Per-browser persisted so
+    // returning to the sub-tab restores the last filter the user
+    // picked. Matches the Custom Formats Browse tab's own persisted
+    // category state in localStorage shape.
+    cfSyncRulesActiveCat: 'all',
+    // CF sub-tab instance picker — '' means "every instance of the
+    // active app type"; otherwise a specific instance ID. Narrowing
+    // to one instance scopes the row list AND the drift counts AND
+    // the Update all batch to that instance, so a 4K-Radarr-only
+    // drift event can be acted on without touching main Radarr.
+    cfSyncRulesActiveInstance: '',
+    // CF sub-tab search query — matches against CF name OR any of
+    // the row's usedByProfiles[].profileName entries. Lets a user
+    // find "all CFs in SQP-3" or "Bad Release Group" without
+    // scrolling. Case-insensitive substring.
+    cfSyncRulesSearch: '',
+    // CF sub-tab expand-row state — trashId of the currently-open
+    // detail row showing per-profile usage. Single-open (clicking a
+    // different row collapses the previous) to keep the layout
+    // compact; empty string = nothing expanded.
+    cfSyncRulesExpandedRow: '',
+    // "Apply all" progress state — total drifted (instance, trashId)
+    // pairs queued, completed so far, current label. Visible while
+    // running so the user sees the batch progressing rather than a
+    // single multi-second spinner with no indication something's
+    // happening. Cleared on completion.
+    cfApplyAllProgress: { running: false, total: 0, done: 0, label: '' },
+    // Per-row drift detail cache. Keyed by "<instanceId>:<trashId>"
+    // so the same CF on two instances caches independently. Loaded
+    // lazily when a drifted row is expanded; entries persist for the
+    // tab session so re-opening a previously-viewed row is instant.
+    // Shape: { loading: bool, diff: CFSpecDiff|null, error: string }.
+    cfDriftDiffCache: {},
+    // CF sub-tab sidebar parent-collapse state. Map of parentName →
+    // explicit visibility. Loaded from localStorage on init; mutated
+    // via cfSRToggleSidebarParent. Empty value means "auto-expand
+    // when active filter targets this parent or a child of it".
+    cfSyncRulesSidebarExpanded: (() => {
+      try { return JSON.parse(localStorage.getItem('clonarr_cfSRSidebarExpanded') || '{}'); }
+      catch (_) { return {}; }
+    })(),
 
     // Debug-log download options. When true, the Download button hits
     // ?activity=1 and the server bundles activity.log alongside debug.log
@@ -117,6 +154,12 @@ export default function baseState() {
     updatingRuleId: '',   // rule id currently running Update profile
     trashResetting: false,
     profileTabs: {},  // per app-type profile tab: { radarr: 'trash-profiles', sonarr: 'sync-rules', ... }
+    // Per app-type Custom Formats sub-tab: { radarr: 'browse' | 'sync-rules', sonarr: ... }.
+    // browse = the existing TRaSH + custom CF catalog (default).
+    // sync-rules = per-CF state for everything any rule pushes to Arr,
+    // including drift status + per-instance Update. Mirror of how
+    // Profiles section uses sub-tabs (TRaSH Profiles + Sync Rules).
+    customFormatsTabs: {},
     // Per app-type Media Management sub-tab: { radarr: 'quality' | 'naming', sonarr: ... }.
     // Section merges the former 'quality-size' + 'naming' top-level pages so
     // *arr-savvy users find both under the same "Media Management" heading.

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -5,6 +5,20 @@ export default function baseState() {
     activeAppType: 'radarr',     // NEW — 'radarr' or 'sonarr', independent of section
     advancedTab: 'builder',      // NEW — sub-tab within Advanced: 'builder', 'scoring', 'group-builder'
 
+    // Sync Rules sub-tab: 'profiles' (default — existing per-rule cards)
+    // or 'cfs' (new per-CF view powered by /api/cf-sync-rules/{appType}).
+    // Local UI state; not persisted because the user typically wants the
+    // Profiles view as the entry point when opening Sync Rules.
+    syncRulesSubTab: 'profiles',
+    // cfSyncRules: per-app-type cache of the per-CF view. Populated by
+    // loadCFSyncRules and refreshed after a successful applyCFDrift.
+    cfSyncRules: { radarr: [], sonarr: [] },
+    cfSyncRulesLoaded: { radarr: false, sonarr: false },
+    // cfApplyingKey: "<instanceId>:<trashId>" of the in-flight apply, so
+    // the matching button can switch to "Applying..." without racing
+    // multiple Apply clicks on the same row.
+    cfApplyingKey: '',
+
     // Debug-log download options. When true, the Download button hits
     // ?activity=1 and the server bundles activity.log alongside debug.log
     // in a ZIP. Default off — most bug reports only need the operation

--- a/ui/static/partials/layout/sidebar.html
+++ b/ui/static/partials/layout/sidebar.html
@@ -90,10 +90,20 @@
       <a class="sidebar-nav-item" :class="{ active: currentSection === 'custom-formats' }"
          :href="navHref('custom-formats')"
          :aria-current="currentSection === 'custom-formats' ? 'page' : null"
-         x-tt="sidebarCollapsed ? 'Custom Formats' : null">
+         x-tt="sidebarCollapsed ? 'Custom Formats' : null"
+         @mouseenter="showSidebarSubnav('custom-formats', $el)"
+         @mouseleave="scheduleHideSidebarSubnav()">
         <span class="sidebar-nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 3h12l4 6-10 13L2 9Z"/><path d="M11 3 8 9l4 13 4-13-3-6"/><path d="M2 9h20"/></svg></span>
         <span class="sidebar-nav-label" x-show="!sidebarCollapsed">Custom Formats</span>
       </a>
+
+      <!-- Sub-nav under Custom Formats, only when sidebar expanded -->
+      <div class="sidebar-subnav" x-show="!sidebarCollapsed && currentSection === 'custom-formats'">
+        <a class="sidebar-subnav-item" :class="{ active: getCustomFormatsTab(activeAppType) === 'browse' }"
+           :href="navHref('custom-formats', { customFormatsTab: 'browse' })">Browse</a>
+        <a class="sidebar-subnav-item" :class="{ active: getCustomFormatsTab(activeAppType) === 'sync-rules' }"
+           :href="navHref('custom-formats', { customFormatsTab: 'sync-rules' })">Sync Rules</a>
+      </div>
 
       <!-- Media Management — consolidates the former Quality Definitions
            and File Naming top-level sections into a single parent with
@@ -420,7 +430,7 @@
        @mouseleave="scheduleHideSidebarSubnav()"
        @keydown.escape.window="sidebarSubnavPopup = ''"
        role="menu"
-       :aria-label="(sidebarSubnavPopup === 'profiles' ? 'Profiles' : sidebarSubnavPopup === 'media-management' ? 'Media Management' : sidebarSubnavPopup === 'maintenance' ? 'Maintenance' : sidebarSubnavPopup === 'settings' ? 'Settings' : 'Advanced') + ' sub-navigation'">
+       :aria-label="(sidebarSubnavPopup === 'profiles' ? 'Profiles' : sidebarSubnavPopup === 'custom-formats' ? 'Custom Formats' : sidebarSubnavPopup === 'media-management' ? 'Media Management' : sidebarSubnavPopup === 'maintenance' ? 'Maintenance' : sidebarSubnavPopup === 'settings' ? 'Settings' : 'Advanced') + ' sub-navigation'">
     <template x-if="sidebarSubnavPopup === 'profiles'">
       <div>
         <div class="sidebar-subnav-popup-header">Profiles</div>
@@ -432,6 +442,15 @@
            :href="navHref('profiles', { profileTab: 'history' })" @click="sidebarSubnavPopup = ''">History</a>
         <a class="sidebar-subnav-popup-item" :class="{ active: getProfileTab(activeAppType) === 'compare' }"
            :href="navHref('profiles', { profileTab: 'compare' })" @click="sidebarSubnavPopup = ''">Compare</a>
+      </div>
+    </template>
+    <template x-if="sidebarSubnavPopup === 'custom-formats'">
+      <div>
+        <div class="sidebar-subnav-popup-header">Custom Formats</div>
+        <a class="sidebar-subnav-popup-item" :class="{ active: getCustomFormatsTab(activeAppType) === 'browse' }"
+           :href="navHref('custom-formats', { customFormatsTab: 'browse' })" @click="sidebarSubnavPopup = ''">Browse</a>
+        <a class="sidebar-subnav-popup-item" :class="{ active: getCustomFormatsTab(activeAppType) === 'sync-rules' }"
+           :href="navHref('custom-formats', { customFormatsTab: 'sync-rules' })" @click="sidebarSubnavPopup = ''">Sync Rules</a>
       </div>
     </template>
     <template x-if="sidebarSubnavPopup === 'media-management'">

--- a/ui/static/partials/layout/top-nav.html
+++ b/ui/static/partials/layout/top-nav.html
@@ -211,6 +211,12 @@
       <a class="topnav-subtab" :class="{ active: getProfileTab(activeAppType) === 'compare' }"
          :href="navHref('profiles', { profileTab: 'compare' })">Compare</a>
     </div>
+    <div class="topnav-subnav" x-show="currentSection === 'custom-formats'">
+      <a class="topnav-subtab" :class="{ active: getCustomFormatsTab(activeAppType) === 'browse' }"
+         :href="navHref('custom-formats', { customFormatsTab: 'browse' })">Browse</a>
+      <a class="topnav-subtab" :class="{ active: getCustomFormatsTab(activeAppType) === 'sync-rules' }"
+         :href="navHref('custom-formats', { customFormatsTab: 'sync-rules' })">Sync Rules</a>
+    </div>
     <div class="topnav-subnav" x-show="currentSection === 'media-management'">
       <a class="topnav-subtab" :class="{ active: getMediaTab(activeAppType) === 'quality' }"
          :href="navHref('media-management', { mediaTab: 'quality' })">Quality Definitions</a>

--- a/ui/static/partials/modals/notification-agent.html
+++ b/ui/static/partials/modals/notification-agent.html
@@ -70,7 +70,11 @@
                 :value="agentModal.config[g.field.name] || ''"
                 @input.stop="agentModal.config[g.field.name] = $event.target.value">
 
-              <!-- stringList: textarea where each line is one entry; bound to a string[] -->
+              <!-- stringList: textarea where each line is one entry; bound to a string[].
+                   Defensive .join via Array.isArray: legacy agents persisted this
+                   field as a plain string (single webhook URL), which crashes the
+                   .join() call without the type check. Falls back to the string
+                   value as-is so the field still shows the user's data. -->
               <textarea
                 x-show="g.field.kind === 'stringList'"
                 class="input"
@@ -78,7 +82,7 @@
                 :placeholder="g.field.placeholder"
                 autocomplete="one-time-code"
                 style="font-family:monospace;font-size:12px"
-                :value="(agentModal.config[g.field.name] || []).join('\n')"
+                :value="(() => { const v = agentModal.config[g.field.name]; if (Array.isArray(v)) return v.join('\n'); return v == null ? '' : String(v); })()"
                 @input="agentModal.config[g.field.name] = $event.target.value.split('\n'); agentModal.testPassed = false"></textarea>
 
               <div x-show="g.field.helpHtml"

--- a/ui/static/partials/modals/sandbox-export.html
+++ b/ui/static/partials/modals/sandbox-export.html
@@ -1,0 +1,46 @@
+{{define "modals/sandbox-export"}}
+  <!-- Sandbox Export modal — bulk-export the currently-visible sandbox
+       result list as plain text. Designed to paste into diff tools
+       (diffchecker.com, sdiff, vimdiff) to compare two scoring sessions
+       (same release set against two profiles, or same profile at two
+       points in time) so the user can see exactly which rows scored
+       differently and which CFs contributed.
+
+       Three implicit modes the formatter picks per-row based on data:
+         - Title only          (release has no scoring)
+         - Title + total       (default toggle off)
+         - Title + total + CF  (toggle on; CFs sorted alphabetically
+                                so same-CF rows line up across sessions) -->
+  <div class="modal-overlay" x-show="sandboxExportModal.show" @keydown.escape.window="sandboxExportModal.show = false" x-cloak>
+    <div class="modal" style="max-width:820px;width:92vw" role="dialog" aria-modal="true" aria-labelledby="modal-title-sandbox-export" x-trap.noscroll.inert="sandboxExportModal.show">
+      <h2 id="modal-title-sandbox-export" class="modal-title" style="display:flex;align-items:center;gap:8px">
+        <span>Export Results</span>
+        <span style="font-size:11px;color:var(--text-secondary);font-weight:400">(plain text · paste into a diff tool to compare scoring runs)</span>
+      </h2>
+      <!-- Breakdown toggle — flips the formatter mode. Watching this
+           via @change re-renders the textbox on the fly so the user
+           sees the size of the export before they commit. -->
+      <div style="margin:8px 0 10px 0;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+        <label style="display:inline-flex;align-items:center;gap:6px;font-size:13px;cursor:pointer">
+          <input type="checkbox"
+                 x-model="sandboxExportModal.includeBreakdown"
+                 @change="rerenderSandboxExport()">
+          <span>Include CF breakdown per release</span>
+        </label>
+        <span style="font-size:12px;color:var(--text-muted)">
+          Rows follow the table's current sort and visible-rows filter.
+        </span>
+      </div>
+      <pre id="sandbox-export-pre" style="background:var(--bg-page);border:1px solid var(--border-subtle);border-radius:6px;padding:12px 14px;margin:0;max-height:60vh;overflow:auto;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.55;color:var(--text-body);white-space:pre;user-select:text" x-text="sandboxExportModal.text || '(no releases to export)'"></pre>
+      <div class="modal-actions">
+        <button class="btn" @click="sandboxExportModal.show = false">Close</button>
+        <button class="btn btn-primary"
+                @click="copySandboxExportText()"
+                :disabled="!sandboxExportModal.text">
+          <span x-text="sandboxExportModal.copied ? '✓ Copied' : 'Copy'"></span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+{{end}}

--- a/ui/static/partials/sections/custom-formats.html
+++ b/ui/static/partials/sections/custom-formats.html
@@ -1,9 +1,11 @@
 {{define "sections/custom-formats"}}
       <!-- ===== Custom Formats section ===== -->
       <div class="page" x-show="currentSection === 'custom-formats'">
-        <div style="font-size:18px;font-weight:600;margin-bottom:4px">Custom Formats</div>
-        <div style="font-size:14px;color:var(--text-muted);margin-bottom:14px;line-height:1.5">All Custom Formats from TRaSH-Guides, organized by category. Use Create to build a custom format from scratch, or Import to add existing formats from an Arr instance or JSON.</div>
 
+        <!-- ====== Browse sub-tab ====== -->
+        <div x-show="getCustomFormatsTab(activeAppType) === 'browse'">
+        <div style="font-size:18px;font-weight:600;margin-bottom:4px">Custom Formats</div>
+        <div style="font-size:14px;color:var(--text-muted);margin-bottom:14px;line-height:1.5">Every TRaSH-Guides custom format, plus the ones you've created or imported, organized by category. Browse, read what each CF does, clone a TRaSH CF as a starting point, or build a new one from scratch.</div>
         <template x-if="getCFBrowseGroups(activeAppType).length > 0">
           <div class="cf-browse-shell">
             <!-- Sidebar rail — All + per-category filter. Same look as
@@ -206,5 +208,329 @@
             <div class="desc">Pull TRaSH data to see Custom Formats</div>
           </div>
         </template>
+        </div>
+        <!-- /Browse sub-tab -->
+
+        <!-- ====== Sync Rules sub-tab ======
+             Per-instance cards (one per Arr instance) listing every
+             Custom Format clonarr manages on that instance. Each row
+             shows the CF + which Arr profiles pull it in (with ID +
+             last-sync chip), drift status, and an Update button when
+             drift exists. Mirrors Profiles → Sync Rules' v3-inst-card
+             layout so the two surfaces feel like the same product. -->
+        <div x-show="getCustomFormatsTab(activeAppType) === 'sync-rules'">
+          <div style="font-size:18px;font-weight:600;margin-bottom:4px">Sync Rules</div>
+          <div style="font-size:14px;color:var(--text-muted);margin-bottom:14px;line-height:1.5">Every custom format any of your sync rules pushes to <span x-text="activeAppLabel"></span>. Spot drift, see which profiles use a CF, and re-push the saved spec when someone edits it directly in <span x-text="activeAppLabel"></span>.</div>
+          <template x-if="!cfSyncRulesLoaded[activeAppType]">
+            <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">Loading custom formats...</div>
+          </template>
+          <template x-if="cfSyncRulesLoaded[activeAppType] && (cfSyncRules[activeAppType] || []).length === 0">
+            <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">No custom formats are managed by your sync rules yet. Sync a profile from <a class="inline-link" :href="navHref('profiles', { profileTab: 'trash-profiles' })">TRaSH Profiles</a> to start managing CFs through clonarr.</div>
+          </template>
+          <template x-if="cfSyncRulesLoaded[activeAppType] && (cfSyncRules[activeAppType] || []).length > 0">
+            <div class="cf-sr-layout">
+              <!-- Sidebar: hierarchical category tree (parent ▸ child).
+                   View-filter pins on top (All, Drifted) when applicable;
+                   then per-parent collapsible children, mirroring the
+                   Browse tab's sidebar pattern. localStorage-persisted
+                   chevron state. -->
+              <aside class="cf-sr-side">
+                <!-- View filters (Drifted / etc) sit at the top in
+                     their own visual group, separated from the
+                     categories list by a divider so the user reads
+                     them as distinct from "All categories". Only
+                     render the filters block when at least one filter
+                     is applicable. -->
+                <template x-if="cfSyncRulesDriftedTotal(activeAppType) > 0">
+                  <div class="cf-sr-side-views">
+                    <button type="button" class="cf-sr-side-item cf-sr-side-view"
+                            :class="{ active: cfSyncRulesActiveCat === 'view:drifted' }"
+                            @click="cfSyncRulesActiveCat = 'view:drifted'">
+                      <span class="cf-sr-side-label">Drifted</span>
+                      <span class="cf-sr-side-count" x-text="cfSyncRulesDriftedTotal(activeAppType)"></span>
+                    </button>
+                  </div>
+                </template>
+                <!-- "All categories" sits directly above the parent
+                     list, no separator between, so they read as one
+                     coherent tree. Matches Browse's sidebar layout. -->
+                <button type="button" class="cf-sr-side-item cf-sr-side-all"
+                        :class="{ active: cfSyncRulesActiveCat === 'all' }"
+                        @click="cfSyncRulesActiveCat = 'all'">
+                  <span class="cf-sr-side-label">All categories</span>
+                  <span class="cf-sr-side-count" x-text="(cfSyncRules[activeAppType] || []).length"></span>
+                </button>
+                <template x-for="par in cfSyncRulesCategories(activeAppType)" :key="par.name">
+                  <div class="cf-sr-side-group">
+                    <div class="cf-sr-side-parent-row">
+                      <button type="button" class="cf-sr-side-chevron"
+                              :class="{ open: cfSRSidebarParentOpen(par.name) }"
+                              @click="cfSRToggleSidebarParent(par.name)"
+                              aria-label="Toggle category">&#9654;</button>
+                      <button type="button" class="cf-sr-side-item cf-sr-side-parent"
+                              :class="{ active: cfSyncRulesActiveCat === 'cat:' + par.name }"
+                              @click="cfSRPickParent(par.name)">
+                        <span class="cf-sr-side-label" x-text="par.name"></span>
+                        <span class="cf-sr-side-count" x-text="par.total"></span>
+                      </button>
+                    </div>
+                    <div class="cf-sr-side-children" x-show="cfSRSidebarParentOpen(par.name)" x-cloak>
+                      <template x-for="child in par.children" :key="par.name + '|' + child.name">
+                        <button type="button" class="cf-sr-side-item cf-sr-side-child"
+                                :class="{ active: cfSyncRulesActiveCat === 'sub:' + par.name + '|' + child.name }"
+                                @click="cfSRPickSubcategory(par.name, child.name)">
+                          <span class="cf-sr-side-label" x-text="child.name"></span>
+                          <span class="cf-sr-side-count" x-text="child.total"></span>
+                        </button>
+                      </template>
+                    </div>
+                  </div>
+                </template>
+              </aside>
+
+              <!-- Main pane: global filter bar (Check + search) + one
+                   v3-inst-card per instance. Each card carries its own
+                   Update all (drift-only) so per-instance scope is
+                   unambiguous. -->
+              <div class="cf-sr-main">
+                <!-- Header row — informative only. Just the total
+                     count. Per-instance drift breakdown lives in
+                     each card header; per-CF state lives in the row
+                     pill; global drift filter+count lives on the
+                     sidebar Drifted pin. No need to repeat it here. -->
+                <div class="cf-sr-header-bar">
+                  <span class="cf-sr-counts">
+                    <span style="font-weight:600" x-text="cfSyncRulesFiltered(activeAppType).length + ' custom format' + (cfSyncRulesFiltered(activeAppType).length === 1 ? '' : 's')"></span>
+                  </span>
+                </div>
+                <!-- Action row — all interactive controls together.
+                     Left-to-right: Expand/Collapse all → Instance
+                     picker → Search → Check. Keeps Expand/Collapse
+                     near the sidebar tree it controls; instance +
+                     search are the most-used filters; Check sits on
+                     the right as the primary "do something" action. -->
+                <div class="cf-sr-filter-bar">
+                  <button type="button" class="cf-browse-expand-toggle"
+                          @click="cfSRToggleAllParents(activeAppType)"
+                          x-text="cfSRAnyParentExpanded(activeAppType) ? 'Collapse all' : 'Expand all'"></button>
+                  <template x-if="cfSyncRulesInstanceOptions(activeAppType).length > 1">
+                    <label class="cf-sr-filter-group">
+                      <span class="cf-sr-filter-label">Instance</span>
+                      <select class="cf-sr-filter-select" x-model="cfSyncRulesActiveInstance">
+                        <option value="">All instances</option>
+                        <template x-for="inst in cfSyncRulesInstanceOptions(activeAppType)" :key="inst.id">
+                          <option :value="inst.id" x-text="inst.name"></option>
+                        </template>
+                      </select>
+                    </label>
+                  </template>
+                  <label class="cf-sr-filter-group cf-sr-filter-search">
+                    <span class="cf-sr-filter-label">Search</span>
+                    <input type="search"
+                           class="cf-sr-filter-input"
+                           placeholder="CF name, TRaSH profile, or Arr profile…"
+                           x-model="cfSyncRulesSearch">
+                    <template x-if="cfSyncRulesSearch">
+                      <button type="button" class="cf-sr-filter-clear"
+                              @click="cfSyncRulesSearch = ''"
+                              aria-label="Clear search">&times;</button>
+                    </template>
+                  </label>
+                  <span class="cf-sr-filter-actions">
+                    <button class="v3-inst-action"
+                            :disabled="checkingUpdates || pulling || cfApplyAllProgress.running"
+                            @click="checkTrashUpdates()"
+                            x-tt="'Check for TRaSH-Guides updates and Arr-side drift. No pull, no Arr writes - just detection.'">Check</button>
+                  </span>
+                </div>
+                <template x-if="cfApplyAllProgress.running && cfApplyAllProgress.label">
+                  <div class="cf-sr-progress" x-text="cfApplyAllProgress.label"></div>
+                </template>
+
+                <!-- One card per Arr instance in this app type -->
+                <template x-for="card in cfSyncRulesByInstance(activeAppType)" :key="'cfsr-card-'+card.id">
+                  <div class="v3-inst-card cf-sr-inst-card">
+                    <div class="v3-inst-header">
+                      <span class="v3-inst-name" x-text="card.name"></span>
+                      <span class="v3-inst-count"
+                            x-text="card.rows.length + ' CF' + (card.rows.length === 1 ? '' : 's')"></span>
+                      <template x-if="cfSRInstanceCardDriftCount(card) > 0">
+                        <span class="cf-sr-card-drift-text"
+                              x-text="cfSRInstanceCardDriftCount(card) + ' drifted'"></span>
+                      </template>
+                      <span class="v3-inst-actions">
+                        <template x-if="cfSRInstanceCardDriftCount(card) > 0">
+                          <button class="v3-inst-action"
+                                  :disabled="checkingUpdates || pulling || cfApplyAllProgress.running"
+                                  @click="applyAllCFDriftForInstance(card)"
+                                  x-tt="'Re-push the saved spec for every drifted custom format on ' + card.name + '. Overwrites the Arr-side edits on each.'">Update all</button>
+                        </template>
+                      </span>
+                    </div>
+                    <div class="cf-sr-table">
+                      <div class="cf-sr-row cf-sr-header">
+                        <span>Name</span>
+                        <span>Category</span>
+                        <span>Used in</span>
+                        <span>Status</span>
+                        <span>Last sync</span>
+                        <span></span>
+                      </div>
+                      <template x-for="r in card.rows" :key="'cfsr-row-'+card.id+'-'+r.trashId">
+                        <div>
+                          <div class="cf-sr-row cf-sr-row-clickable"
+                               :class="{ 'cf-sr-row-expanded': cfSyncRulesExpandedRow === card.id + ':' + r.trashId }"
+                               role="button"
+                               tabindex="0"
+                               :aria-expanded="cfSyncRulesExpandedRow === card.id + ':' + r.trashId ? 'true' : 'false'"
+                               @click="cfSyncRulesToggleExpand(card.id + ':' + r.trashId)"
+                               @keydown.enter.prevent="cfSyncRulesToggleExpand(card.id + ':' + r.trashId)"
+                               @keydown.space.prevent="cfSyncRulesToggleExpand(card.id + ':' + r.trashId)">
+                            <span class="cf-sr-name" x-text="r.name"></span>
+                            <span class="cf-sr-cat">
+                              <span x-text="r.category"></span>
+                              <template x-if="r.subcategory">
+                                <span class="cf-sr-subcat" x-text="' · ' + r.subcategory"></span>
+                              </template>
+                            </span>
+                            <!-- Used in: compact count + chevron only.
+                                 Per-profile breakdown lives in the expand-
+                                 row. Multi-profile chips here previously
+                                 broke the grid by pushing Status into the
+                                 next column. -->
+                            <span class="cf-sr-uses"
+                                  x-tt="'Click anywhere on this row for profile + drift detail.'">
+                              <span x-text="(r.instance.profiles || []).length + ' profile' + ((r.instance.profiles || []).length === 1 ? '' : 's')"></span>
+                              <span class="cf-sr-uses-chev"
+                                    :class="{ open: cfSyncRulesExpandedRow === card.id + ':' + r.trashId }"
+                                    aria-hidden="true">&#9656;</span>
+                            </span>
+                            <span>
+                              <template x-if="!r.instance.drift">
+                                <span class="cf-sr-pill cf-sr-pill-ok">In sync</span>
+                              </template>
+                              <template x-if="r.instance.drift">
+                                <span class="cf-sr-pill cf-sr-pill-drift">Arr drift</span>
+                              </template>
+                            </span>
+                            <span class="cf-sr-lastsync"
+                                  x-text="cfSRInstanceLastSync(r.instance) ? timeAgo(cfSRInstanceLastSync(r.instance)) : 'never'"></span>
+                            <span style="text-align:right">
+                              <template x-if="r.instance.drift">
+                                <button class="v3-inst-action"
+                                        style="font-size:11px"
+                                        :disabled="cfApplyingKey === card.id + ':' + r.trashId || cfApplyAllProgress.running"
+                                        @click.stop="applyCFDrift(card.id, r.trashId, r.name, card.name)"
+                                        x-tt="'Re-push the saved spec back to ' + card.name + ', overwriting the Arr-side edits on this CF.'"
+                                        x-text="cfApplyingKey === card.id + ':' + r.trashId ? 'Updating...' : 'Update'"></button>
+                              </template>
+                            </span>
+                          </div>
+                          <template x-if="cfSyncRulesExpandedRow === card.id + ':' + r.trashId">
+                            <div class="cf-sr-expand">
+                              <template x-if="r.instance.drift">
+                                <div class="cf-sr-expand-section">
+                                  <div class="cf-sr-expand-section-title">Drift detail</div>
+                                  <div class="cf-sr-diff-block">
+                                    <template x-if="(cfDriftDiffCache[card.id + ':' + r.trashId] || {}).loading">
+                                      <div class="cf-sr-diff-status">Loading diff…</div>
+                                    </template>
+                                    <template x-if="(cfDriftDiffCache[card.id + ':' + r.trashId] || {}).error">
+                                      <div class="cf-sr-diff-status cf-sr-diff-status-err"
+                                           x-text="'Could not load diff: ' + cfDriftDiffCache[card.id + ':' + r.trashId].error"></div>
+                                    </template>
+                                    <template x-if="(cfDriftDiffCache[card.id + ':' + r.trashId] || {}).liveMissing">
+                                      <div class="cf-sr-diff-status">Not in Arr yet — next sync will create it.</div>
+                                    </template>
+                                    <template x-if="!((cfDriftDiffCache[card.id + ':' + r.trashId] || {}).loading || (cfDriftDiffCache[card.id + ':' + r.trashId] || {}).error) && (cfDriftDiffCache[card.id + ':' + r.trashId] || {}).diff && !cfDriftDiffHasChanges(cfDriftDiffCache[card.id + ':' + r.trashId].diff)">
+                                      <div class="cf-sr-diff-status cf-sr-diff-status-ok">Drift was already resolved.</div>
+                                    </template>
+                                    <template x-if="((cfDriftDiffCache[card.id + ':' + r.trashId] || {}).diff) && cfDriftDiffHasChanges(cfDriftDiffCache[card.id + ':' + r.trashId].diff)">
+                                      <!-- Flat one-line-per-change list,
+                                           same format Profile Sync Rules uses
+                                           in its status-review modal. Verb
+                                           prefix (Added / Removed / Changed
+                                           / Setting) tells the user the kind
+                                           of change inline so there's no
+                                           need for separate group headers. -->
+                                      <div class="cf-sr-diff-body">
+                                        <template x-for="sc in (cfDriftDiffCache[card.id + ':' + r.trashId].diff.settingsChanges || [])" :key="'set-'+sc.field">
+                                          <div class="cf-sr-diff-line">
+                                            <span class="cf-sr-diff-verb">Setting</span>
+                                            <strong x-text="sc.field"></strong>:
+                                            <span class="cf-sr-diff-val" x-text="sc.before || '(empty)'"></span>
+                                            <span class="cf-sr-diff-arrow">&rarr;</span>
+                                            <span class="cf-sr-diff-val" x-text="sc.after || '(empty)'"></span>
+                                          </div>
+                                        </template>
+                                        <template x-for="ac in (cfDriftDiffCache[card.id + ':' + r.trashId].diff.addedConditions || [])" :key="'add-'+ac.name">
+                                          <div class="cf-sr-diff-line">
+                                            <span class="cf-sr-diff-verb">Added</span>
+                                            <strong x-text="ac.name"></strong>
+                                            <template x-if="ac.value">
+                                              <span>: <span class="cf-sr-diff-val" x-text="ac.value"></span></span>
+                                            </template>
+                                          </div>
+                                        </template>
+                                        <template x-for="rc in (cfDriftDiffCache[card.id + ':' + r.trashId].diff.removedConditions || [])" :key="'rem-'+rc.name">
+                                          <div class="cf-sr-diff-line">
+                                            <span class="cf-sr-diff-verb">Removed</span>
+                                            <strong x-text="rc.name"></strong>
+                                            <template x-if="rc.value">
+                                              <span>: <span class="cf-sr-diff-val" x-text="rc.value"></span></span>
+                                            </template>
+                                          </div>
+                                        </template>
+                                        <template x-for="(cc, i) in (cfDriftDiffCache[card.id + ':' + r.trashId].diff.changedConditions || [])" :key="'chg-'+i">
+                                          <div class="cf-sr-diff-line">
+                                            <strong x-text="cc.name"></strong>
+                                            <span x-text="cc.field"></span>:
+                                            <span class="cf-sr-diff-val" x-text="cc.before || '(empty)'"></span>
+                                            <span class="cf-sr-diff-arrow">&rarr;</span>
+                                            <span class="cf-sr-diff-val" x-text="cc.after || '(empty)'"></span>
+                                          </div>
+                                        </template>
+                                      </div>
+                                    </template>
+                                  </div>
+                                </div>
+                              </template>
+
+                              <div class="cf-sr-expand-section">
+                                <div class="cf-sr-expand-section-title">Used in profiles</div>
+                                <template x-if="(r.instance.profiles || []).length === 0">
+                                  <div class="cf-sr-expand-empty">Not in any profile on this instance.</div>
+                                </template>
+                                <template x-if="(r.instance.profiles || []).length > 0">
+                                  <table class="cf-sr-prof-table">
+                                    <thead>
+                                      <tr><th>TRaSH Profile</th><th></th><th>ID</th><th>Arr Profile</th><th>Last sync</th></tr>
+                                    </thead>
+                                    <tbody>
+                                      <template x-for="p in r.instance.profiles" :key="'profrow-'+p.ruleId">
+                                        <tr>
+                                          <td x-text="p.trashProfileName"></td>
+                                          <td class="cf-sr-prof-arrow">&rarr;</td>
+                                          <td class="cf-sr-prof-id" x-text="p.arrProfileId || '—'"></td>
+                                          <td x-text="p.arrProfileName || '(never synced)'"></td>
+                                          <td x-text="p.lastSync ? timeAgo(p.lastSync) : '—'"></td>
+                                        </tr>
+                                      </template>
+                                    </tbody>
+                                  </table>
+                                </template>
+                              </div>
+                            </div>
+                          </template>
+                        </div>
+                      </template>
+                    </div>
+                  </div>
+                </template>
+              </div>
+            </div>
+          </template>
+        </div>
+        <!-- /Sync Rules sub-tab -->
       </div>
 {{end}}

--- a/ui/static/partials/sections/custom-formats.html
+++ b/ui/static/partials/sections/custom-formats.html
@@ -220,7 +220,7 @@
              layout so the two surfaces feel like the same product. -->
         <div x-show="getCustomFormatsTab(activeAppType) === 'sync-rules'">
           <div style="font-size:18px;font-weight:600;margin-bottom:4px">Sync Rules</div>
-          <div style="font-size:14px;color:var(--text-muted);margin-bottom:14px;line-height:1.5">Every custom format any of your sync rules pushes to <span x-text="activeAppLabel"></span>. Spot drift, see which profiles use a CF, and re-push the saved spec when someone edits it directly in <span x-text="activeAppLabel"></span>.</div>
+          <div style="font-size:14px;color:var(--text-muted);margin-bottom:14px;line-height:1.5">Status for every custom format your sync rules manage on <span x-text="activeAppLabel"></span>. Spot drift and pending TRaSH updates, see which profiles use a CF, and re-sync when needed.</div>
           <template x-if="!cfSyncRulesLoaded[activeAppType]">
             <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">Loading custom formats...</div>
           </template>
@@ -241,14 +241,24 @@
                      them as distinct from "All categories". Only
                      render the filters block when at least one filter
                      is applicable. -->
-                <template x-if="cfSyncRulesDriftedTotal(activeAppType) > 0">
+                <template x-if="cfSyncRulesDriftedTotal(activeAppType) > 0 || cfSyncRulesUpdatesTotal(activeAppType) > 0">
                   <div class="cf-sr-side-views">
-                    <button type="button" class="cf-sr-side-item cf-sr-side-view"
-                            :class="{ active: cfSyncRulesActiveCat === 'view:drifted' }"
-                            @click="cfSyncRulesActiveCat = 'view:drifted'">
-                      <span class="cf-sr-side-label">Drifted</span>
-                      <span class="cf-sr-side-count" x-text="cfSyncRulesDriftedTotal(activeAppType)"></span>
-                    </button>
+                    <template x-if="cfSyncRulesUpdatesTotal(activeAppType) > 0">
+                      <button type="button" class="cf-sr-side-item cf-sr-side-view-upd"
+                              :class="{ active: cfSyncRulesActiveCat === 'view:updates' }"
+                              @click="cfSyncRulesActiveCat = 'view:updates'">
+                        <span class="cf-sr-side-label">Updates</span>
+                        <span class="cf-sr-side-count" x-text="cfSyncRulesUpdatesTotal(activeAppType)"></span>
+                      </button>
+                    </template>
+                    <template x-if="cfSyncRulesDriftedTotal(activeAppType) > 0">
+                      <button type="button" class="cf-sr-side-item cf-sr-side-view"
+                              :class="{ active: cfSyncRulesActiveCat === 'view:drifted' }"
+                              @click="cfSyncRulesActiveCat = 'view:drifted'">
+                        <span class="cf-sr-side-label">Drifted</span>
+                        <span class="cf-sr-side-count" x-text="cfSyncRulesDriftedTotal(activeAppType)"></span>
+                      </button>
+                    </template>
                   </div>
                 </template>
                 <!-- "All categories" sits directly above the parent
@@ -354,16 +364,34 @@
                       <span class="v3-inst-name" x-text="card.name"></span>
                       <span class="v3-inst-count"
                             x-text="card.rows.length + ' CF' + (card.rows.length === 1 ? '' : 's')"></span>
+                      <template x-if="cfSRInstanceCardUpdateCount(card) > 0">
+                        <span class="cf-sr-card-update-text"
+                              x-text="cfSRInstanceCardUpdateCount(card) + ' with updates'"></span>
+                      </template>
                       <template x-if="cfSRInstanceCardDriftCount(card) > 0">
                         <span class="cf-sr-card-drift-text"
                               x-text="cfSRInstanceCardDriftCount(card) + ' drifted'"></span>
                       </template>
                       <span class="v3-inst-actions">
-                        <template x-if="cfSRInstanceCardDriftCount(card) > 0">
+                        <!-- Update all takes precedence over Apply drift
+                             when there are pending TRaSH updates: a
+                             sync push covers both channels (Arr gets
+                             the new spec, drift resolves naturally
+                             since clonarr's saved state now matches
+                             upstream). When ONLY drift exists, fall
+                             back to the targeted Apply path. -->
+                        <template x-if="cfSRInstanceCardUpdateCount(card) > 0">
+                          <button class="v3-inst-action"
+                                  :disabled="checkingUpdates || pulling || cfApplyAllProgress.running || updatingInstance === card.id"
+                                  @click="(() => { const inst = instances.find(i => i.id === card.id); if (inst) updateAllForInstance(inst); })()"
+                                  x-tt="'Pull latest TRaSH-Guides data, then sync all rules on ' + card.name + ' that have pending updates or drift.'"
+                                  x-text="updatingInstance === card.id ? 'Updating...' : 'Update all'"></button>
+                        </template>
+                        <template x-if="cfSRInstanceCardUpdateCount(card) === 0 && cfSRInstanceCardDriftCount(card) > 0">
                           <button class="v3-inst-action"
                                   :disabled="checkingUpdates || pulling || cfApplyAllProgress.running"
                                   @click="applyAllCFDriftForInstance(card)"
-                                  x-tt="'Re-push the saved spec for every drifted custom format on ' + card.name + '. Overwrites the Arr-side edits on each.'">Update all</button>
+                                  x-tt="'Re-push the saved spec for every drifted custom format on ' + card.name + '. Overwrites the Arr-side edits on each.'">Apply drift</button>
                         </template>
                       </span>
                     </div>
@@ -406,23 +434,52 @@
                                     aria-hidden="true">&#9656;</span>
                             </span>
                             <span>
-                              <template x-if="!r.instance.drift">
+                              <template x-if="!r.instance.drift && !r.instance.updateAvailable">
                                 <span class="cf-sr-pill cf-sr-pill-ok">In sync</span>
                               </template>
-                              <template x-if="r.instance.drift">
+                              <template x-if="r.instance.updateAvailable && !r.instance.drift">
+                                <span class="cf-sr-pill cf-sr-pill-upd">Update</span>
+                              </template>
+                              <template x-if="r.instance.drift && !r.instance.updateAvailable">
                                 <span class="cf-sr-pill cf-sr-pill-drift">Arr drift</span>
+                              </template>
+                              <template x-if="r.instance.drift && r.instance.updateAvailable">
+                                <span class="cf-sr-pill cf-sr-pill-both">Update + drift</span>
                               </template>
                             </span>
                             <span class="cf-sr-lastsync"
                                   x-text="cfSRInstanceLastSync(r.instance) ? timeAgo(cfSRInstanceLastSync(r.instance)) : 'never'"></span>
                             <span style="text-align:right">
-                              <template x-if="r.instance.drift">
+                              <!-- Update wins over Apply when both are
+                                   relevant: a sync push pulls the new
+                                   spec from disk and writes it to Arr,
+                                   covering the upstream change AND
+                                   overwriting any drifted Arr-side
+                                   edits in one operation. -->
+                              <template x-if="r.instance.updateAvailable">
+                                <!-- Only disable when THIS specific row or
+                                     THIS card's batch action is running.
+                                     The global updatingRuleId flag (used
+                                     by Profile Sync Rules' Update profile
+                                     button) intentionally NOT checked here
+                                     — it would otherwise leave every CF
+                                     Update button stuck across the page
+                                     when a stale flag survives from a
+                                     prior hung sync on Profile Sync. -->
+                                <button class="v3-inst-action"
+                                        style="font-size:11px"
+                                        :disabled="cfApplyingKey === card.id + ':' + r.trashId || cfApplyAllProgress.running || updatingInstance === card.id"
+                                        @click.stop="updateCFForInstance(card.id, r.trashId, r.name, card.name, (r.instance.profiles || []).map(p => p.ruleId))"
+                                        x-tt="'Pull latest TRaSH-Guides spec for this CF and push it to ' + card.name + '. Resolves both the upstream update and any Arr drift on this CF.'"
+                                        x-text="cfApplyingKey === card.id + ':' + r.trashId ? 'Updating...' : 'Update'"></button>
+                              </template>
+                              <template x-if="r.instance.drift && !r.instance.updateAvailable">
                                 <button class="v3-inst-action"
                                         style="font-size:11px"
                                         :disabled="cfApplyingKey === card.id + ':' + r.trashId || cfApplyAllProgress.running"
                                         @click.stop="applyCFDrift(card.id, r.trashId, r.name, card.name)"
-                                        x-tt="'Re-push the saved spec back to ' + card.name + ', overwriting the Arr-side edits on this CF.'"
-                                        x-text="cfApplyingKey === card.id + ':' + r.trashId ? 'Updating...' : 'Update'"></button>
+                                        x-tt="'Re-push clonarr&#39;s saved spec back to ' + card.name + ', overwriting the Arr-side edits on this CF.'"
+                                        x-text="cfApplyingKey === card.id + ':' + r.trashId ? 'Applying...' : 'Apply'"></button>
                               </template>
                             </span>
                           </div>
@@ -491,6 +548,17 @@
                                           </div>
                                         </template>
                                       </div>
+                                    </template>
+                                  </div>
+                                </div>
+                              </template>
+
+                              <template x-if="r.instance.updateAvailable && (r.instance.updateDetails || []).length > 0">
+                                <div class="cf-sr-expand-section">
+                                  <div class="cf-sr-expand-section-title">Upcoming changes on next sync</div>
+                                  <div class="cf-sr-diff-body">
+                                    <template x-for="(d, i) in r.instance.updateDetails" :key="'upd-'+card.id+'-'+r.trashId+'-'+i">
+                                      <div class="cf-sr-diff-line" x-text="d"></div>
                                     </template>
                                   </div>
                                 </div>

--- a/ui/static/partials/sections/profiles.html
+++ b/ui/static/partials/sections/profiles.html
@@ -8,26 +8,10 @@
         <div class="page" x-show="getProfileTab(activeAppType) === 'sync-rules'">
           <div style="font-size:18px;font-weight:600;margin-bottom:4px">Sync Rules</div>
           <div style="font-size:14px;color:var(--text-muted);margin-bottom:12px;line-height:1.5">
-            Your active TRaSH sync rules for this <span x-text="activeAppLabel"></span> instance. Toggle auto-sync, edit per-rule overrides, or re-sync on demand. Add new rules from the <strong>TRaSH Profiles</strong> tab.
+            Every TRaSH profile you've set up to sync with this <span x-text="activeAppLabel"></span> instance. Toggle auto-sync, edit per-rule overrides, or update on demand.
+            Add new rules from <a class="inline-link" :href="navHref('profiles', { profileTab: 'trash-profiles' })">TRaSH Profiles</a>.
+            For a per-CF view with drift status, see <a class="inline-link" :href="navHref('custom-formats', { customFormatsTab: 'sync-rules' })">Custom Formats &rarr; Sync Rules</a>.
           </div>
-
-          <!-- Sub-tab strip: Profiles (today's per-rule view) and Custom
-               Formats (per-CF view scoped to the active app type). The
-               Custom Formats view is a derived render of /api/cf-sync-rules
-               that shows every CF currently managed by any enabled rule
-               on any instance, with its drift state and used-by list.
-               Switching sub-tabs is local UI state — no nav or routing. -->
-          <div class="sync-rules-subtabs">
-            <button type="button"
-                    :class="syncRulesSubTab === 'profiles' ? 'sync-rules-subtab-active' : ''"
-                    @click="syncRulesSubTab = 'profiles'">Profiles</button>
-            <button type="button"
-                    :class="syncRulesSubTab === 'cfs' ? 'sync-rules-subtab-active' : ''"
-                    @click="syncRulesSubTab = 'cfs'; loadCFSyncRules(activeAppType)">Custom Formats</button>
-          </div>
-
-          <!-- Profiles sub-tab: existing per-instance rule cards. -->
-          <div x-show="syncRulesSubTab === 'profiles'">
 
           <!-- Per-instance cards. Each card carries its own auto-sync
                pause state (v3 — per-instance, not global). When paused,
@@ -221,74 +205,8 @@
             </template>
           </template>
           <template x-if="!instancesOfType(activeAppType).some(inst => sortedSyncRules(inst.id).length > 0)">
-            <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">No sync rules yet. Sync a profile from the <strong>TRaSH Profiles</strong> tab to get started.</div>
+            <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">No sync rules yet. Sync a profile from <a class="inline-link" :href="navHref('profiles', { profileTab: 'trash-profiles' })">TRaSH Profiles</a> to get started.</div>
           </template>
-          </div>
-          <!-- /Profiles sub-tab -->
-
-          <!-- Custom Formats sub-tab: per-CF view. Each row is one
-               managed CF; status pill aggregates drift state across all
-               instances the CF is on; Apply re-pushes clonarr's saved
-               spec to whichever instance has drift on this CF. Empty
-               state covers both "no rules yet" and "data still loading
-               after first sub-tab click". -->
-          <div x-show="syncRulesSubTab === 'cfs'">
-            <template x-if="!cfSyncRulesLoaded[activeAppType]">
-              <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">Loading custom formats...</div>
-            </template>
-            <template x-if="cfSyncRulesLoaded[activeAppType] && (cfSyncRules[activeAppType] || []).length === 0">
-              <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">No custom formats are managed by your sync rules yet. Sync a profile from the <strong>TRaSH Profiles</strong> tab to start managing CFs through clonarr.</div>
-            </template>
-            <template x-if="cfSyncRulesLoaded[activeAppType] && (cfSyncRules[activeAppType] || []).length > 0">
-              <div class="v3-inst-card" style="padding:0">
-                <div style="padding:14px 18px;border-bottom:1px solid var(--border-subtle);display:flex;align-items:baseline;gap:10px">
-                  <span style="font-weight:600" x-text="(cfSyncRules[activeAppType] || []).length + ' custom format' + ((cfSyncRules[activeAppType] || []).length === 1 ? '' : 's') + ' managed'"></span>
-                  <span style="color:var(--text-muted);font-size:12px"
-                        x-text="cfDriftedCount(activeAppType) > 0 ? cfDriftedCount(activeAppType) + ' drifted' : 'All in sync'"
-                        :style="cfDriftedCount(activeAppType) > 0 ? 'color:var(--accent-red)' : ''"></span>
-                </div>
-                <div class="cf-sr-table">
-                  <div class="cf-sr-row cf-sr-header">
-                    <span>Name</span>
-                    <span>Category</span>
-                    <span>Used by</span>
-                    <span>Status</span>
-                    <span></span>
-                  </div>
-                  <template x-for="row in cfSyncRules[activeAppType] || []" :key="row.trashId">
-                    <div class="cf-sr-row">
-                      <span class="cf-sr-name" x-text="row.name"></span>
-                      <span class="cf-sr-cat" x-text="row.category"></span>
-                      <span class="cf-sr-uses"
-                            :title="(row.usedByProfiles || []).map(p => p.profileName).join(', ')"
-                            x-text="(row.usedByProfiles || []).length + ' profile' + ((row.usedByProfiles || []).length === 1 ? '' : 's')"></span>
-                      <span>
-                        <template x-if="cfRowDriftCount(row) === 0">
-                          <span class="cf-sr-pill cf-sr-pill-ok">In sync</span>
-                        </template>
-                        <template x-if="cfRowDriftCount(row) > 0">
-                          <span class="cf-sr-pill cf-sr-pill-drift"
-                                :title="(row.instances || []).filter(i => i.drift).map(i => i.name).join(', ')"
-                                x-text="'Arr drift (' + cfRowDriftCount(row) + ')'"></span>
-                        </template>
-                      </span>
-                      <span style="text-align:right">
-                        <template x-for="inst in (row.instances || []).filter(i => i.drift)" :key="inst.id">
-                          <button class="v3-inst-action"
-                                  style="font-size:11px"
-                                  :disabled="cfApplyingKey === inst.id + ':' + row.trashId"
-                                  @click="applyCFDrift(inst.id, row.trashId, row.name, inst.name)"
-                                  x-tt="'Re-push clonarr's saved spec back to ' + inst.name + ', overwriting the Arr-side edits on this CF.'"
-                                  x-text="cfApplyingKey === inst.id + ':' + row.trashId ? 'Applying...' : 'Apply (' + inst.name + ')'"></button>
-                        </template>
-                      </span>
-                    </div>
-                  </template>
-                </div>
-              </div>
-            </template>
-          </div>
-          <!-- /Custom Formats sub-tab -->
 
         </div>
         <!-- end Sync Rules tab -->

--- a/ui/static/partials/sections/profiles.html
+++ b/ui/static/partials/sections/profiles.html
@@ -7,9 +7,27 @@
         <!-- ===== Sync Rules tab ===== -->
         <div class="page" x-show="getProfileTab(activeAppType) === 'sync-rules'">
           <div style="font-size:18px;font-weight:600;margin-bottom:4px">Sync Rules</div>
-          <div style="font-size:14px;color:var(--text-muted);margin-bottom:16px;line-height:1.5">
+          <div style="font-size:14px;color:var(--text-muted);margin-bottom:12px;line-height:1.5">
             Your active TRaSH sync rules for this <span x-text="activeAppLabel"></span> instance. Toggle auto-sync, edit per-rule overrides, or re-sync on demand. Add new rules from the <strong>TRaSH Profiles</strong> tab.
           </div>
+
+          <!-- Sub-tab strip: Profiles (today's per-rule view) and Custom
+               Formats (per-CF view scoped to the active app type). The
+               Custom Formats view is a derived render of /api/cf-sync-rules
+               that shows every CF currently managed by any enabled rule
+               on any instance, with its drift state and used-by list.
+               Switching sub-tabs is local UI state — no nav or routing. -->
+          <div class="sync-rules-subtabs">
+            <button type="button"
+                    :class="syncRulesSubTab === 'profiles' ? 'sync-rules-subtab-active' : ''"
+                    @click="syncRulesSubTab = 'profiles'">Profiles</button>
+            <button type="button"
+                    :class="syncRulesSubTab === 'cfs' ? 'sync-rules-subtab-active' : ''"
+                    @click="syncRulesSubTab = 'cfs'; loadCFSyncRules(activeAppType)">Custom Formats</button>
+          </div>
+
+          <!-- Profiles sub-tab: existing per-instance rule cards. -->
+          <div x-show="syncRulesSubTab === 'profiles'">
 
           <!-- Per-instance cards. Each card carries its own auto-sync
                pause state (v3 — per-instance, not global). When paused,
@@ -205,6 +223,72 @@
           <template x-if="!instancesOfType(activeAppType).some(inst => sortedSyncRules(inst.id).length > 0)">
             <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">No sync rules yet. Sync a profile from the <strong>TRaSH Profiles</strong> tab to get started.</div>
           </template>
+          </div>
+          <!-- /Profiles sub-tab -->
+
+          <!-- Custom Formats sub-tab: per-CF view. Each row is one
+               managed CF; status pill aggregates drift state across all
+               instances the CF is on; Apply re-pushes clonarr's saved
+               spec to whichever instance has drift on this CF. Empty
+               state covers both "no rules yet" and "data still loading
+               after first sub-tab click". -->
+          <div x-show="syncRulesSubTab === 'cfs'">
+            <template x-if="!cfSyncRulesLoaded[activeAppType]">
+              <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">Loading custom formats...</div>
+            </template>
+            <template x-if="cfSyncRulesLoaded[activeAppType] && (cfSyncRules[activeAppType] || []).length === 0">
+              <div style="padding:24px;text-align:center;color:var(--text-muted);font-size:13px">No custom formats are managed by your sync rules yet. Sync a profile from the <strong>TRaSH Profiles</strong> tab to start managing CFs through clonarr.</div>
+            </template>
+            <template x-if="cfSyncRulesLoaded[activeAppType] && (cfSyncRules[activeAppType] || []).length > 0">
+              <div class="v3-inst-card" style="padding:0">
+                <div style="padding:14px 18px;border-bottom:1px solid var(--border-subtle);display:flex;align-items:baseline;gap:10px">
+                  <span style="font-weight:600" x-text="(cfSyncRules[activeAppType] || []).length + ' custom format' + ((cfSyncRules[activeAppType] || []).length === 1 ? '' : 's') + ' managed'"></span>
+                  <span style="color:var(--text-muted);font-size:12px"
+                        x-text="cfDriftedCount(activeAppType) > 0 ? cfDriftedCount(activeAppType) + ' drifted' : 'All in sync'"
+                        :style="cfDriftedCount(activeAppType) > 0 ? 'color:var(--accent-red)' : ''"></span>
+                </div>
+                <div class="cf-sr-table">
+                  <div class="cf-sr-row cf-sr-header">
+                    <span>Name</span>
+                    <span>Category</span>
+                    <span>Used by</span>
+                    <span>Status</span>
+                    <span></span>
+                  </div>
+                  <template x-for="row in cfSyncRules[activeAppType] || []" :key="row.trashId">
+                    <div class="cf-sr-row">
+                      <span class="cf-sr-name" x-text="row.name"></span>
+                      <span class="cf-sr-cat" x-text="row.category"></span>
+                      <span class="cf-sr-uses"
+                            :title="(row.usedByProfiles || []).map(p => p.profileName).join(', ')"
+                            x-text="(row.usedByProfiles || []).length + ' profile' + ((row.usedByProfiles || []).length === 1 ? '' : 's')"></span>
+                      <span>
+                        <template x-if="cfRowDriftCount(row) === 0">
+                          <span class="cf-sr-pill cf-sr-pill-ok">In sync</span>
+                        </template>
+                        <template x-if="cfRowDriftCount(row) > 0">
+                          <span class="cf-sr-pill cf-sr-pill-drift"
+                                :title="(row.instances || []).filter(i => i.drift).map(i => i.name).join(', ')"
+                                x-text="'Arr drift (' + cfRowDriftCount(row) + ')'"></span>
+                        </template>
+                      </span>
+                      <span style="text-align:right">
+                        <template x-for="inst in (row.instances || []).filter(i => i.drift)" :key="inst.id">
+                          <button class="v3-inst-action"
+                                  style="font-size:11px"
+                                  :disabled="cfApplyingKey === inst.id + ':' + row.trashId"
+                                  @click="applyCFDrift(inst.id, row.trashId, row.name, inst.name)"
+                                  x-tt="'Re-push clonarr's saved spec back to ' + inst.name + ', overwriting the Arr-side edits on this CF.'"
+                                  x-text="cfApplyingKey === inst.id + ':' + row.trashId ? 'Applying...' : 'Apply (' + inst.name + ')'"></button>
+                        </template>
+                      </span>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </template>
+          </div>
+          <!-- /Custom Formats sub-tab -->
 
         </div>
         <!-- end Sync Rules tab -->

--- a/ui/static/partials/sections/scoring.html
+++ b/ui/static/partials/sections/scoring.html
@@ -253,6 +253,16 @@
                 <button class="btn btn-sm" x-show="sandboxSelectedCount(activeAppType) > 0"
                         @click="sandbox[activeAppType].results.forEach(r => r._selected = false); sandbox[activeAppType].results = [...sandbox[activeAppType].results]; sandbox[activeAppType].filterToSelected = false"
                         x-tt="'Uncheck all'">Reset filter</button>
+                <!-- Export — opens a modal with the visible result list as
+                     plain text. Includes a toggle for the per-CF breakdown.
+                     Diff-tool friendly (line-per-release for compact mode;
+                     per-release block sorted alphabetical-by-CF when
+                     breakdown is on so two sessions of the same set line up
+                     row-for-row across diffchecker.com paste). -->
+                <button class="btn btn-sm"
+                        @click="openSandboxExport(activeAppType)"
+                        :disabled="(sandbox[activeAppType].results?.length || 0) === 0"
+                        x-tt="'Copy the current result list as plain text. Choose total-only or include the CF breakdown. Use to share runs or diff against a previous session.'">Export</button>
                 <button class="btn btn-sm"
                         style="border-color:var(--accent-red);color:var(--accent-red)"
                         @click="sandboxClearResults(activeAppType)"


### PR DESCRIPTION
## What

- New **Custom Formats → Sync Rules** sub-tab: per-instance card, 4-state status pill (In sync / Update / Arr drift / Update + drift), per-CF + per-instance Update buttons, Updates / Drifted view-pins.
- Backend detects Arr-side CF drift via per-instance `CFDriftFingerprints` + diff vs disk; clears fingerprints post-sync to keep Profile Sync + CF Sync consistent.
- Profile description parser: cutoff-aware source picker; Audio Formats opt-in surfaced in summary.
- Scoring Sandbox: Export modal (plain text, diff-tool-friendly, optional CF breakdown, follows current sort).
- Notification agents: defensive textarea binding for legacy stringList configs.

## Risk

Sync engine + profile editor untouched. Drift detection is read-only until user clicks Update.

## Test

End-to-end verified against `clonarr-trash-test` rounds 1-5 (Add/Remove/Change/Settings/Score drift paths).