### PR TITLE
feat(instances): HTTP Basic Auth for externally-authenticated Sonarr/Radarr instances

### DIFF
--- a/internal/api/autosync.go
+++ b/internal/api/autosync.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"clonarr/internal/arr"
 	"clonarr/internal/core"
 )
 
@@ -541,7 +540,7 @@ func (s *Server) handleRestoreAutoSyncRule(w http.ResponseWriter, r *http.Reques
 	}
 
 	// Collision check 1: Arr profile with this name already exists.
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	existing, err := client.ListProfiles()
 	if err != nil {
 		writeError(w, 502, "Failed to query Arr profiles: "+err.Error())

--- a/internal/api/calculator.go
+++ b/internal/api/calculator.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"clonarr/internal/arr"
+	"clonarr/internal/core"
 	"clonarr/internal/core/calculator"
 )
 
@@ -56,7 +56,7 @@ func (s *Server) handleCalcGrabTitles(w http.ResponseWriter, r *http.Request) {
 	if limit > 500 {
 		limit = 500
 	}
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	path := fmt.Sprintf("/history?page=1&pageSize=%d&sortKey=date&sortDirection=descending&eventType=1", limit)
 	data, status, err := client.DoRequest("GET", path, nil)
 	if err != nil {

--- a/internal/api/cf_drift.go
+++ b/internal/api/cf_drift.go
@@ -106,7 +106,7 @@ func (s *Server) handleCFDriftApply(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Find the live CF in Arr so we know the id to PUT against.
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(*inst, s.Core.HTTPClient)
 	liveCFs, err := client.ListCustomFormats()
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "list arr custom formats: "+err.Error())

--- a/internal/api/cf_drift_diff.go
+++ b/internal/api/cf_drift_diff.go
@@ -75,7 +75,7 @@ func (s *Server) handleCFDriftDiff(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(*inst, s.Core.HTTPClient)
 	liveCFs, err := client.ListCustomFormats()
 	if err != nil {
 		writeError(w, http.StatusBadGateway, "list arr custom formats: "+err.Error())

--- a/internal/api/cf_sync_rules.go
+++ b/internal/api/cf_sync_rules.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"clonarr/internal/arr"
 	"clonarr/internal/core"
 )
 
@@ -405,7 +404,7 @@ func (s *Server) handleCFSyncRules(w http.ResponseWriter, r *http.Request) {
 		if inst.URL == "" {
 			continue
 		}
-		client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+		client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 		arrCFs, err := client.ListCustomFormats()
 		if err != nil {
 			log.Printf("handleCFSyncRules: instance %s (%s) ListCustomFormats failed: %v - skipping Unmanaged enrichment for this instance",

--- a/internal/api/cleanup.go
+++ b/internal/api/cleanup.go
@@ -101,7 +101,7 @@ func (s *Server) handleCleanupScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 
 	switch req.Action {
 	case "duplicates":
@@ -193,7 +193,7 @@ func (s *Server) handleCleanupApply(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 
 	// Defense-in-depth: for actions that affect CFs, re-validate the
 	// caller-supplied IDs against the persisted keep list. If a scan was

--- a/internal/api/custom_cfs.go
+++ b/internal/api/custom_cfs.go
@@ -283,7 +283,7 @@ func (s *Server) handleImportCFsFromInstance(w http.ResponseWriter, r *http.Requ
 	defer func() { op.End(endResult) }()
 
 	// Fetch all CFs from instance
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	arrCFs, err := client.ListCustomFormats()
 	if err != nil {
 		endResult = fmt.Sprintf("error: fetch from %s failed: %v", inst.Name, err)
@@ -411,7 +411,7 @@ func (s *Server) handleCFSchema(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Fetch schema from Arr API
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(*inst, s.Core.HTTPClient)
 	data, status, err := client.DoRequest("GET", "/customformat/schema", nil)
 	if err != nil {
 		writeError(w, 502, "Failed to fetch schema: "+err.Error())

--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -25,10 +25,13 @@ func (s *Server) handleListInstances(w http.ResponseWriter, r *http.Request) {
 	if instances == nil {
 		instances = []core.Instance{}
 	}
-	// Mask API keys (safe: Get() returns deep copy)
+	// Mask secrets (safe: Get() returns deep copy)
 	for i := range instances {
 		if instances[i].APIKey != "" {
 			instances[i].APIKey = maskKey(instances[i].APIKey)
+		}
+		if instances[i].Password != "" {
+			instances[i].Password = maskKey(instances[i].Password)
 		}
 	}
 	writeJSON(w, instances)
@@ -45,6 +48,8 @@ func (s *Server) handleCreateInstance(w http.ResponseWriter, r *http.Request) {
 	inst.Type = strings.TrimSpace(inst.Type)
 	inst.URL = strings.TrimSpace(inst.URL)
 	inst.APIKey = strings.TrimSpace(inst.APIKey)
+	inst.Username = strings.TrimSpace(inst.Username)
+	inst.Password = strings.TrimSpace(inst.Password)
 
 	if inst.Name == "" || inst.URL == "" || inst.APIKey == "" {
 		writeError(w, 400, "name, url, and apiKey are required")
@@ -54,6 +59,10 @@ func (s *Server) handleCreateInstance(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 400, "type must be 'radarr' or 'sonarr'")
 		return
 	}
+	if inst.ExternalAuth && (inst.Username == "" || inst.Password == "") {
+		writeError(w, 400, "username and password are required when external authentication is enabled")
+		return
+	}
 
 	created, err := s.Core.Config.AddInstance(inst)
 	if err != nil {
@@ -61,8 +70,11 @@ func (s *Server) handleCreateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// M2: mask API key in response
+	// Mask secrets in response
 	created.APIKey = maskKey(created.APIKey)
+	if created.Password != "" {
+		created.Password = maskKey(created.Password)
+	}
 	w.WriteHeader(http.StatusCreated)
 	writeJSON(w, created)
 }
@@ -84,6 +96,8 @@ func (s *Server) handleUpdateInstance(w http.ResponseWriter, r *http.Request) {
 	inst.Type = strings.TrimSpace(inst.Type)
 	inst.URL = strings.TrimSpace(inst.URL)
 	inst.APIKey = strings.TrimSpace(inst.APIKey)
+	inst.Username = strings.TrimSpace(inst.Username)
+	inst.Password = strings.TrimSpace(inst.Password)
 
 	if inst.Name == "" || inst.URL == "" {
 		writeError(w, 400, "name and url are required")
@@ -93,13 +107,28 @@ func (s *Server) handleUpdateInstance(w http.ResponseWriter, r *http.Request) {
 		writeError(w, 400, "type must be 'radarr' or 'sonarr'")
 		return
 	}
+	if inst.ExternalAuth && inst.Username == "" {
+		writeError(w, 400, "username is required when external authentication is enabled")
+		return
+	}
 
-	// M9: If API key is empty or masked, keep the existing one
+	existing, hasExisting := s.Core.Config.GetInstance(id)
+
+	// If API key is empty or masked, keep the existing one
 	if inst.APIKey == "" || isMasked(inst.APIKey) {
-		existing, ok := s.Core.Config.GetInstance(id)
-		if ok {
+		if hasExisting {
 			inst.APIKey = existing.APIKey
 		}
+	}
+	// If password is empty or masked, keep the existing one
+	if inst.Password == "" || isMasked(inst.Password) {
+		if hasExisting {
+			inst.Password = existing.Password
+		}
+	}
+	if inst.ExternalAuth && inst.Password == "" {
+		writeError(w, 400, "password is required when external authentication is enabled")
+		return
 	}
 
 	updated, err := s.Core.Config.UpdateInstance(id, inst)
@@ -108,8 +137,11 @@ func (s *Server) handleUpdateInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// M1: mask API key in response
+	// Mask secrets in response
 	updated.APIKey = maskKey(updated.APIKey)
+	if updated.Password != "" {
+		updated.Password = maskKey(updated.Password)
+	}
 	writeJSON(w, updated)
 }
 
@@ -179,7 +211,7 @@ func (s *Server) handleTestInstance(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	status, err := client.TestConnection()
 	if err != nil {
 		errMsg := err.Error()
@@ -252,8 +284,11 @@ func isNonRoutable(ip net.IP) bool {
 func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 4096)
 	var req struct {
-		URL    string `json:"url"`
-		APIKey string `json:"apiKey"`
+		URL          string `json:"url"`
+		APIKey       string `json:"apiKey"`
+		ExternalAuth bool   `json:"externalAuth"`
+		Username     string `json:"username"`
+		Password     string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, 400, "Invalid JSON")
@@ -261,6 +296,8 @@ func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
 	}
 	req.URL = strings.TrimSpace(req.URL)
 	req.APIKey = strings.TrimSpace(req.APIKey)
+	req.Username = strings.TrimSpace(req.Username)
+	req.Password = strings.TrimSpace(req.Password)
 	if req.URL == "" || req.APIKey == "" {
 		writeError(w, 400, "url and apiKey are required")
 		return
@@ -273,7 +310,11 @@ func (s *Server) handleTestConnection(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(req.URL, req.APIKey, s.Core.HTTPClient)
+	u, p := "", ""
+	if req.ExternalAuth {
+		u, p = req.Username, req.Password
+	}
+	client := arr.NewArrClient(req.URL, req.APIKey, u, p, s.Core.HTTPClient)
 	status, err := client.TestConnection()
 	if err != nil {
 		errMsg := err.Error()
@@ -302,7 +343,7 @@ func (s *Server) handleInstanceProfiles(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	profiles, err := client.ListProfiles()
 	if err != nil {
 		writeError(w, 502, "Failed to connect to instance")
@@ -317,7 +358,7 @@ func (s *Server) handleQualityDefinitions(w http.ResponseWriter, r *http.Request
 	if !ok {
 		return
 	}
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	defs, err := client.ListQualityDefinitions()
 	if err != nil {
 		writeError(w, 502, "Failed to fetch quality definitions: "+err.Error())
@@ -359,7 +400,7 @@ func (s *Server) handleRenameProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	profiles, err := client.ListProfiles()
 	if err != nil {
 		writeError(w, 502, "Failed to list profiles: "+err.Error())
@@ -427,7 +468,7 @@ func (s *Server) handleInstanceProfileExport(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 
 	profiles, err := client.ListProfiles()
 	if err != nil {
@@ -657,7 +698,7 @@ func (s *Server) handleInstanceLanguages(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	languages, err := client.ListLanguages()
 	if err != nil {
 		writeError(w, 502, "Failed to fetch languages")
@@ -689,7 +730,7 @@ func (s *Server) handleInstanceBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 
 	allCFs, err := client.ListCustomFormats()
 	if err != nil {
@@ -779,7 +820,7 @@ func (s *Server) handleInstanceRestore(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 
 	// Fetch current state from instance
 	existingCFs, err := client.ListCustomFormats()
@@ -920,7 +961,7 @@ func (s *Server) handleInstanceCFs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	cfs, err := client.ListCustomFormats()
 	if err != nil {
 		writeError(w, 502, "Failed to connect to instance")
@@ -999,7 +1040,7 @@ func (s *Server) handleAddCFsToInstance(w http.ResponseWriter, r *http.Request) 
 
 	// One ListCustomFormats call up front for collision detection — cheaper
 	// than checking per CF and gives the same answer for the batch.
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	existing, err := client.ListCustomFormats()
 	if err != nil {
 		writeError(w, 502, "Failed to list existing CFs: "+err.Error())
@@ -1147,7 +1188,7 @@ func (s *Server) handleManageExistingCF(w http.ResponseWriter, r *http.Request) 
 	// it; we just claim ownership in clonarr's records. If it is not
 	// there, the adopt is meaningless - either the user clicked from a
 	// stale list or something deleted the CF on Arr in the meantime.
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	existing, err := client.ListCustomFormats()
 	if err != nil {
 		writeError(w, 502, "Failed to verify CF on Arr: "+err.Error())
@@ -1210,7 +1251,7 @@ func (s *Server) handleInstanceQualitySizes(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	defs, err := client.ListQualityDefinitions()
 	if err != nil {
 		writeError(w, 502, "Failed to fetch quality sizes: "+err.Error())
@@ -1225,7 +1266,7 @@ func (s *Server) handleGetInstanceNaming(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	naming, err := client.GetNaming()
 	if err != nil {
 		writeError(w, 502, "Failed to fetch naming config: "+err.Error())
@@ -1377,7 +1418,7 @@ func (s *Server) handleSyncQualitySizes(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	if err := client.UpdateQualityDefinitions(req.Definitions); err != nil {
 		writeError(w, 502, "Sync failed: "+err.Error())
 		return
@@ -1403,7 +1444,7 @@ func (s *Server) buildQualitySizeDefs(inst core.Instance, qsType string) ([]arr.
 		return nil, fmt.Errorf("no TRaSH quality sizes for type %q", qsType)
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	defs, err := client.ListQualityDefinitions()
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch definitions: %w", err)
@@ -1567,7 +1608,7 @@ func (s *Server) AutoSyncQualitySizes() {
 		}
 
 		// Get current instance quality definitions
-		client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+		client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 		defs, err := client.ListQualityDefinitions()
 		if err != nil {
 			log.Printf("Auto-sync QS [%s]: failed to fetch definitions: %v", inst.Name, err)
@@ -1795,7 +1836,7 @@ func buildProfileComparison(inst core.Instance, ad *core.AppData, trashProfileID
 	}
 	comp.TrashProfileName = trashProfile.Name
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, httpClient)
+	client := core.NewArrClientFor(inst, httpClient)
 
 	// Fetch existing CFs from instance
 	arrCFs, err := client.ListCustomFormats()
@@ -2313,7 +2354,7 @@ func (s *Server) handleRemoveProfileCFs(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	profiles, err := client.ListProfiles()
 	if err != nil {
 		writeError(w, 502, "Failed to fetch profiles: "+err.Error())
@@ -2390,7 +2431,7 @@ func (s *Server) handleSyncSingleCF(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 
 	// Check if CF already exists in instance
 	arrCFs, err := client.ListCustomFormats()

--- a/internal/api/instances_test.go
+++ b/internal/api/instances_test.go
@@ -162,6 +162,78 @@ func TestHandleUpdateInstanceRejectsWhitespaceRequiredFields(t *testing.T) {
 	}
 }
 
+func TestHandleUpdateInstanceRejectsExternalAuthWithoutPassword(t *testing.T) {
+	app := setupTestApp(t)
+	existing, err := app.Config.AddInstance(core.Instance{
+		Name:   "Old",
+		Type:   "radarr",
+		URL:    "http://old.local:7878",
+		APIKey: "saved-key",
+	})
+	if err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	server := &Server{Core: app}
+	req := httptest.NewRequest(http.MethodPut, "/api/instances/"+existing.ID, instanceJSON(t, map[string]any{
+		"name":         "Radarr HD",
+		"type":         "radarr",
+		"url":          "http://arr.local:7878",
+		"apiKey":       "saved-key",
+		"externalAuth": true,
+		"username":     "user",
+		"password":     "",
+	}))
+	req.SetPathValue("id", existing.ID)
+	w := httptest.NewRecorder()
+
+	server.handleUpdateInstance(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestHandleUpdateInstanceAllowsExternalAuthWithStoredPassword(t *testing.T) {
+	app := setupTestApp(t)
+	existing, err := app.Config.AddInstance(core.Instance{
+		Name:         "Old",
+		Type:         "radarr",
+		URL:          "http://old.local:7878",
+		APIKey:       "saved-key",
+		ExternalAuth: true,
+		Username:     "user",
+		Password:     "saved-pass",
+	})
+	if err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	server := &Server{Core: app}
+	req := httptest.NewRequest(http.MethodPut, "/api/instances/"+existing.ID, instanceJSON(t, map[string]any{
+		"name":         "Radarr HD",
+		"type":         "radarr",
+		"url":          "http://arr.local:7878",
+		"apiKey":       "saved-key",
+		"externalAuth": true,
+		"username":     "user",
+		"password":     "",
+	}))
+	req.SetPathValue("id", existing.ID)
+	w := httptest.NewRecorder()
+
+	server.handleUpdateInstance(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	stored, ok := app.Config.GetInstance(existing.ID)
+	if !ok {
+		t.Fatalf("updated instance %q not found in config", existing.ID)
+	}
+	if stored.Password != "saved-pass" {
+		t.Fatalf("stored password = %q, want preserved %q", stored.Password, "saved-pass")
+	}
+}
+
 func TestHandleTestConnectionRejectsWhitespaceRequiredFields(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/api/naming.go
+++ b/internal/api/naming.go
@@ -122,7 +122,7 @@ func extractNamingPatterns(instType string, current arr.ArrNamingConfig) map[str
 // updates the fingerprint. Every actual change also appends a per-field history
 // event {from, to, at, via} for the inline history + restore.
 func (s *Server) applyNamingFields(inst core.Instance, fields map[string]string, schemes map[string]string, replacedBy string) (arr.ArrNamingConfig, map[string]string, error) {
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	current, err := client.GetNaming()
 	if err != nil {
 		return nil, nil, err
@@ -546,7 +546,7 @@ func (s *Server) AutoSyncNaming() {
 		// EITHER reason: the guide changed (update) OR it was edited directly in
 		// Arr so it no longer matches the scheme (drift). Drift correction is
 		// gated on arrDriftOn; guide updates always apply on this path.
-		client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+		client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 		liveCfg, err := client.GetNaming()
 		if err != nil {
 			log.Printf("Auto-sync naming [%s]: read failed: %v", inst.Name, err)

--- a/internal/api/naming_delayed.go
+++ b/internal/api/naming_delayed.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"clonarr/internal/arr"
 	"clonarr/internal/core"
 	"log"
 	"time"
@@ -56,7 +55,7 @@ func (s *Server) RunNamingDelayed() {
 		if ad == nil && un == nil {
 			continue // no pattern source (guide not loaded + upstream unreachable)
 		}
-		client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+		client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 		liveCfg, err := client.GetNaming()
 		if err != nil {
 			continue // unreachable — leave pending state alone, try next tick

--- a/internal/api/scoring.go
+++ b/internal/api/scoring.go
@@ -283,7 +283,7 @@ func isLanguageCF(name string) bool {
 
 // parseSingleRelease calls the Arr Parse API and enriches CFs with trash_ids.
 func (s *Server) parseSingleRelease(inst core.Instance, title string) (*ScoringParseResult, error) {
-	client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+	client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 	data, status, err := client.DoRequest("GET", "/parse?title="+url.QueryEscape(title), nil)
 	if err != nil {
 		// Transport-level failure (connection refused, DNS, timeout): the

--- a/internal/api/sync.go
+++ b/internal/api/sync.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"clonarr/internal/arr"
 	"clonarr/internal/core"
 
 	"encoding/json"
@@ -694,7 +693,7 @@ func (s *Server) handleSyncHistory(w http.ResponseWriter, r *http.Request) {
 	// unreachable — never mutate state on a connection error.
 	inst, ok := s.Core.Config.GetInstance(id)
 	if ok {
-		client := arr.NewArrClient(inst.URL, inst.APIKey, s.Core.HTTPClient)
+		client := core.NewArrClientFor(inst, s.Core.HTTPClient)
 		profiles, err := client.ListProfiles()
 		if err != nil {
 			log.Printf("Cleanup: skipping %s — instance not reachable: %v", inst.Name, err)

--- a/internal/arr/arr.go
+++ b/internal/arr/arr.go
@@ -12,20 +12,24 @@ import (
 
 // ArrClient talks to a Radarr or Sonarr instance's API v3.
 type ArrClient struct {
-	baseURL string
-	apiKey  string
-	client  *http.Client
+	baseURL  string
+	apiKey   string
+	username string
+	password string
+	client   *http.Client
 }
 
-func NewArrClient(url, apiKey string, client *http.Client) *ArrClient {
+func NewArrClient(url, apiKey, username, password string, client *http.Client) *ArrClient {
 	url = strings.TrimRight(url, "/")
 	if !strings.HasPrefix(url, "http") {
 		url = "http://" + url
 	}
 	return &ArrClient{
-		baseURL: url,
-		apiKey:  apiKey,
-		client:  client,
+		baseURL:  url,
+		apiKey:   apiKey,
+		username: username,
+		password: password,
+		client:   client,
 	}
 }
 
@@ -46,6 +50,9 @@ func (c *ArrClient) DoRequest(method, path string, body any) ([]byte, int, error
 		return nil, 0, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("X-Api-Key", c.apiKey)
+	if c.username != "" {
+		req.SetBasicAuth(c.username, c.password)
+	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/core/arr_client.go
+++ b/internal/core/arr_client.go
@@ -1,0 +1,16 @@
+package core
+
+import (
+	"clonarr/internal/arr"
+	"net/http"
+)
+
+// NewArrClientFor constructs an ArrClient for the given instance, including
+// HTTP Basic Auth credentials when ExternalAuth is enabled on the instance.
+func NewArrClientFor(inst Instance, client *http.Client) *arr.ArrClient {
+	u, p := "", ""
+	if inst.ExternalAuth {
+		u, p = inst.Username, inst.Password
+	}
+	return arr.NewArrClient(inst.URL, inst.APIKey, u, p, client)
+}

--- a/internal/core/autosync.go
+++ b/internal/core/autosync.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"clonarr/internal/arr"
 )
 
 // (App.RunPullAndSync moved to pull.go — canonical Pull-and-sync flow.)
@@ -874,7 +873,7 @@ func (app *App) CleanupStaleRules() {
 	validProfiles := make(map[string]map[int]bool)
 	for _, inst := range cfg.Instances {
 		instNames[inst.ID] = inst.Name
-		client := arr.NewArrClient(inst.URL, inst.APIKey, app.HTTPClient)
+		client := NewArrClientFor(inst, app.HTTPClient)
 		profiles, err := client.ListProfiles()
 		if err != nil {
 			log.Printf("Cleanup: skipping %s — instance not reachable: %v", inst.Name, err)
@@ -1083,7 +1082,7 @@ func (app *App) WaitForInstanceReachable(inst Instance) bool {
 				return false
 			}
 		}
-		client := arr.NewArrClient(inst.URL, inst.APIKey, app.HTTPClient)
+		client := NewArrClientFor(inst, app.HTTPClient)
 		if _, err := client.TestConnection(); err == nil {
 			if i > 0 {
 				log.Printf("Auto-sync: %s reachable on probe %d/%d — proceeding with sync", inst.Name, i+1, len(autoSyncReachabilityDelays))

--- a/internal/core/config.go
+++ b/internal/core/config.go
@@ -465,6 +465,14 @@ type Instance struct {
 	Type   string `json:"type"` // "radarr" or "sonarr"
 	URL    string `json:"url"`
 	APIKey string `json:"apiKey"`
+
+	// ExternalAuth enables HTTP Basic Auth on every request to this instance.
+	// Use when the instance sits behind a reverse proxy or uses *arr's own
+	// "Basic" authentication mode — the API key alone is rejected in that case.
+	ExternalAuth bool   `json:"externalAuth,omitempty"`
+	Username     string `json:"username,omitempty"`
+	Password     string `json:"password,omitempty"`
+
 	// AutoSyncPaused, when true, skips non-user-initiated sync for this
 	// instance only. AutoSyncAfterPull, the delayed-apply runner, and the
 	// drift detector all silently drop rules belonging to a paused

--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -183,7 +183,7 @@ func (d *DriftRunner) runOnceInternal(ctx context.Context, autoApply bool) ([]Dr
 			return s
 		}
 		s := &arrSnapshot{}
-		client := arr.NewArrClient(inst.URL, inst.APIKey, d.app.HTTPClient)
+		client := NewArrClientFor(inst, d.app.HTTPClient)
 		s.profiles, s.err = client.ListProfiles()
 		if s.err == nil {
 			s.cfs, s.err = client.ListCustomFormats()

--- a/internal/core/naming_drift.go
+++ b/internal/core/naming_drift.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"clonarr/internal/arr"
 	"context"
 	"time"
 )
@@ -107,7 +106,7 @@ func runNamingDriftPass(d *DriftRunner, checkDrift, checkUpdate bool) namingDrif
 		if !ok {
 			continue
 		}
-		client := arr.NewArrClient(inst.URL, inst.APIKey, d.app.HTTPClient)
+		client := NewArrClientFor(inst, d.app.HTTPClient)
 		current, err := client.GetNaming()
 		if err != nil {
 			// Unreachable: leave existing drift/update state alone (no false

--- a/internal/core/sync.go
+++ b/internal/core/sync.go
@@ -356,7 +356,7 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 	}
 
 	// Connect to Arr instance
-	client := arr.NewArrClient(instance.URL, instance.APIKey, httpClient)
+	client := NewArrClientFor(instance, httpClient)
 
 	// Fetch existing CFs
 	existingCFs, err := client.ListCustomFormats()
@@ -989,7 +989,7 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 		}
 	}
 
-	client := arr.NewArrClient(instance.URL, instance.APIKey, httpClient)
+	client := NewArrClientFor(instance, httpClient)
 	result := &SyncResult{Errors: []string{}}
 
 	// Track created CF name → Arr ID for score assignment

--- a/ui/static/js/features/instances.js
+++ b/ui/static/js/features/instances.js
@@ -5,7 +5,7 @@ export default {
     instanceVersion: {},
     showInstanceModal: false,
     editingInstance: null,
-    instanceForm: { name: '', type: 'radarr', url: '', apiKey: '' },
+    instanceForm: { name: '', type: 'radarr', url: '', apiKey: '', externalAuth: false, username: '', password: '' },
     instanceFormErrors: {},
     modalTestResult: null,
     // Prowlarr's data shape (single global config) differs from the
@@ -35,6 +35,9 @@ export default {
         type: (this.instanceForm.type || '').trim(),
         url: (this.instanceForm.url || '').trim(),
         apiKey: (this.instanceForm.apiKey || '').trim(),
+        externalAuth: !!this.instanceForm.externalAuth,
+        username: (this.instanceForm.username || '').trim(),
+        password: (this.instanceForm.password || '').trim(),
       };
     },
 
@@ -63,10 +66,10 @@ export default {
       this.editingInstance = inst;
       this.modalTestResult = null;
       if (inst) {
-        this.instanceForm = { name: inst.name, type: inst.type, url: inst.url, apiKey: '' };
+        this.instanceForm = { name: inst.name, type: inst.type, url: inst.url, apiKey: '', externalAuth: !!inst.externalAuth, username: inst.username || '', password: '' };
       } else {
         const fallbackType = ['radarr','sonarr'].includes(this.activeAppType) ? this.activeAppType : 'radarr';
-        this.instanceForm = { name: '', type: defaultType || fallbackType, url: '', apiKey: '' };
+        this.instanceForm = { name: '', type: defaultType || fallbackType, url: '', apiKey: '', externalAuth: false, username: '', password: '' };
       }
       this.showInstanceModal = true;
     },
@@ -79,14 +82,14 @@ export default {
     startInlineEdit(inst) {
       this.inlineEditingId = inst.id;
       this.editingInstance = inst;
-      this.instanceForm = { name: inst.name, type: inst.type, url: inst.url, apiKey: '' };
+      this.instanceForm = { name: inst.name, type: inst.type, url: inst.url, apiKey: '', externalAuth: !!inst.externalAuth, username: inst.username || '', password: '' };
       this.instanceFormErrors = {};
       this.modalTestResult = null;
     },
     startInlineAdd(type) {
       this.inlineEditingId = 'new-' + type;
       this.editingInstance = null;
-      this.instanceForm = { name: '', type, url: '', apiKey: '' };
+      this.instanceForm = { name: '', type, url: '', apiKey: '', externalAuth: false, username: '', password: '' };
       this.instanceFormErrors = {};
       this.modalTestResult = null;
     },
@@ -148,11 +151,14 @@ export default {
       if (!data.url) this.instanceFormErrors.url = 'URL is required';
       if (!data.name) this.instanceFormErrors.name = 'Name is required';
       if (!this.editingInstance && !data.apiKey) this.instanceFormErrors.apiKey = 'API Key is required';
+      if (data.externalAuth && !this.editingInstance && !data.username) this.instanceFormErrors.username = 'Username is required when external authentication is enabled';
+      if (data.externalAuth && !this.editingInstance && !data.password) this.instanceFormErrors.password = 'Password is required when external authentication is enabled';
       if (Object.keys(this.instanceFormErrors).length > 0) return;
 
       let r;
       if (this.editingInstance) {
         if (!data.apiKey) data.apiKey = this.editingInstance.apiKey;
+        // password left blank → backend preserves existing (mirrors apiKey behaviour)
         r = await fetch(`/api/instances/${this.editingInstance.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
@@ -250,7 +256,7 @@ export default {
           r = await fetch('/api/test-connection', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ url: formData.url, apiKey: formData.apiKey })
+            body: JSON.stringify({ url: formData.url, apiKey: formData.apiKey, externalAuth: formData.externalAuth, username: formData.username, password: formData.password })
           });
         }
         const data = await r.json();

--- a/ui/static/partials/modals/instance.html
+++ b/ui/static/partials/modals/instance.html
@@ -32,6 +32,32 @@
         <div id="instance-apikey-error" class="field-error" x-show="instanceFormErrors.apiKey" x-text="instanceFormErrors.apiKey"></div>
         <div x-show="editingInstance && !instanceForm.apiKey" style="font-size:13px;color:var(--text-muted);margin-top:4px">API key is saved — leave empty to keep it, or enter a new one to replace it.</div>
       </div>
+      <div class="form-group">
+        <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+          <input type="checkbox" x-model="instanceForm.externalAuth">
+          Enable external authentication
+        </label>
+        <div style="font-size:13px;color:var(--text-muted);margin-top:4px">Use this if the instance is behind a reverse proxy or uses Basic authentication. The username and password are sent with every request (UI and API).</div>
+      </div>
+      <template x-if="instanceForm.externalAuth">
+        <div>
+          <div class="form-group">
+            <label>Username</label>
+            <input class="input" x-model="instanceForm.username" placeholder="Username" autocomplete="one-time-code"
+                   :aria-invalid="!!instanceFormErrors.username"
+                   :aria-describedby="instanceFormErrors.username ? 'instance-username-error' : null">
+            <div id="instance-username-error" class="field-error" x-show="instanceFormErrors.username" x-text="instanceFormErrors.username"></div>
+          </div>
+          <div class="form-group">
+            <label>Password</label>
+            <input class="input" x-model="instanceForm.password" :placeholder="editingInstance ? 'Leave empty to keep current password' : 'Password'" type="password" autocomplete="one-time-code"
+                   :aria-invalid="!!instanceFormErrors.password"
+                   :aria-describedby="instanceFormErrors.password ? 'instance-password-error' : null">
+            <div id="instance-password-error" class="field-error" x-show="instanceFormErrors.password" x-text="instanceFormErrors.password"></div>
+            <div x-show="editingInstance && !instanceForm.password" style="font-size:13px;color:var(--text-muted);margin-top:4px">Password is saved — leave empty to keep it, or enter a new one to replace it.</div>
+          </div>
+        </div>
+      </template>
       <!-- Test result -->
       <div x-show="modalTestResult !== null">
         <template x-if="modalTestResult === 'testing'">

--- a/ui/static/partials/sections/instance-edit-form.html
+++ b/ui/static/partials/sections/instance-edit-form.html
@@ -33,6 +33,37 @@
         <div x-show="editingInstance && !instanceForm.apiKey" style="font-size:13px;color:var(--text-muted);margin-top:4px">API key is saved — leave empty to keep it, or enter a new one to replace it.</div>
       </div>
     </div>
+    <div class="setting-row">
+      <div class="setting-label">External Auth</div>
+      <div class="setting-value">
+        <label style="display:flex;align-items:center;gap:8px;cursor:pointer">
+          <input type="checkbox" x-model="instanceForm.externalAuth">
+          Enable external authentication
+        </label>
+        <div style="font-size:13px;color:var(--text-muted);margin-top:4px">Use this if the instance is behind a reverse proxy or uses Basic authentication. The username and password are sent with every request (UI and API).</div>
+      </div>
+    </div>
+    <template x-if="instanceForm.externalAuth">
+      <div>
+        <div class="setting-row">
+          <div class="setting-label">Username</div>
+          <div class="setting-value">
+            <input class="input" style="width:260px" x-model="instanceForm.username" placeholder="Username" autocomplete="one-time-code"
+                   :aria-invalid="!!instanceFormErrors.username">
+            <div class="field-error" x-show="instanceFormErrors.username" x-text="instanceFormErrors.username"></div>
+          </div>
+        </div>
+        <div class="setting-row">
+          <div class="setting-label">Password</div>
+          <div class="setting-value">
+            <input class="input" style="width:260px" x-model="instanceForm.password" :placeholder="editingInstance ? 'Leave empty to keep current password' : 'Password'" type="password" autocomplete="one-time-code"
+                   :aria-invalid="!!instanceFormErrors.password">
+            <div class="field-error" x-show="instanceFormErrors.password" x-text="instanceFormErrors.password"></div>
+            <div x-show="editingInstance && !instanceForm.password" style="font-size:13px;color:var(--text-muted);margin-top:4px">Password is saved — leave empty to keep it, or enter a new one to replace it.</div>
+          </div>
+        </div>
+      </div>
+    </template>
     <!-- Test result -->
     <div x-show="modalTestResult !== null" style="margin-top:8px">
       <template x-if="modalTestResult === 'testing'">


### PR DESCRIPTION
## Summary

- Adds a per-instance **External Authentication** toggle (username + password) for Sonarr/Radarr instances that sit behind a reverse proxy or use the app's own Basic authentication mode
- When enabled, HTTP Basic Auth credentials are attached to **every** outbound request Clonarr makes to that instance (alongside the existing `X-Api-Key` header)
- Password is masked in API responses and preserved on update when left blank, matching the existing API key behaviour

## Changes

**Backend**
- `Instance` struct gains `ExternalAuth bool`, `Username string`, `Password string` fields (`omitempty` — no migration needed for existing configs)
- `ArrClient` gains `username`/`password`; `NewArrClient` accepts them; `DoRequest` calls `req.SetBasicAuth` when username is non-empty
- New `core.NewArrClientFor(inst, httpClient)` helper centralises the gating so Basic Auth is only sent when `ExternalAuth` is true; all ~40 call sites updated
- API handlers: mask `Password` in responses; preserve on update when blank/masked; require both username and a non-empty **resolved** password (i.e. after the keep-existing step) when `ExternalAuth` is enabled, on both the create and update paths
- `handleTestConnection` accepts `externalAuth`/`username`/`password` in the request body so credentials can be validated before saving

**Frontend**
- Modal and inline-edit form: external auth checkbox with explanatory text, and conditional username/password fields that mirror the "leave empty to keep" UX of the API key field