### PR TITLE
feat: Enhance drift detection and notifications for quality order and quality group changes

### DIFF
--- a/internal/api/alignment_test.go
+++ b/internal/api/alignment_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"clonarr/internal/arr"
+	"clonarr/internal/core"
+	"testing"
+)
+
+func TestBuildAlignment_MatchesAndGaps(t *testing.T) {
+	cKeys := []string{"Q1", "Q3", "Q4"}
+	gKeys := []string{"Q1", "Q2", "Q3", "Q5"}
+	
+	// Q1 matches
+	// Q2 is missing in current
+	// Q3 matches
+	// Q4 is missing in guide
+	// Q5 is missing in current
+	
+	cItemMap := map[string]arr.ArrQualityItem{
+		"Q1": {Name: "Q1"},
+		"Q3": {Name: "Q3"},
+		"Q4": {Name: "Q4"},
+	}
+	gItemMap := map[string]core.QualityItem{
+		"Q1": {Name: "Q1"},
+		"Q2": {Name: "Q2"},
+		"Q3": {Name: "Q3"},
+		"Q5": {Name: "Q5"},
+	}
+	
+	guideExpectedEnabled := map[string]bool{
+		"Q1": true, "Q2": true, "Q3": true, "Q4": true, "Q5": true,
+	}
+	
+	rows := BuildAlignment("radarr", cKeys, gKeys, true, guideExpectedEnabled, cItemMap, gItemMap)
+	
+	// We expect:
+	// Q1 <-> Q1 (Match: true)
+	// "" <-> Q2 (Match: false)
+	// Q3 <-> Q3 (Match: true)
+	// Q4 <-> "" (Match: false)
+	// "" <-> Q5 (Match: false)
+	
+	for i, r := range rows {
+		t.Logf("row %d: Current=%q, Guide=%q, Match=%v", i, r.Current, r.Guide, r.Match)
+	}
+	
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d", len(rows))
+	}
+	
+	if rows[0].Current != "Q1" || rows[0].Guide != "Q1" || !rows[0].Match { t.Errorf("row 0 mismatch") }
+	if rows[1].Current != "" || rows[1].Guide != "Q2" || rows[1].Match { t.Errorf("row 1 mismatch") }
+	if rows[2].Current != "Q3" || rows[2].Guide != "Q3" || !rows[2].Match { t.Errorf("row 2 mismatch") }
+	if rows[3].Current != "" || rows[3].Guide != "Q5" || rows[3].Match { t.Errorf("row 3 mismatch") }
+	if rows[4].Current != "Q4" || rows[4].Guide != "" || rows[4].Match { t.Errorf("row 4 mismatch") }
+}
+
+func TestBuildAlignment_DisabledSection(t *testing.T) {
+	cKeys := []string{"Q1", "Q2"}
+	gKeys := []string{"Q1"}
+	
+	cItemMap := map[string]arr.ArrQualityItem{"Q1": {Name: "Q1"}, "Q2": {Name: "Q2"}}
+	gItemMap := map[string]core.QualityItem{"Q1": {Name: "Q1"}}
+	
+	// Guide expects Q2 to be enabled, but it's in the disabled section
+	guideExpectedEnabled := map[string]bool{
+		"Q2": true,
+	}
+	
+	rows := BuildAlignment("radarr", cKeys, gKeys, false, guideExpectedEnabled, cItemMap, gItemMap)
+	
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	
+	// Q1 matches and is NOT expected enabled -> Match: true
+	if rows[0].Current != "Q1" || rows[0].Guide != "Q1" || !rows[0].Match {
+		t.Errorf("expected Q1 to be true Match")
+	}
+	
+	// Q2 is in disabled section but guide expects it enabled -> Match: false
+	if rows[1].Current != "Q2" || rows[1].Guide != "" || rows[1].Match {
+		t.Errorf("expected Q2 to be false Match, got %v", rows[1].Match)
+	}
+}

--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -1656,6 +1656,7 @@ type ProfileComparison struct {
 	// Profile settings and quality comparison
 	SettingsDiffs []SettingDiff     `json:"settingsDiffs,omitempty"`
 	QualityDiffs  []QualityItemDiff `json:"qualityDiffs,omitempty"`
+	QualityStructure *CompareQualityStructure `json:"qualityStructure,omitempty"`
 	// LEGACY (keep for now)
 	OptionalCategories []CompareCategory `json:"optionalCategories"` // optional CF groups categorized
 	Summary            ComparisonSummary `json:"summary"`
@@ -1672,6 +1673,27 @@ type ComparisonSummary struct {
 	QualityDiffs  int `json:"qualityDiffs"`  // quality items that differ
 }
 
+type CompareQualityStructureMember struct {
+	Name  string `json:"name"`
+	Match bool   `json:"match"`
+}
+
+type CompareQualityStructureRow struct {
+	Current        string                          `json:"current"`
+	Guide          string                          `json:"guide"`
+	Match          bool                            `json:"match"`
+	CurrentMembers []CompareQualityStructureMember `json:"currentMembers"`
+	GuideMembers   []CompareQualityStructureMember `json:"guideMembers"`
+}
+
+type CompareQualityStructure struct {
+	HasDrift      bool                         `json:"hasDrift"`
+	CurrentCutoff string                       `json:"currentCutoff"`
+	GuideCutoff   string                       `json:"guideCutoff"`
+	Rows          []CompareQualityStructureRow `json:"rows"`
+	DisabledRows  []CompareQualityStructureRow `json:"disabledRows"`
+}
+
 // SettingDiff describes a profile setting that differs between Arr and TRaSH.
 type SettingDiff struct {
 	Name    string `json:"name"`
@@ -1685,6 +1707,10 @@ type QualityItemDiff struct {
 	Name           string `json:"name"`
 	CurrentAllowed bool   `json:"currentAllowed"`
 	DesiredAllowed bool   `json:"desiredAllowed"`
+	CurrentGroup   string `json:"currentGroup,omitempty"`
+	DesiredGroup   string `json:"desiredGroup,omitempty"`
+	AllowedMatch   bool   `json:"allowedMatch"`
+	GroupMatch     bool   `json:"groupMatch"`
 	Match          bool   `json:"match"`
 }
 
@@ -2192,44 +2218,365 @@ func buildProfileComparison(inst core.Instance, ad *core.AppData, trashProfileID
 	addSetting("Cutoff", arrCutoffName, trashProfile.Cutoff)
 
 	// Compare quality items: TRaSH items vs Arr items
-	// Build Arr quality state: name → allowed
+	// Build Arr quality state: name → allowed, name → group
 	arrQuality := make(map[string]bool)
-	var collectArrQualities func(items []arr.ArrQualityItem)
-	collectArrQualities = func(items []arr.ArrQualityItem) {
+	arrGroup := make(map[string]string)
+	var collectArrQualities func(items []arr.ArrQualityItem, groupName string)
+	collectArrQualities = func(items []arr.ArrQualityItem, groupName string) {
 		for _, item := range items {
+			if len(item.Items) > 0 {
+				collectArrQualities(item.Items, item.Name)
+				name := item.Name
+				if name != "" {
+					arrQuality[strings.ToLower(name)] = item.Allowed
+					arrGroup[strings.ToLower(name)] = ""
+				}
+				continue
+			}
 			name := item.Name
 			if name == "" && item.Quality != nil {
 				name = item.Quality.Name
 			}
 			if name != "" {
 				arrQuality[strings.ToLower(name)] = item.Allowed
-			}
-			if len(item.Items) > 0 {
-				collectArrQualities(item.Items)
+				arrGroup[strings.ToLower(name)] = groupName
 			}
 		}
 	}
-	collectArrQualities(arrProfile.Items)
+	collectArrQualities(arrProfile.Items, "")
 
-	// Compare against TRaSH quality items
-	for _, tItem := range trashProfile.Items {
+	// Similar for TRaSH Profile to get desired groups
+	trashGroup := make(map[string]string)
+	for _, item := range trashProfile.Items {
+		if len(item.Items) > 0 {
+			for _, childStr := range item.Items {
+				if childStr != "" {
+					trashGroup[strings.ToLower(childStr)] = item.Name
+				}
+			}
+		}
+	}
+
+	var allTrashItems []core.QualityItem
+	for _, it := range trashProfile.Items {
+		allTrashItems = append(allTrashItems, it)
+		// For nested string items, they inherit the group's allowed state implicitly in TRaSH
+		for _, childStr := range it.Items {
+			if childStr != "" {
+				allTrashItems = append(allTrashItems, core.QualityItem{
+					Name:    childStr,
+					Allowed: it.Allowed,
+				})
+			}
+		}
+	}
+
+	// Compare against all flattened TRaSH quality items
+	for _, tItem := range allTrashItems {
 		name := tItem.Name
+		if name == "" {
+			continue
+		}
 		desiredAllowed := tItem.Allowed
 		currentAllowed, exists := arrQuality[strings.ToLower(name)]
 		if !exists {
-			// Quality item not found in Arr — skip (may be a group name that maps differently)
+			// Quality item not found in Arr — skip
 			continue
 		}
-		match := currentAllowed == desiredAllowed
+		
+		cGroup := arrGroup[strings.ToLower(name)]
+		dGroup := trashGroup[strings.ToLower(name)]
+		
+		allowedMatch := currentAllowed == desiredAllowed
+		groupMatch := cGroup == dGroup
+		match := allowedMatch && groupMatch
+		
 		comp.QualityDiffs = append(comp.QualityDiffs, QualityItemDiff{
 			Name:           name,
 			CurrentAllowed: currentAllowed,
 			DesiredAllowed: desiredAllowed,
+			CurrentGroup:   cGroup,
+			DesiredGroup:   dGroup,
+			AllowedMatch:   allowedMatch,
+			GroupMatch:     groupMatch,
 			Match:          match,
 		})
 		if !match {
 			comp.Summary.QualityDiffs++
 		}
+	}
+
+	// Compare ordering structure by using the fingerprint method
+	filtered := core.FilterArrItemsToDesired(arrProfile.Items, trashProfile.Items)
+	faCur := core.FingerprintArrItems(filtered, false)
+	faCurRev := core.FingerprintArrItems(filtered, true)
+	ftTgt := core.FingerprintTrashItems(trashProfile.Items)
+	
+	hasDrift := faCur != ftTgt && faCurRev != ftTgt
+	
+	cItemMap := make(map[string]arr.ArrQualityItem)
+	var currentKeys []string
+	var disabledKeys []string
+	for _, it := range filtered {
+		name := it.Name
+		if name == "" && it.Quality != nil {
+			name = it.Quality.Name
+		}
+		if name != "" {
+			cItemMap[name] = it
+			if it.Allowed {
+				currentKeys = append(currentKeys, name)
+			} else {
+				disabledKeys = append(disabledKeys, name)
+			}
+		}
+	}
+	// Sonarr's API always returns quality items worst-to-best. We reverse them
+	// here so the Compare tool presents them best-to-worst, visually aligning
+	// them with the TRaSH guide's best-to-worst format.
+	if inst.Type == "sonarr" {
+		for i, j := 0, len(currentKeys)-1; i < j; i, j = i+1, j-1 {
+			currentKeys[i], currentKeys[j] = currentKeys[j], currentKeys[i]
+		}
+		for i, j := 0, len(disabledKeys)-1; i < j; i, j = i+1, j-1 {
+			disabledKeys[i], disabledKeys[j] = disabledKeys[j], disabledKeys[i]
+		}
+	}
+	
+	gItemMap := make(map[string]core.QualityItem)
+	var guideKeys []string
+	var guideDisabledKeys []string
+	for _, it := range trashProfile.Items {
+		if it.Name != "" {
+			gItemMap[it.Name] = it
+			if it.Allowed {
+				guideKeys = append(guideKeys, it.Name)
+			} else {
+				guideDisabledKeys = append(guideDisabledKeys, it.Name)
+			}
+		}
+	}
+	
+	guideExpectedEnabled := make(map[string]bool)
+	for _, it := range trashProfile.Items {
+		if it.Allowed && it.Name != "" {
+			guideExpectedEnabled[it.Name] = true
+			for _, sub := range it.Items {
+				guideExpectedEnabled[sub] = true
+			}
+		}
+	}
+
+	buildAlignment := func(cKeys, gKeys []string, isEnabledSection bool) []CompareQualityStructureRow {
+		m := len(cKeys)
+		n := len(gKeys)
+		dp := make([][]int, m+1)
+		for i := range dp {
+			dp[i] = make([]int, n+1)
+		}
+
+		for i := 1; i <= m; i++ {
+			for j := 1; j <= n; j++ {
+				if cKeys[i-1] == gKeys[j-1] {
+					dp[i][j] = dp[i-1][j-1] + 1
+				} else {
+					if dp[i-1][j] > dp[i][j-1] {
+						dp[i][j] = dp[i-1][j]
+					} else {
+						dp[i][j] = dp[i][j-1]
+					}
+				}
+			}
+		}
+
+		var matches [][2]int
+		i, j := m, n
+		for i > 0 && j > 0 {
+			if cKeys[i-1] == gKeys[j-1] {
+				matches = append(matches, [2]int{i - 1, j - 1})
+				i--
+				j--
+			} else if dp[i-1][j] > dp[i][j-1] {
+				i--
+			} else {
+				j--
+			}
+		}
+		for left, right := 0, len(matches)-1; left < right; left, right = left+1, right-1 {
+			matches[left], matches[right] = matches[right], matches[left]
+		}
+
+		maxInt := func(a, b int) int {
+			if a > b {
+				return a
+			}
+			return b
+		}
+
+		var filteredMatches [][2]int
+		for k, mt := range matches {
+			prev := [2]int{-1, -1}
+			if len(filteredMatches) > 0 {
+				prev = filteredMatches[len(filteredMatches)-1]
+			}
+			next := [2]int{len(cKeys), len(gKeys)}
+			if k < len(matches)-1 {
+				next = matches[k+1]
+			}
+
+			isContiguousPrev := mt[0]-prev[0] == 1 && mt[1]-prev[1] == 1
+			isContiguousNext := next[0]-mt[0] == 1 && next[1]-mt[1] == 1
+
+			if isContiguousPrev || isContiguousNext {
+				filteredMatches = append(filteredMatches, mt)
+				continue
+			}
+
+			rowsWith := maxInt(mt[0]-prev[0]-1, mt[1]-prev[1]-1) + 1 + maxInt(next[0]-mt[0]-1, next[1]-mt[1]-1)
+			rowsWithout := maxInt(next[0]-prev[0]-1, next[1]-prev[1]-1)
+
+			if rowsWith < rowsWithout {
+				filteredMatches = append(filteredMatches, mt)
+			}
+		}
+
+		globalCSet := make(map[string]bool)
+		globalGSet := make(map[string]bool)
+		for _, k := range cKeys { globalCSet[k] = true }
+		for _, k := range gKeys { globalGSet[k] = true }
+
+		localRows := make([]CompareQualityStructureRow, 0)
+		
+		makeRow := func(c, g string, match bool) CompareQualityStructureRow {
+			cMembers := make([]CompareQualityStructureMember, 0)
+			gMembers := make([]CompareQualityStructureMember, 0)
+			
+			if !isEnabledSection {
+				// In disabled section, neutral (match=true) unless Guide expected it to be enabled (match=false -> red)
+				if c != "" && guideExpectedEnabled[c] {
+					match = false
+				} else if c != "" && !guideExpectedEnabled[c] {
+					match = true
+				}
+			}
+
+			if c != "" {
+				if cIt, ok := cItemMap[c]; ok {
+					gSet := make(map[string]bool)
+					if gIt, ok := gItemMap[c]; ok {
+						for _, sub := range gIt.Items {
+							gSet[sub] = true
+						}
+					}
+					for _, sub := range cIt.Items {
+						subName := sub.Name
+						if subName == "" && sub.Quality != nil {
+							subName = sub.Quality.Name
+						}
+						if subName != "" {
+							memMatch := gSet[subName]
+							if !isEnabledSection {
+								if guideExpectedEnabled[subName] {
+									memMatch = false
+								} else {
+									memMatch = true
+								}
+							} else {
+								if !guideExpectedEnabled[subName] {
+									memMatch = false
+								}
+							}
+							cMembers = append(cMembers, CompareQualityStructureMember{
+								Name: subName,
+								Match: memMatch,
+							})
+						}
+					}
+					if inst.Type == "sonarr" {
+						for i, j := 0, len(cMembers)-1; i < j; i, j = i+1, j-1 {
+							cMembers[i], cMembers[j] = cMembers[j], cMembers[i]
+						}
+					}
+				}
+			}
+			if g != "" {
+				if gIt, ok := gItemMap[g]; ok {
+					for _, sub := range gIt.Items {
+						gMembers = append(gMembers, CompareQualityStructureMember{
+							Name: sub,
+							Match: true,
+						})
+					}
+				}
+			}
+			return CompareQualityStructureRow{
+				Current: c, Guide: g, Match: match,
+				CurrentMembers: cMembers, GuideMembers: gMembers,
+			}
+		}
+		
+		processGap := func(cGap, gGap []string) {
+			var cPresent, gPresent []string
+			for _, k := range cGap {
+				if globalGSet[k] {
+					cPresent = append(cPresent, k)
+				}
+			}
+			for _, k := range gGap {
+				if globalCSet[k] {
+					gPresent = append(gPresent, k)
+				}
+			}
+			
+			cIdx, gIdx := 0, 0
+			cPresIdx, gPresIdx := 0, 0
+			
+			for cIdx < len(cGap) || gIdx < len(gGap) {
+				if gIdx < len(gGap) && !globalCSet[gGap[gIdx]] {
+					localRows = append(localRows, makeRow("", gGap[gIdx], false))
+					gIdx++
+					continue
+				}
+				if cIdx < len(cGap) && !globalGSet[cGap[cIdx]] {
+					localRows = append(localRows, makeRow(cGap[cIdx], "", false))
+					cIdx++
+					continue
+				}
+				
+				if cPresIdx < len(cPresent) || gPresIdx < len(gPresent) {
+					c := ""
+					g := ""
+					if cPresIdx < len(cPresent) { c = cPresent[cPresIdx]; cPresIdx++ }
+					if gPresIdx < len(gPresent) { g = gPresent[gPresIdx]; gPresIdx++ }
+					localRows = append(localRows, makeRow(c, g, c != "" && c == g))
+				}
+				
+				if cIdx < len(cGap) && globalGSet[cGap[cIdx]] { cIdx++ }
+				if gIdx < len(gGap) && globalCSet[gGap[gIdx]] { gIdx++ }
+			}
+		}
+
+		lastCur, lastGuide := 0, 0
+		for _, mt := range filteredMatches {
+			processGap(cKeys[lastCur:mt[0]], gKeys[lastGuide:mt[1]])
+			localRows = append(localRows, makeRow(cKeys[mt[0]], gKeys[mt[1]], true))
+			lastCur = mt[0] + 1
+			lastGuide = mt[1] + 1
+		}
+		processGap(cKeys[lastCur:], gKeys[lastGuide:])
+		
+		return localRows
+	}
+
+	rows := buildAlignment(currentKeys, guideKeys, true)
+	disabledRows := buildAlignment(disabledKeys, guideDisabledKeys, false)
+
+	comp.QualityStructure = &CompareQualityStructure{
+		HasDrift:      hasDrift,
+		CurrentCutoff: arrCutoffName,
+		GuideCutoff:   trashProfile.Cutoff,
+		Rows:          rows,
+		DisabledRows:  disabledRows,
 	}
 
 	return comp

--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -2368,204 +2368,7 @@ func buildProfileComparison(inst core.Instance, ad *core.AppData, trashProfileID
 	}
 
 	buildAlignment := func(cKeys, gKeys []string, isEnabledSection bool) []CompareQualityStructureRow {
-		m := len(cKeys)
-		n := len(gKeys)
-		dp := make([][]int, m+1)
-		for i := range dp {
-			dp[i] = make([]int, n+1)
-		}
-
-		for i := 1; i <= m; i++ {
-			for j := 1; j <= n; j++ {
-				if cKeys[i-1] == gKeys[j-1] {
-					dp[i][j] = dp[i-1][j-1] + 1
-				} else {
-					if dp[i-1][j] > dp[i][j-1] {
-						dp[i][j] = dp[i-1][j]
-					} else {
-						dp[i][j] = dp[i][j-1]
-					}
-				}
-			}
-		}
-
-		var matches [][2]int
-		i, j := m, n
-		for i > 0 && j > 0 {
-			if cKeys[i-1] == gKeys[j-1] {
-				matches = append(matches, [2]int{i - 1, j - 1})
-				i--
-				j--
-			} else if dp[i-1][j] > dp[i][j-1] {
-				i--
-			} else {
-				j--
-			}
-		}
-		for left, right := 0, len(matches)-1; left < right; left, right = left+1, right-1 {
-			matches[left], matches[right] = matches[right], matches[left]
-		}
-
-		maxInt := func(a, b int) int {
-			if a > b {
-				return a
-			}
-			return b
-		}
-
-		var filteredMatches [][2]int
-		for k, mt := range matches {
-			prev := [2]int{-1, -1}
-			if len(filteredMatches) > 0 {
-				prev = filteredMatches[len(filteredMatches)-1]
-			}
-			next := [2]int{len(cKeys), len(gKeys)}
-			if k < len(matches)-1 {
-				next = matches[k+1]
-			}
-
-			isContiguousPrev := mt[0]-prev[0] == 1 && mt[1]-prev[1] == 1
-			isContiguousNext := next[0]-mt[0] == 1 && next[1]-mt[1] == 1
-
-			if isContiguousPrev || isContiguousNext {
-				filteredMatches = append(filteredMatches, mt)
-				continue
-			}
-
-			rowsWith := maxInt(mt[0]-prev[0]-1, mt[1]-prev[1]-1) + 1 + maxInt(next[0]-mt[0]-1, next[1]-mt[1]-1)
-			rowsWithout := maxInt(next[0]-prev[0]-1, next[1]-prev[1]-1)
-
-			if rowsWith < rowsWithout {
-				filteredMatches = append(filteredMatches, mt)
-			}
-		}
-
-		globalCSet := make(map[string]bool)
-		globalGSet := make(map[string]bool)
-		for _, k := range cKeys { globalCSet[k] = true }
-		for _, k := range gKeys { globalGSet[k] = true }
-
-		localRows := make([]CompareQualityStructureRow, 0)
-		
-		makeRow := func(c, g string, match bool) CompareQualityStructureRow {
-			cMembers := make([]CompareQualityStructureMember, 0)
-			gMembers := make([]CompareQualityStructureMember, 0)
-			
-			if !isEnabledSection {
-				// In disabled section, neutral (match=true) unless Guide expected it to be enabled (match=false -> red)
-				if c != "" && guideExpectedEnabled[c] {
-					match = false
-				} else if c != "" && !guideExpectedEnabled[c] {
-					match = true
-				}
-			}
-
-			if c != "" {
-				if cIt, ok := cItemMap[c]; ok {
-					gSet := make(map[string]bool)
-					if gIt, ok := gItemMap[c]; ok {
-						for _, sub := range gIt.Items {
-							gSet[sub] = true
-						}
-					}
-					for _, sub := range cIt.Items {
-						subName := sub.Name
-						if subName == "" && sub.Quality != nil {
-							subName = sub.Quality.Name
-						}
-						if subName != "" {
-							memMatch := gSet[subName]
-							if !isEnabledSection {
-								if guideExpectedEnabled[subName] {
-									memMatch = false
-								} else {
-									memMatch = true
-								}
-							} else {
-								if !guideExpectedEnabled[subName] {
-									memMatch = false
-								}
-							}
-							cMembers = append(cMembers, CompareQualityStructureMember{
-								Name: subName,
-								Match: memMatch,
-							})
-						}
-					}
-					if inst.Type == "sonarr" {
-						for i, j := 0, len(cMembers)-1; i < j; i, j = i+1, j-1 {
-							cMembers[i], cMembers[j] = cMembers[j], cMembers[i]
-						}
-					}
-				}
-			}
-			if g != "" {
-				if gIt, ok := gItemMap[g]; ok {
-					for _, sub := range gIt.Items {
-						gMembers = append(gMembers, CompareQualityStructureMember{
-							Name: sub,
-							Match: true,
-						})
-					}
-				}
-			}
-			return CompareQualityStructureRow{
-				Current: c, Guide: g, Match: match,
-				CurrentMembers: cMembers, GuideMembers: gMembers,
-			}
-		}
-		
-		processGap := func(cGap, gGap []string) {
-			var cPresent, gPresent []string
-			for _, k := range cGap {
-				if globalGSet[k] {
-					cPresent = append(cPresent, k)
-				}
-			}
-			for _, k := range gGap {
-				if globalCSet[k] {
-					gPresent = append(gPresent, k)
-				}
-			}
-			
-			cIdx, gIdx := 0, 0
-			cPresIdx, gPresIdx := 0, 0
-			
-			for cIdx < len(cGap) || gIdx < len(gGap) {
-				if gIdx < len(gGap) && !globalCSet[gGap[gIdx]] {
-					localRows = append(localRows, makeRow("", gGap[gIdx], false))
-					gIdx++
-					continue
-				}
-				if cIdx < len(cGap) && !globalGSet[cGap[cIdx]] {
-					localRows = append(localRows, makeRow(cGap[cIdx], "", false))
-					cIdx++
-					continue
-				}
-				
-				if cPresIdx < len(cPresent) || gPresIdx < len(gPresent) {
-					c := ""
-					g := ""
-					if cPresIdx < len(cPresent) { c = cPresent[cPresIdx]; cPresIdx++ }
-					if gPresIdx < len(gPresent) { g = gPresent[gPresIdx]; gPresIdx++ }
-					localRows = append(localRows, makeRow(c, g, c != "" && c == g))
-				}
-				
-				if cIdx < len(cGap) && globalGSet[cGap[cIdx]] { cIdx++ }
-				if gIdx < len(gGap) && globalCSet[gGap[gIdx]] { gIdx++ }
-			}
-		}
-
-		lastCur, lastGuide := 0, 0
-		for _, mt := range filteredMatches {
-			processGap(cKeys[lastCur:mt[0]], gKeys[lastGuide:mt[1]])
-			localRows = append(localRows, makeRow(cKeys[mt[0]], gKeys[mt[1]], true))
-			lastCur = mt[0] + 1
-			lastGuide = mt[1] + 1
-		}
-		processGap(cKeys[lastCur:], gKeys[lastGuide:])
-		
-		return localRows
+		return BuildAlignment(inst.Type, cKeys, gKeys, isEnabledSection, guideExpectedEnabled, cItemMap, gItemMap)
 	}
 
 	rows := buildAlignment(currentKeys, guideKeys, true)
@@ -2923,4 +2726,205 @@ func (s *Server) handleTrashNaming(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, ad.Naming)
+}
+
+func BuildAlignment(instType string, cKeys, gKeys []string, isEnabledSection bool, guideExpectedEnabled map[string]bool, cItemMap map[string]arr.ArrQualityItem, gItemMap map[string]core.QualityItem) []CompareQualityStructureRow {
+	m := len(cKeys)
+	n := len(gKeys)
+	dp := make([][]int, m+1)
+	for i := range dp {
+		dp[i] = make([]int, n+1)
+	}
+
+	for i := 1; i <= m; i++ {
+		for j := 1; j <= n; j++ {
+			if cKeys[i-1] == gKeys[j-1] {
+				dp[i][j] = dp[i-1][j-1] + 1
+			} else {
+				if dp[i-1][j] > dp[i][j-1] {
+					dp[i][j] = dp[i-1][j]
+				} else {
+					dp[i][j] = dp[i][j-1]
+				}
+			}
+		}
+	}
+
+	var matches [][2]int
+	i, j := m, n
+	for i > 0 && j > 0 {
+		if cKeys[i-1] == gKeys[j-1] {
+			matches = append(matches, [2]int{i - 1, j - 1})
+			i--
+			j--
+		} else if dp[i-1][j] > dp[i][j-1] {
+			i--
+		} else {
+			j--
+		}
+	}
+	for left, right := 0, len(matches)-1; left < right; left, right = left+1, right-1 {
+		matches[left], matches[right] = matches[right], matches[left]
+	}
+
+	maxInt := func(a, b int) int {
+		if a > b {
+			return a
+		}
+		return b
+	}
+
+	var filteredMatches [][2]int
+	for k, mt := range matches {
+		prev := [2]int{-1, -1}
+		if len(filteredMatches) > 0 {
+			prev = filteredMatches[len(filteredMatches)-1]
+		}
+		next := [2]int{len(cKeys), len(gKeys)}
+		if k < len(matches)-1 {
+			next = matches[k+1]
+		}
+
+		isContiguousPrev := mt[0]-prev[0] == 1 && mt[1]-prev[1] == 1
+		isContiguousNext := next[0]-mt[0] == 1 && next[1]-mt[1] == 1
+
+		if isContiguousPrev || isContiguousNext {
+			filteredMatches = append(filteredMatches, mt)
+			continue
+		}
+
+		rowsWith := maxInt(mt[0]-prev[0]-1, mt[1]-prev[1]-1) + 1 + maxInt(next[0]-mt[0]-1, next[1]-mt[1]-1)
+		rowsWithout := maxInt(next[0]-prev[0]-1, next[1]-prev[1]-1)
+
+		if rowsWith < rowsWithout {
+			filteredMatches = append(filteredMatches, mt)
+		}
+	}
+
+	globalCSet := make(map[string]bool)
+	globalGSet := make(map[string]bool)
+	for _, k := range cKeys { globalCSet[k] = true }
+	for _, k := range gKeys { globalGSet[k] = true }
+
+	localRows := make([]CompareQualityStructureRow, 0)
+	
+	makeRow := func(c, g string, match bool) CompareQualityStructureRow {
+		cMembers := make([]CompareQualityStructureMember, 0)
+		gMembers := make([]CompareQualityStructureMember, 0)
+		
+		if !isEnabledSection {
+			// In disabled section, neutral (match=true) unless Guide expected it to be enabled (match=false -> red)
+			if c != "" && guideExpectedEnabled[c] {
+				match = false
+			} else if c != "" && !guideExpectedEnabled[c] {
+				match = true
+			}
+		}
+
+		if c != "" {
+			if cIt, ok := cItemMap[c]; ok {
+				gSet := make(map[string]bool)
+				if gIt, ok := gItemMap[c]; ok {
+					for _, sub := range gIt.Items {
+						gSet[sub] = true
+					}
+				}
+				for _, sub := range cIt.Items {
+					subName := sub.Name
+					if subName == "" && sub.Quality != nil {
+						subName = sub.Quality.Name
+					}
+					if subName != "" {
+						memMatch := gSet[subName]
+						if !isEnabledSection {
+							if guideExpectedEnabled[subName] {
+								memMatch = false
+							} else {
+								memMatch = true
+							}
+						} else {
+							if !guideExpectedEnabled[subName] {
+								memMatch = false
+							}
+						}
+						cMembers = append(cMembers, CompareQualityStructureMember{
+							Name: subName,
+							Match: memMatch,
+						})
+					}
+				}
+				if instType == "sonarr" {
+					for i, j := 0, len(cMembers)-1; i < j; i, j = i+1, j-1 {
+						cMembers[i], cMembers[j] = cMembers[j], cMembers[i]
+					}
+				}
+			}
+		}
+		if g != "" {
+			if gIt, ok := gItemMap[g]; ok {
+				for _, sub := range gIt.Items {
+					gMembers = append(gMembers, CompareQualityStructureMember{
+						Name: sub,
+						Match: true,
+					})
+				}
+			}
+		}
+		return CompareQualityStructureRow{
+			Current: c, Guide: g, Match: match,
+			CurrentMembers: cMembers, GuideMembers: gMembers,
+		}
+	}
+	
+	processGap := func(cGap, gGap []string) {
+		var cPresent, gPresent []string
+		for _, k := range cGap {
+			if globalGSet[k] {
+				cPresent = append(cPresent, k)
+			}
+		}
+		for _, k := range gGap {
+			if globalCSet[k] {
+				gPresent = append(gPresent, k)
+			}
+		}
+		
+		cIdx, gIdx := 0, 0
+		cPresIdx, gPresIdx := 0, 0
+		
+		for cIdx < len(cGap) || gIdx < len(gGap) {
+			if gIdx < len(gGap) && !globalCSet[gGap[gIdx]] {
+				localRows = append(localRows, makeRow("", gGap[gIdx], false))
+				gIdx++
+				continue
+			}
+			if cIdx < len(cGap) && !globalGSet[cGap[cIdx]] {
+				localRows = append(localRows, makeRow(cGap[cIdx], "", false))
+				cIdx++
+				continue
+			}
+			
+			if cPresIdx < len(cPresent) || gPresIdx < len(gPresent) {
+				c := ""
+				g := ""
+				if cPresIdx < len(cPresent) { c = cPresent[cPresIdx]; cPresIdx++ }
+				if gPresIdx < len(gPresent) { g = gPresent[gPresIdx]; gPresIdx++ }
+				localRows = append(localRows, makeRow(c, g, c != "" && c == g))
+			}
+			
+			if cIdx < len(cGap) && globalGSet[cGap[cIdx]] { cIdx++ }
+			if gIdx < len(gGap) && globalCSet[gGap[gIdx]] { gIdx++ }
+		}
+	}
+
+	lastCur, lastGuide := 0, 0
+	for _, mt := range filteredMatches {
+		processGap(cKeys[lastCur:mt[0]], gKeys[lastGuide:mt[1]])
+		localRows = append(localRows, makeRow(cKeys[mt[0]], gKeys[mt[1]], true))
+		lastCur = mt[0] + 1
+		lastGuide = mt[1] + 1
+	}
+	processGap(cKeys[lastCur:], gKeys[lastGuide:])
+	
+	return localRows
 }

--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -771,13 +771,19 @@ func driftDetailToPendingChange(d DriftDetail, when string) PendingChange {
 			AffectedID:   d.CFName, // CF name is the stable identifier for drift since trash_id may be unknown
 			AffectedName: d.CFName,
 		}
-	case "quality":
+	case "quality", "group", "quality_order":
+		name := d.CFName
+		if d.Field == "group" {
+			name += fmt.Sprintf(" (Group changed from %v to %v)", d.Current, d.Target)
+		} else if d.Field == "quality_order" {
+			name = "Ordering changed"
+		}
 		return PendingChange{
 			Source:       "drift",
 			DetectedAt:   when,
 			ChangeType:   "qs-modified",
 			AffectedID:   "quality:" + d.CFName,
-			AffectedName: d.CFName,
+			AffectedName: name,
 		}
 	default:
 		return PendingChange{
@@ -985,6 +991,8 @@ func diffArrProfile(current, target *arr.ArrQualityProfile, cfs []arr.ArrCF, rul
 	// changes that don't flip any allowed flag are a no-op for the user.
 	curAllowed := flattenAllowed(current.Items)
 	tgtAllowed := flattenAllowed(target.Items)
+	curGroups := flattenGroups(current.Items)
+	tgtGroups := flattenGroups(target.Items)
 	seen := make(map[string]bool, len(curAllowed)+len(tgtAllowed))
 	for name, ca := range curAllowed {
 		seen[name] = true
@@ -997,6 +1005,18 @@ func diffArrProfile(current, target *arr.ArrQualityProfile, cfs []arr.ArrCF, rul
 		}
 		if ca != ta {
 			out = append(out, DriftDetail{Field: "quality", CFName: name, Current: ca, Target: ta})
+		} else {
+			cg := curGroups[name]
+			tg := tgtGroups[name]
+			if cg != tg {
+				if cg == "" {
+					cg = "Ungrouped"
+				}
+				if tg == "" {
+					tg = "Ungrouped"
+				}
+				out = append(out, DriftDetail{Field: "group", CFName: name, Current: cg, Target: tg})
+			}
 		}
 	}
 	for name, ta := range tgtAllowed {
@@ -1004,6 +1024,22 @@ func diffArrProfile(current, target *arr.ArrQualityProfile, cfs []arr.ArrCF, rul
 			continue
 		}
 		out = append(out, DriftDetail{Field: "quality", CFName: name, Current: false, Target: ta})
+	}
+	faCur := FingerprintArrItems(current.Items, false)
+	faCurRev := FingerprintArrItems(current.Items, true)
+	faTgt := FingerprintArrItems(target.Items, false)
+
+	if faCur != faTgt && faCurRev != faTgt {
+		orderOnly := true
+		for _, d := range out {
+			if d.Field == "quality" || d.Field == "group" {
+				orderOnly = false
+				break
+			}
+		}
+		if orderOnly {
+			out = append(out, DriftDetail{Field: "quality_order", CFName: "structure", Current: "Drifted", Target: "Original"})
+		}
 	}
 
 	return out
@@ -1042,6 +1078,41 @@ func languageName(l *arr.ArrLanguage) string {
 		return l.Name
 	}
 	return fmt.Sprintf("id=%d", l.ID)
+}
+
+// flattenGroups extracts a flat mapping of quality-name → group-name from the
+// items tree, allowing drift detection for group changes that leave allowed state intact.
+func flattenGroups(items []arr.ArrQualityItem) map[string]string {
+	out := make(map[string]string)
+	for _, it := range items {
+		if len(it.Items) > 0 {
+			groupName := it.Name
+			for _, m := range it.Items {
+				name := ""
+				if m.Quality != nil {
+					name = m.Quality.Name
+				} else if m.Name != "" {
+					name = m.Name
+				}
+				if name == "" {
+					continue
+				}
+				out[name] = groupName
+			}
+			continue
+		}
+		name := ""
+		if it.Quality != nil {
+			name = it.Quality.Name
+		} else if it.Name != "" {
+			name = it.Name
+		}
+		if name == "" {
+			continue
+		}
+		out[name] = ""
+	}
+	return out
 }
 
 // flattenAllowed reduces an items tree to a flat quality-name → allowed
@@ -1092,7 +1163,7 @@ func summariseDrift(details []DriftDetail) []string {
 		switch d.Field {
 		case "score":
 			scoreCount++
-		case "quality":
+		case "quality", "group":
 			qualityCount++
 		default:
 			settingsCount++

--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -774,7 +774,7 @@ func driftDetailToPendingChange(d DriftDetail, when string) PendingChange {
 	case "quality", "group", "quality_order":
 		name := d.CFName
 		if d.Field == "group" {
-			name += fmt.Sprintf(" (Group changed from %v to %v)", d.Current, d.Target)
+			name += fmt.Sprintf(" (Group changed from %v to %v)", d.Target, d.Current)
 		} else if d.Field == "quality_order" {
 			name = "Ordering changed"
 		}
@@ -1163,7 +1163,7 @@ func summariseDrift(details []DriftDetail) []string {
 		switch d.Field {
 		case "score":
 			scoreCount++
-		case "quality", "group":
+		case "quality", "group", "quality_order":
 			qualityCount++
 		default:
 			settingsCount++

--- a/internal/core/drift.go
+++ b/internal/core/drift.go
@@ -1030,19 +1030,82 @@ func diffArrProfile(current, target *arr.ArrQualityProfile, cfs []arr.ArrCF, rul
 	faTgt := FingerprintArrItems(target.Items, false)
 
 	if faCur != faTgt && faCurRev != faTgt {
-		orderOnly := true
-		for _, d := range out {
-			if d.Field == "quality" || d.Field == "group" {
-				orderOnly = false
-				break
-			}
-		}
-		if orderOnly {
+		// Fingerprint mismatched, meaning there is some structural drift (group, allowed state, or order).
+		// We only want to report quality_order if the actual linear sequence of enabled items changed.
+		driftedGroups := getGroupDriftQualities(current.Items, target.Items)
+		orderCur := getEnabledOrder(current.Items, false, driftedGroups)
+		orderCurRev := getEnabledOrder(current.Items, true, driftedGroups)
+		orderTgt := getEnabledOrder(target.Items, false, driftedGroups)
+		
+		if orderCur != orderTgt && orderCurRev != orderTgt {
 			out = append(out, DriftDetail{Field: "quality_order", CFName: "structure", Current: "Drifted", Target: "Original"})
 		}
 	}
 
 	return out
+}
+
+func getGroupMapping(items []arr.ArrQualityItem) map[string]string {
+	mapping := make(map[string]string)
+	for _, it := range items {
+		if !it.Allowed {
+			continue
+		}
+		if len(it.Items) > 0 || (it.Name != "" && it.Quality == nil) {
+			for _, child := range it.Items {
+				mapping[arrItemName(child)] = it.Name
+			}
+		} else {
+			mapping[arrItemName(it)] = ""
+		}
+	}
+	return mapping
+}
+
+func getGroupDriftQualities(cur, tgt []arr.ArrQualityItem) map[string]bool {
+	mapCur := getGroupMapping(cur)
+	mapTgt := getGroupMapping(tgt)
+	drifted := make(map[string]bool)
+	for q, cGrp := range mapCur {
+		if tGrp, ok := mapTgt[q]; ok && cGrp != tGrp {
+			drifted[q] = true
+		}
+	}
+	return drifted
+}
+
+func getEnabledOrder(items []arr.ArrQualityItem, reverseEnabled bool, exclude map[string]bool) string {
+	var seq []string
+	
+	processItem := func(it arr.ArrQualityItem) {
+		if !it.Allowed {
+			return
+		}
+		if len(it.Items) > 0 || (it.Name != "" && it.Quality == nil) {
+			for _, child := range it.Items {
+				name := arrItemName(child)
+				if !exclude[name] {
+					seq = append(seq, name)
+				}
+			}
+		} else {
+			name := arrItemName(it)
+			if !exclude[name] {
+				seq = append(seq, name)
+			}
+		}
+	}
+
+	if reverseEnabled {
+		for i := len(items) - 1; i >= 0; i-- {
+			processItem(items[i])
+		}
+	} else {
+		for i := 0; i < len(items); i++ {
+			processItem(items[i])
+		}
+	}
+	return strings.Join(seq, ",")
 }
 
 // qualityIDName resolves a quality-or-group ID to its display name by

--- a/internal/core/drift_notifications.go
+++ b/internal/core/drift_notifications.go
@@ -216,6 +216,8 @@ func formatDriftDetail(d DriftDetail) string {
 		return fmt.Sprintf("%s score: %v → %v", d.CFName, d.Current, d.Target)
 	case "quality":
 		return fmt.Sprintf("Quality %s allowed: %v → %v", d.CFName, d.Current, d.Target)
+	case "group":
+		return fmt.Sprintf("Quality %s group: %v → %v", d.CFName, d.Current, d.Target)
 	case "upgradeAllowed":
 		return fmt.Sprintf("Upgrade allowed: %v → %v", d.Current, d.Target)
 	case "cutoff":

--- a/internal/core/drift_structure_test.go
+++ b/internal/core/drift_structure_test.go
@@ -1,0 +1,74 @@
+package core
+
+import (
+	"clonarr/internal/arr"
+	"testing"
+)
+
+func TestFlattenGroups(t *testing.T) {
+	items := []arr.ArrQualityItem{
+		arrQ(1, "Flat1", true),
+		arrG(100, "Group1", true, 
+			arrQ(2, "Member1", true),
+			arrQ(3, "Member2", true),
+		),
+		arrQ(4, "Flat2", false),
+	}
+	
+	groups := flattenGroups(items)
+	
+	if groups["Flat1"] != "" { t.Errorf("expected Flat1 to have no group, got %q", groups["Flat1"]) }
+	if groups["Flat2"] != "" { t.Errorf("expected Flat2 to have no group, got %q", groups["Flat2"]) }
+	if groups["Member1"] != "Group1" { t.Errorf("expected Member1 to be in Group1, got %q", groups["Member1"]) }
+	if groups["Member2"] != "Group1" { t.Errorf("expected Member2 to be in Group1, got %q", groups["Member2"]) }
+}
+
+func TestDiffArrProfile_StructureChanges(t *testing.T) {
+	current := &arr.ArrQualityProfile{
+		Items: []arr.ArrQualityItem{
+			{Name: "A", Allowed: true},
+			{Name: "B", Allowed: true},
+			{Name: "Group", Allowed: true, Items: []arr.ArrQualityItem{{Name: "C", Allowed: true}}},
+		},
+	}
+	// Target has C ungrouped, and B and A swapped
+	target := &arr.ArrQualityProfile{
+		Items: []arr.ArrQualityItem{
+			{Name: "B", Allowed: true},
+			{Name: "A", Allowed: true},
+			{Name: "C", Allowed: true},
+		},
+	}
+	// diffArrProfile(current, target, cfs, rule, priorAvailableGroups, scoreOverrides, extras, ad)
+	details := diffArrProfile(current, target, nil, &AutoSyncRule{}, map[string]bool{}, map[string]int{}, nil, nil)
+	
+	groupDriftFound := false
+	orderDriftFound := false
+	
+	for _, d := range details {
+		if d.Field == "group" && d.CFName == "C" && d.Current == "Group" && d.Target == "Ungrouped" {
+			groupDriftFound = true
+		}
+	}
+	
+	if !groupDriftFound { t.Error("expected group drift for C") }
+	
+	// Target2 has only order changes
+	target2 := &arr.ArrQualityProfile{
+		Items: []arr.ArrQualityItem{
+			{Name: "B", Allowed: true},
+			{Name: "A", Allowed: true},
+			{Name: "Group", Allowed: true, Items: []arr.ArrQualityItem{{Name: "C", Allowed: true}}},
+		},
+	}
+	
+	details2 := diffArrProfile(current, target2, nil, &AutoSyncRule{}, map[string]bool{}, map[string]int{}, nil, nil)
+	
+	for _, d := range details2 {
+		if d.Field == "quality_order" && d.CFName == "structure" {
+			orderDriftFound = true
+		}
+	}
+	
+	if !orderDriftFound { t.Error("expected order drift") }
+}

--- a/internal/core/drift_structure_test.go
+++ b/internal/core/drift_structure_test.go
@@ -53,22 +53,30 @@ func TestDiffArrProfile_StructureChanges(t *testing.T) {
 	
 	if !groupDriftFound { t.Error("expected group drift for C") }
 	
-	// Target2 has only order changes
+	// Target2 has order AND group changes (B and A swapped, C inside Group instead of Ungrouped)
 	target2 := &arr.ArrQualityProfile{
 		Items: []arr.ArrQualityItem{
 			{Name: "B", Allowed: true},
 			{Name: "A", Allowed: true},
-			{Name: "Group", Allowed: true, Items: []arr.ArrQualityItem{{Name: "C", Allowed: true}}},
+			{Name: "Group", Allowed: true, Items: []arr.ArrQualityItem{}},
+			{Name: "C", Allowed: true},
 		},
 	}
 	
 	details2 := diffArrProfile(current, target2, nil, &AutoSyncRule{}, map[string]bool{}, map[string]int{}, nil, nil)
 	
+	groupDriftFound = false
+	orderDriftFound = false
+	t.Logf("details2: %+v", details2)
 	for _, d := range details2 {
+		if d.Field == "group" && d.CFName == "C" && d.Current == "Group" && d.Target == "Ungrouped" {
+			groupDriftFound = true
+		}
 		if d.Field == "quality_order" && d.CFName == "structure" {
 			orderDriftFound = true
 		}
 	}
 	
-	if !orderDriftFound { t.Error("expected order drift") }
+	if !groupDriftFound { t.Error("expected group drift for C in Target2") }
+	if !orderDriftFound { t.Error("expected order drift in Target2") }
 }

--- a/internal/core/sync.go
+++ b/internal/core/sync.go
@@ -636,8 +636,11 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 			desiredItems = req.QualityStructure
 		}
 		if len(desiredItems) > 0 {
-			filtered := filterArrItemsToDesired(targetProfile.Items, desiredItems)
-			if fingerprintTrashItems(desiredItems) != fingerprintArrItems(filtered) {
+			filtered := FilterArrItemsToDesired(targetProfile.Items, desiredItems)
+			ft := FingerprintTrashItems(desiredItems)
+			fa := FingerprintArrItems(filtered, false)
+			faRev := FingerprintArrItems(filtered, true)
+			if ft != fa && ft != faRev {
 				plan.Summary.QualityChanged = true
 			}
 		}
@@ -756,8 +759,9 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 			// for nested items even though the comparison table shows them
 			// (handleCompareProfile recurses, this loop must too).
 			oldAllowed := make(map[string]bool)
-			var collectOldAllowed func(items []arr.ArrQualityItem)
-			collectOldAllowed = func(items []arr.ArrQualityItem) {
+			oldGroups := make(map[string]string)
+			var collectOldAllowed func(items []arr.ArrQualityItem, groupName string)
+			collectOldAllowed = func(items []arr.ArrQualityItem, groupName string) {
 				for _, item := range items {
 					name := item.Name
 					if name == "" && item.Quality != nil {
@@ -765,13 +769,16 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 					}
 					if name != "" {
 						oldAllowed[name] = item.Allowed
+						if len(item.Items) == 0 {
+							oldGroups[name] = groupName
+						}
 					}
 					if len(item.Items) > 0 {
-						collectOldAllowed(item.Items)
+						collectOldAllowed(item.Items, name)
 					}
 				}
 			}
-			collectOldAllowed(targetProfile.Items)
+			collectOldAllowed(targetProfile.Items, "")
 			// Resolve desired quality items to get Allowed state
 			qualityDefs, err := client.ListQualityDefinitions()
 			if err == nil {
@@ -793,27 +800,53 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 							}
 						}
 					}
-					for _, item := range newItems {
-						name := item.Name
-						if name == "" && item.Quality != nil {
-							name = item.Quality.Name
-						}
-						if name == "" {
-							continue
-						}
-						oldState, exists := oldAllowed[name]
-						if exists && oldState != item.Allowed {
-							suffix := ""
-							if _, isOverride := req.QualityOverrides[name]; isOverride {
-								suffix = " (override)"
+					var collectNewState func(items []arr.ArrQualityItem, groupName string)
+					collectNewState = func(items []arr.ArrQualityItem, groupName string) {
+						for _, item := range items {
+							name := item.Name
+							if name == "" && item.Quality != nil {
+								name = item.Quality.Name
 							}
-							if item.Allowed {
-								plan.QualityPreview = append(plan.QualityPreview, name+": Disabled → Enabled"+suffix)
-							} else {
-								plan.QualityPreview = append(plan.QualityPreview, name+": Enabled → Disabled"+suffix)
+							if name == "" {
+								continue
+							}
+							
+							oldState, exists := oldAllowed[name]
+							if exists && oldState != item.Allowed {
+								suffix := ""
+								if _, isOverride := req.QualityOverrides[name]; isOverride {
+									suffix = " (override)"
+								}
+								if item.Allowed {
+									plan.QualityPreview = append(plan.QualityPreview, name+": Disabled → Enabled"+suffix)
+								} else {
+									plan.QualityPreview = append(plan.QualityPreview, name+": Enabled → Disabled"+suffix)
+								}
+							}
+							
+							if len(item.Items) == 0 {
+								oldGrp, grpExists := oldGroups[name]
+								if grpExists || oldGrp != "" || groupName != "" {
+									if oldGrp != groupName {
+										from := oldGrp
+										if from == "" {
+											from = "ungrouped"
+										}
+										to := groupName
+										if to == "" {
+											to = "ungrouped"
+										}
+										plan.QualityPreview = append(plan.QualityPreview, name+": Group changed from "+from+" to "+to)
+									}
+								}
+							}
+							
+							if len(item.Items) > 0 {
+								collectNewState(item.Items, name)
 							}
 						}
 					}
+					collectNewState(newItems, "")
 				}
 			}
 			// Also handle legacy flat overrides when quality rebuild was skipped
@@ -827,6 +860,10 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 						}
 					}
 				}
+			}
+			
+			if plan.Summary.QualityChanged && len(plan.QualityPreview) == 0 {
+				plan.QualityPreview = append(plan.QualityPreview, "Ordering changed (will be restored to profile configuration)")
 			}
 		}
 	} else {
@@ -1275,7 +1312,7 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 		}
 		var prevItemsFingerprint string
 		if len(desiredItemsSnapshot) > 0 {
-			prevItemsFingerprint = fingerprintArrItems(filterArrItemsToDesired(targetProfile.Items, desiredItemsSnapshot))
+			prevItemsFingerprint = FingerprintArrItems(FilterArrItemsToDesired(targetProfile.Items, desiredItemsSnapshot), false)
 		}
 		prevCutoffName := cutoffIDToName(targetProfile.Cutoff, targetProfile.Items)
 
@@ -1512,8 +1549,9 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 				// must record the same change in QualityDetails or the
 				// sync-history rendering diverges from what the user saw.
 				oldAllowed := make(map[string]bool)
-				var collectOldAllowed func(items []arr.ArrQualityItem)
-				collectOldAllowed = func(items []arr.ArrQualityItem) {
+				oldGroups := make(map[string]string)
+				var collectOldAllowed func(items []arr.ArrQualityItem, groupName string)
+				collectOldAllowed = func(items []arr.ArrQualityItem, groupName string) {
 					for _, item := range items {
 						name := item.Name
 						if name == "" && item.Quality != nil {
@@ -1521,13 +1559,16 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 						}
 						if name != "" {
 							oldAllowed[name] = item.Allowed
+							if len(item.Items) == 0 {
+								oldGroups[name] = groupName
+							}
 						}
 						if len(item.Items) > 0 {
-							collectOldAllowed(item.Items)
+							collectOldAllowed(item.Items, name)
 						}
 					}
 				}
-				collectOldAllowed(targetProfile.Items)
+				collectOldAllowed(targetProfile.Items, "")
 
 				// Source: structure override trumps TRaSH items.
 				itemsSource := profile.Items
@@ -1555,27 +1596,53 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 					}
 
 					// Track quality changes (comparing Arr state vs desired final state)
-					for _, item := range newItems {
-						name := item.Name
-						if name == "" && item.Quality != nil {
-							name = item.Quality.Name
-						}
-						if name == "" {
-							continue
-						}
-						oldState, exists := oldAllowed[name]
-						if exists && oldState != item.Allowed {
-							suffix := ""
-							if _, isOverride := req.QualityOverrides[name]; isOverride {
-								suffix = " (override)"
+					var collectNewState func(items []arr.ArrQualityItem, groupName string)
+					collectNewState = func(items []arr.ArrQualityItem, groupName string) {
+						for _, item := range items {
+							name := item.Name
+							if name == "" && item.Quality != nil {
+								name = item.Quality.Name
 							}
-							if item.Allowed {
-								result.QualityDetails = append(result.QualityDetails, name+": Disabled → Enabled"+suffix)
-							} else {
-								result.QualityDetails = append(result.QualityDetails, name+": Enabled → Disabled"+suffix)
+							if name == "" {
+								continue
+							}
+							
+							oldState, exists := oldAllowed[name]
+							if exists && oldState != item.Allowed {
+								suffix := ""
+								if _, isOverride := req.QualityOverrides[name]; isOverride {
+									suffix = " (override)"
+								}
+								if item.Allowed {
+									result.QualityDetails = append(result.QualityDetails, name+": Disabled → Enabled"+suffix)
+								} else {
+									result.QualityDetails = append(result.QualityDetails, name+": Enabled → Disabled"+suffix)
+								}
+							}
+							
+							if len(item.Items) == 0 {
+								oldGrp, grpExists := oldGroups[name]
+								if grpExists || oldGrp != "" || groupName != "" {
+									if oldGrp != groupName {
+										from := oldGrp
+										if from == "" {
+											from = "ungrouped"
+										}
+										to := groupName
+										if to == "" {
+											to = "ungrouped"
+										}
+										result.QualityDetails = append(result.QualityDetails, name+": Group changed from "+from+" to "+to)
+									}
+								}
+							}
+							
+							if len(item.Items) > 0 {
+								collectNewState(item.Items, name)
 							}
 						}
 					}
+					collectNewState(newItems, "")
 					usedQualities := make(map[int]bool)
 					collectUsedQualities(newItems, usedQualities)
 					unused := make([]arr.ArrQualityItem, 0)
@@ -1696,9 +1763,9 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 		// extract-from-group. Both snapshots are filtered to the TRaSH-managed
 		// subset so Radarr's unused-tail ordering can't produce false positives.
 		if len(desiredItemsSnapshot) > 0 {
-			postFP := fingerprintArrItems(filterArrItemsToDesired(targetProfile.Items, desiredItemsSnapshot))
+			postFP := FingerprintArrItems(FilterArrItemsToDesired(targetProfile.Items, desiredItemsSnapshot), false)
 			if postFP != prevItemsFingerprint && !result.QualityUpdated {
-				result.QualityDetails = append(result.QualityDetails, "Quality structure: restored")
+				result.QualityDetails = append(result.QualityDetails, "Ordering changed (will be restored to profile configuration)")
 				result.QualityUpdated = true
 				updated = true
 			}
@@ -2270,6 +2337,7 @@ func fpGroup(name string, allowed bool, members []string) string {
 	for i, m := range members {
 		quoted[i] = strconv.Quote(m)
 	}
+	sort.Strings(quoted)
 	return "G:" + strconv.Quote(name) + "=" + strconv.FormatBool(allowed) + "[" + strings.Join(quoted, ",") + "]"
 }
 
@@ -2277,42 +2345,62 @@ func fpGroup(name string, allowed bool, members []string) string {
 // Arr quality-item tree capturing ordering, group structure, and allowed state.
 // This is what lets the sync detect drift the set-based diff misses: reorders,
 // regroups, and moving a quality in/out of a group with the same allowed state.
-func fingerprintArrItems(items []arr.ArrQualityItem) string {
-	parts := make([]string, 0, len(items))
+func FingerprintArrItems(items []arr.ArrQualityItem, reverseEnabled bool) string {
+	var enabledParts []string
+	var disabledParts []string
 	for _, it := range items {
+		part := ""
 		if len(it.Items) > 0 || (it.Name != "" && it.Quality == nil) {
 			members := make([]string, 0, len(it.Items))
 			for _, sub := range it.Items {
 				members = append(members, arrItemName(sub))
 			}
-			parts = append(parts, fpGroup(it.Name, it.Allowed, members))
+			part = fpGroup(it.Name, it.Allowed, members)
 		} else {
-			parts = append(parts, fpQuality(arrItemName(it), it.Allowed))
+			part = fpQuality(arrItemName(it), it.Allowed)
+		}
+		if it.Allowed {
+			enabledParts = append(enabledParts, part)
+		} else {
+			disabledParts = append(disabledParts, part)
 		}
 	}
-	return strings.Join(parts, "|")
+	if reverseEnabled {
+		for i, j := 0, len(enabledParts)-1; i < j; i, j = i+1, j-1 {
+			enabledParts[i], enabledParts[j] = enabledParts[j], enabledParts[i]
+		}
+	}
+	sort.Strings(disabledParts)
+	return strings.Join(append(enabledParts, disabledParts...), "|")
 }
 
 // fingerprintTrashItems produces the same canonical format as fingerprintArrItems
 // but from a TRaSH-shaped []QualityItem. This lets the plan phase compare desired
-// (TRaSH) against current (Arr) without building an intermediate tree.
-func fingerprintTrashItems(items []QualityItem) string {
-	parts := make([]string, 0, len(items))
+func FingerprintTrashItems(items []QualityItem) string {
+	var enabledParts []string
+	var disabledParts []string
 	for _, it := range items {
+		part := ""
 		if len(it.Items) > 0 {
-			parts = append(parts, fpGroup(it.Name, it.Allowed, it.Items))
+			part = fpGroup(it.Name, it.Allowed, it.Items)
 		} else {
-			parts = append(parts, fpQuality(it.Name, it.Allowed))
+			part = fpQuality(it.Name, it.Allowed)
+		}
+		if it.Allowed {
+			enabledParts = append(enabledParts, part)
+		} else {
+			disabledParts = append(disabledParts, part)
 		}
 	}
-	return strings.Join(parts, "|")
+	sort.Strings(disabledParts)
+	return strings.Join(append(enabledParts, disabledParts...), "|")
 }
 
 // filterArrItemsToDesired returns the subset of Arr items that TRaSH manages:
 // groups (always kept — a stale group surfaces as drift), plus flat qualities
 // whose name appears in the desired set. Drops the "unused" tail so fingerprint
 // comparisons are insensitive to Radarr's API response ordering of unused items.
-func filterArrItemsToDesired(arrItems []arr.ArrQualityItem, desired []QualityItem) []arr.ArrQualityItem {
+func FilterArrItemsToDesired(arrItems []arr.ArrQualityItem, desired []QualityItem) []arr.ArrQualityItem {
 	desiredNames := make(map[string]bool, len(desired)*2)
 	for _, it := range desired {
 		if it.Name != "" {

--- a/internal/core/sync.go
+++ b/internal/core/sync.go
@@ -847,6 +847,16 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 						}
 					}
 					collectNewState(newItems, "")
+					if plan.Summary.QualityChanged {
+						filtered := FilterArrItemsToDesired(targetProfile.Items, desiredItems)
+						drifted := getGroupDriftQualities(filtered, newItems)
+						orderCur := getEnabledOrder(filtered, false, drifted)
+						orderCurRev := getEnabledOrder(filtered, true, drifted)
+						orderTgt := getEnabledOrder(newItems, false, drifted)
+						if orderCur != orderTgt && orderCurRev != orderTgt {
+							plan.QualityPreview = append(plan.QualityPreview, "Ordering changed (will be restored to profile configuration)")
+						}
+					}
 				}
 			}
 			// Also handle legacy flat overrides when quality rebuild was skipped
@@ -860,10 +870,6 @@ func BuildSyncPlan(ad *AppData, instance Instance, req SyncRequest, imported *Im
 						}
 					}
 				}
-			}
-			
-			if plan.Summary.QualityChanged && len(plan.QualityPreview) == 0 {
-				plan.QualityPreview = append(plan.QualityPreview, "Ordering changed (will be restored to profile configuration)")
 			}
 		}
 	} else {
@@ -1310,10 +1316,6 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 		if len(req.QualityStructure) > 0 {
 			desiredItemsSnapshot = req.QualityStructure
 		}
-		var prevItemsFingerprint string
-		if len(desiredItemsSnapshot) > 0 {
-			prevItemsFingerprint = FingerprintArrItems(FilterArrItemsToDesired(targetProfile.Items, desiredItemsSnapshot), false)
-		}
 		prevCutoffName := cutoffIDToName(targetProfile.Cutoff, targetProfile.Items)
 
 		// Update profile-level settings (cutoff, min scores, upgrade)
@@ -1643,6 +1645,18 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 						}
 					}
 					collectNewState(newItems, "")
+
+					filteredSnapshot := FilterArrItemsToDesired(targetProfile.Items, desiredItemsSnapshot)
+					driftedSnapshot := getGroupDriftQualities(filteredSnapshot, newItems)
+					orderCur := getEnabledOrder(filteredSnapshot, false, driftedSnapshot)
+					orderCurRev := getEnabledOrder(filteredSnapshot, true, driftedSnapshot)
+					orderTgt := getEnabledOrder(newItems, false, driftedSnapshot)
+					if orderCur != orderTgt && orderCurRev != orderTgt {
+						result.QualityDetails = append(result.QualityDetails, "Ordering changed (will be restored to profile configuration)")
+						result.QualityUpdated = true
+						updated = true
+					}
+
 					usedQualities := make(map[int]bool)
 					collectUsedQualities(newItems, usedQualities)
 					unused := make([]arr.ArrQualityItem, 0)
@@ -1759,17 +1773,7 @@ func ExecuteSyncPlan(ad *AppData, instance Instance, req SyncRequest, plan *Sync
 			}
 		}
 
-		// Catch drift missed by the enable/disable loop above: reorder, regroup,
-		// extract-from-group. Both snapshots are filtered to the TRaSH-managed
-		// subset so Radarr's unused-tail ordering can't produce false positives.
-		if len(desiredItemsSnapshot) > 0 {
-			postFP := FingerprintArrItems(FilterArrItemsToDesired(targetProfile.Items, desiredItemsSnapshot), false)
-			if postFP != prevItemsFingerprint && !result.QualityUpdated {
-				result.QualityDetails = append(result.QualityDetails, "Ordering changed (will be restored to profile configuration)")
-				result.QualityUpdated = true
-				updated = true
-			}
-		}
+		// Extract-from-group drift is already captured above.
 
 		if profileSettingsChanged {
 			updated = true

--- a/internal/core/sync_structure_test.go
+++ b/internal/core/sync_structure_test.go
@@ -1,0 +1,35 @@
+package core
+
+import (
+	"clonarr/internal/arr"
+	"testing"
+)
+
+
+
+func TestFingerprintArrItems_ReverseEnabled(t *testing.T) {
+	items := []arr.ArrQualityItem{
+		arrQ(1, "A", true),
+		arrQ(2, "B", true),
+		arrQ(3, "C", false),
+		arrQ(4, "D", false),
+	}
+	
+	fpNormal := FingerprintArrItems(items, false)
+	// Expected: enabled parts stay A then B. Disabled parts sorted (C, D)
+	// A|B|C|D
+	wantNormal := `Q:"A"=true|Q:"B"=true|Q:"C"=false|Q:"D"=false`
+	
+	if fpNormal != wantNormal {
+		t.Errorf("normal fingerprint mismatch:\n  got:  %s\n  want: %s", fpNormal, wantNormal)
+	}
+	
+	fpReverse := FingerprintArrItems(items, true)
+	// Expected: enabled parts are reversed to B then A. Disabled parts sorted (C, D)
+	// B|A|C|D
+	wantReverse := `Q:"B"=true|Q:"A"=true|Q:"C"=false|Q:"D"=false`
+	
+	if fpReverse != wantReverse {
+		t.Errorf("reverse fingerprint mismatch:\n  got:  %s\n  want: %s", fpReverse, wantReverse)
+	}
+}

--- a/internal/core/sync_test.go
+++ b/internal/core/sync_test.go
@@ -254,8 +254,8 @@ func TestFingerprintArrItems_FlatOnly(t *testing.T) {
 		arrQ(3, "Bluray-1080p", true),
 		arrQ(4, "WEB 1080p", true),
 	}
-	got := fingerprintArrItems(items)
-	want := `Q:"DVD"=false|Q:"Bluray-1080p"=true|Q:"WEB 1080p"=true`
+	got := FingerprintArrItems(items, false)
+	want := `Q:"Bluray-1080p"=true|Q:"WEB 1080p"=true|Q:"DVD"=false`
 	if got != want {
 		t.Errorf("fingerprint mismatch:\n  got:  %s\n  want: %s", got, want)
 	}
@@ -263,8 +263,8 @@ func TestFingerprintArrItems_FlatOnly(t *testing.T) {
 
 func TestFingerprintArrItems_ReorderChangesFingerprint(t *testing.T) {
 	a := []arr.ArrQualityItem{arrQ(1, "A", true), arrQ(2, "B", true), arrQ(3, "C", false)}
-	b := []arr.ArrQualityItem{arrQ(3, "C", false), arrQ(1, "A", true), arrQ(2, "B", true)}
-	if fingerprintArrItems(a) == fingerprintArrItems(b) {
+	b := []arr.ArrQualityItem{arrQ(3, "C", false), arrQ(2, "B", true), arrQ(1, "A", true)}
+	if FingerprintArrItems(a, false) == FingerprintArrItems(b, false) {
 		t.Error("reorder must produce different fingerprints (set-based diff blindspot)")
 	}
 }
@@ -278,14 +278,14 @@ func TestFingerprintArrItems_WithGroup(t *testing.T) {
 		),
 		arrQ(20, "Remux-1080p", true),
 	}
-	got := fingerprintArrItems(items)
-	want := `Q:"SDTV"=false|G:"WEB 1080p"=true["WEBDL-1080p","WEBRip-1080p"]|Q:"Remux-1080p"=true`
+	got := FingerprintArrItems(items, false)
+	want := `G:"WEB 1080p"=true["WEBDL-1080p","WEBRip-1080p"]|Q:"Remux-1080p"=true|Q:"SDTV"=false`
 	if got != want {
 		t.Errorf("fingerprint mismatch:\n  got:  %s\n  want: %s", got, want)
 	}
 }
 
-func TestFingerprintArrItems_GroupMemberReorderChangesFingerprint(t *testing.T) {
+func TestFingerprintArrItems_GroupMemberReorderDoesNotChangeFingerprint(t *testing.T) {
 	a := []arr.ArrQualityItem{
 		arrG(1000, "WEB 1080p", true,
 			arrQ(10, "WEBDL-1080p", true),
@@ -298,8 +298,8 @@ func TestFingerprintArrItems_GroupMemberReorderChangesFingerprint(t *testing.T) 
 			arrQ(10, "WEBDL-1080p", true),
 		),
 	}
-	if fingerprintArrItems(a) == fingerprintArrItems(b) {
-		t.Error("group member reorder must produce different fingerprints")
+	if FingerprintArrItems(a, false) != FingerprintArrItems(b, false) {
+		t.Error("group member reorder must produce identical fingerprints because they are sorted")
 	}
 }
 
@@ -312,8 +312,8 @@ func TestFingerprintArrItems_DelimiterInjectionSafe(t *testing.T) {
 	b := []arr.ArrQualityItem{
 		arrG(1000, "foo", true, arrQ(10, "bar", true)),
 	}
-	if fingerprintArrItems(a) == fingerprintArrItems(b) {
-		t.Errorf("delimiter injection collision:\n  a: %s\n  b: %s", fingerprintArrItems(a), fingerprintArrItems(b))
+	if FingerprintArrItems(a, false) == FingerprintArrItems(b, false) {
+		t.Errorf("delimiter injection collision:\n  a: %s\n  b: %s", FingerprintArrItems(a, false), FingerprintArrItems(b, false))
 	}
 }
 
@@ -334,7 +334,7 @@ func TestFingerprintArrItems_ExtractFromGroupChangesFingerprint(t *testing.T) {
 			arrQ(11, "WEBRip-1080p", true),
 		),
 	}
-	if fingerprintArrItems(a) == fingerprintArrItems(b) {
+	if FingerprintArrItems(a, false) == FingerprintArrItems(b, false) {
 		t.Error("extracting a quality from a group with same allowed-state must produce different fingerprints (set-based diff blindspot)")
 	}
 }
@@ -355,8 +355,8 @@ func TestFingerprintTrashItems_MatchesArrFingerprint(t *testing.T) {
 		),
 		arrQ(20, "Remux-1080p", true),
 	}
-	if fingerprintTrashItems(trash) != fingerprintArrItems(arr) {
-		t.Errorf("representations diverged:\n  trash: %s\n  arr:   %s", fingerprintTrashItems(trash), fingerprintArrItems(arr))
+	if FingerprintTrashItems(trash) != FingerprintArrItems(arr, false) {
+		t.Errorf("representations diverged:\n  trash: %s\n  arr:   %s", FingerprintTrashItems(trash), FingerprintArrItems(arr, false))
 	}
 }
 
@@ -376,13 +376,13 @@ func TestFilterArrItemsToDesired_DropsUnusedTail(t *testing.T) {
 		{Name: "WEBDL-1080p", Allowed: true},
 		{Name: "WEB 1080p", Allowed: true, Items: []string{"WEBRip-1080p"}},
 	}
-	filtered := filterArrItemsToDesired(arr, desired)
+	filtered := FilterArrItemsToDesired(arr, desired)
 	if len(filtered) != 2 {
 		t.Fatalf("expected 2 filtered items (WEBDL + group), got %d", len(filtered))
 	}
-	if fingerprintArrItems(filtered) != fingerprintTrashItems(desired) {
+	if FingerprintArrItems(filtered, false) != FingerprintTrashItems(desired) {
 		t.Errorf("after filtering, fingerprints should match:\n  got:  %s\n  want: %s",
-			fingerprintArrItems(filtered), fingerprintTrashItems(desired))
+			FingerprintArrItems(filtered, false), FingerprintTrashItems(desired))
 	}
 }
 

--- a/ui/static/css/features/sync-compare.css
+++ b/ui/static/css/features/sync-compare.css
@@ -116,8 +116,9 @@
   /* Match-based colouring on Current ONLY. Guide stays neutral so the
      row reads as "this is what your Arr has now (red = wrong, green =
      OK)" against the guide reference value (no colour signal). */
-  .cmp-settings-table td.current-diff { color: var(--accent-red); font-family: ui-monospace, SFMono-Regular, monospace; font-weight: 600; text-align: left; }
-  .cmp-settings-table td.current-match { color: var(--accent-green); font-family: ui-monospace, SFMono-Regular, monospace; text-align: left; }
+  .cmp-settings-table td.current-cell { font-family: ui-monospace, SFMono-Regular, monospace; text-align: left; }
+  .cmp-settings-table .current-diff { color: var(--accent-red); font-weight: 600; }
+  .cmp-settings-table .current-match { color: var(--accent-green); }
   .cmp-settings-table td.guide { color: var(--text-secondary); font-family: ui-monospace, SFMono-Regular, monospace; text-align: left; }
   .cmp-settings-table td.new-fixed { color: var(--accent-green); font-family: ui-monospace, SFMono-Regular, monospace; font-weight: 600; }
   .cmp-settings-table td.new-unchanged { color: var(--text-muted-secondary); font-family: ui-monospace, SFMono-Regular, monospace; font-style: italic; }

--- a/ui/static/css/styles.css
+++ b/ui/static/css/styles.css
@@ -8,7 +8,7 @@
 @import url('./features/profile-sync-preview.css');
 @import url('./features/cf-detail.css');
 @import url('./features/quality.css');
-@import url('./features/sync-compare.css');
+@import url('./features/sync-compare.css?v=2');
 @import url('./features/builders.css');
 @import url('./features/naming.css');
 @import url('./features/scoring.css');

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -5287,6 +5287,8 @@ export default {
           return 'Top-level profile settings: language, upgrades allowed, min/cutoff scores.';
         case 'quality':
           return 'Quality items and cutoff. Shows what is enabled in your profile vs what the guide enables.';
+        case 'quality-order':
+          return 'This view compares the top-to-bottom order of your qualities and groups against the TRaSH guide.';
         case 'all-diffs':
           return 'Everything that differs from the guide - grouped by Required → Default on → Optional. Optional CFs only appear here if you have enabled them.';
         case 'wrong':
@@ -5358,7 +5360,22 @@ export default {
       // Walk both data sources (Required formatItems + Group CFs) and
       // tally per the helper-driven classification. Mirrors what the
       // filter renders so sub-nav counts and visible rows agree.
-      let missing = 0, wrong = 0, overview = 0, optional = 0, allActive = 0;
+      let missing = 0, wrong = 0, overview = 0, optional = 0, allActive = 0, qualityOrder = 0;
+      if (cr?.qualityStructure) {
+        const countMismatches = (rows) => {
+          let cnt = 0;
+          for (const r of (rows || [])) {
+            if (!r.match) cnt++;
+            if (r.currentMembers) {
+              for (const m of r.currentMembers) {
+                if (!m.match) cnt++;
+              }
+            }
+          }
+          return cnt;
+        };
+        qualityOrder = countMismatches(cr.qualityStructure.rows) + countMismatches(cr.qualityStructure.disabledRows);
+      }
       for (const fi of (cr?.formatItems || [])) {
         const st = this.cfRowStatus(fi, null);
         if (st === 'na') continue;
@@ -5387,9 +5404,9 @@ export default {
       // the previous semantics. Summary-bar code that wants the old
       // meaning needs updating, not this helper.
       return {
-        overview, optional, missing, wrong, extra, settings, quality,
+        overview, optional, missing, wrong, extra, settings, quality, qualityOrder,
         allDiffs, allActive,
-        diffs: allDiffs + extra + settings + quality, // legacy alias
+        diffs: allDiffs + extra + settings + quality + qualityOrder, // legacy alias
         all: overview + optional, // legacy alias (rough)
       };
     },
@@ -6148,6 +6165,8 @@ export default {
         if (grp.items.length === 0) {
           arr.splice(d.srcGroup, 1);
           if (d.srcGroup < gapIdx) insertAt -= 1;
+        } else if (grp.items.length === 1) {
+          arr.splice(d.srcGroup, 1, { _id: ++this._qsIdCounter, name: grp.items[0], allowed: grp.allowed });
         }
         arr.splice(insertAt, 0, newSingle);
       }
@@ -6205,6 +6224,8 @@ export default {
         if (oldGroup.items.length === 0) {
           arr.splice(d.srcGroup, 1);
           if (d.srcGroup < tIdx) tIdx -= 1;
+        } else if (oldGroup.items.length === 1) {
+          arr.splice(d.srcGroup, 1, { _id: ++this._qsIdCounter, name: oldGroup.items[0], allowed: oldGroup.allowed });
         }
         const tgtItem = arr[tIdx];
         if (!tgtItem) { this.qsResetDrag(); return; }
@@ -6263,6 +6284,8 @@ export default {
         if (oldGroup.items.length === 0) {
           arr.splice(d.srcGroup, 1);
           if (d.srcGroup < realGroupIdx) realGroupIdx -= 1;
+        } else if (oldGroup.items.length === 1) {
+          arr.splice(d.srcGroup, 1, { _id: ++this._qsIdCounter, name: oldGroup.items[0], allowed: oldGroup.allowed });
         }
         if (arr[realGroupIdx] && arr[realGroupIdx].items) {
           arr[realGroupIdx].items.splice(gapIdx, 0, memberName);
@@ -6309,6 +6332,8 @@ export default {
       });
       if (grp.items.length === 0) {
         arr.splice(groupIdx, 1);
+      } else if (grp.items.length === 1) {
+        arr.splice(groupIdx, 1, { _id: ++this._qsIdCounter, name: grp.items[0], allowed: grp.allowed });
       }
     },
 

--- a/ui/static/partials/sections/profiles.html
+++ b/ui/static/partials/sections/profiles.html
@@ -828,11 +828,11 @@
                                              Sonarr blue when something is unsynced; green when fully
                                              in sync. -->
                                         <div style="background:var(--bg-card);border:1px solid var(--text-muted-secondary);border-radius:8px;padding:10px 14px;margin-bottom:20px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;box-shadow:0 2px 6px var(--alpha-shadow)"
-                                             :style="{ borderColor: compareAdjustedCounts(cr).allDiffs > 0 || (cr.summary?.extra||0) > 0 || (cr.summary?.settingsDiffs||0) > 0 || (cr.summary?.qualityDiffs||0) > 0 ? 'var(--app-color)' : 'var(--accent-green)' }">
+                                             :style="{ borderColor: compareAdjustedCounts(cr).allDiffs > 0 || (cr.summary?.extra||0) > 0 || (cr.summary?.settingsDiffs||0) > 0 || (cr.summary?.qualityDiffs||0) > 0 || (cr.qualityStructure && cr.qualityStructure.hasDrift) ? 'var(--app-color)' : 'var(--accent-green)' }">
                                           <strong style="color:var(--text-primary);font-size:13px" x-text="ap.name"></strong>
                                           <span style="color:var(--app-color);font-size:12px;font-weight:600">vs</span>
                                           <strong style="color:var(--text-primary);font-size:13px" x-text="cr.trashProfileName"></strong>
-                                          <span x-show="compareAdjustedCounts(cr).allDiffs === 0 && (cr.summary?.extra||0) === 0 && (cr.summary?.settingsDiffs||0) === 0 && (cr.summary?.qualityDiffs||0) === 0"
+                                          <span x-show="compareAdjustedCounts(cr).allDiffs === 0 && (cr.summary?.extra||0) === 0 && (cr.summary?.settingsDiffs||0) === 0 && (cr.summary?.qualityDiffs||0) === 0 && !(cr.qualityStructure && cr.qualityStructure.hasDrift)"
                                                 style="color:var(--accent-green);font-size:13px;font-weight:500;margin-left:8px">&#10003; Profile fully in sync</span>
                                           <div style="margin-left:auto;display:flex;gap:6px;flex-wrap:wrap">
                                             <!-- Edit & Sync — opens the profile editor pre-loaded with
@@ -877,6 +877,12 @@
                                                     @click="compareFilter = 'quality'">
                                               <span class="cmp-side-label">Qualities</span>
                                               <span class="cmp-side-count" x-text="((cr.settingsDiffs || []).filter(s => s.name === 'Cutoff' && !s.match).length + (cr.qualityDiffs || []).filter(q => !q.match).length) || ''"></span>
+                                            </button>
+                                            <button type="button" class="cmp-side-item"
+                                                    :class="{ active: compareFilter === 'quality-order', inactive: compareAdjustedCounts(cr).qualityOrder === 0 }"
+                                                    @click="compareFilter = 'quality-order'">
+                                              <span class="cmp-side-label">Quality Order</span>
+                                              <span class="cmp-side-count" x-text="compareAdjustedCounts(cr).qualityOrder || ''"></span>
                                             </button>
                                             <div class="cmp-side-divider" aria-hidden="true"></div>
                                             <button type="button" class="cmp-side-item"
@@ -968,16 +974,26 @@
                                                   <tbody>
                                                     <template x-for="sd in (cr.settingsDiffs || []).filter(s => s.name === 'Cutoff')" :key="'q-'+sd.name">
                                                       <tr>
-                                                        <td class="name">Cutoff</td>
-                                                        <td :class="sd.match ? 'current-match' : 'current-diff'" x-text="sd.current"></td>
+                                                        <td class="name" x-text="sd.name"></td>
+                                                        <td class="current-cell" :class="sd.match ? 'current-match' : 'current-diff'" x-text="sd.current"></td>
                                                         <td class="guide" x-text="sd.desired"></td>
                                                       </tr>
                                                     </template>
                                                     <template x-for="qd in (cr.qualityDiffs || [])" :key="'qi-'+qd.name">
                                                       <tr>
                                                         <td class="name" x-text="qd.name"></td>
-                                                        <td :class="qd.match ? 'current-match' : 'current-diff'" x-text="qd.currentAllowed ? 'Enabled' : 'Disabled'"></td>
-                                                        <td class="guide" x-text="qd.desiredAllowed ? 'Enabled' : 'Disabled'"></td>
+                                                        <td class="current-cell">
+                                                          <span :class="qd.allowedMatch ? 'current-match' : 'current-diff'" x-text="qd.currentAllowed ? 'Enabled' : 'Disabled'"></span>
+                                                          <template x-if="qd.currentGroup || qd.desiredGroup">
+                                                            <div style="font-size:11px; opacity:0.7;" :class="qd.groupMatch ? 'current-match' : 'current-diff'" x-text="'Group: ' + (qd.currentGroup || 'Ungrouped')"></div>
+                                                          </template>
+                                                        </td>
+                                                        <td class="guide">
+                                                          <span x-text="qd.desiredAllowed ? 'Enabled' : 'Disabled'"></span>
+                                                          <template x-if="qd.currentGroup || qd.desiredGroup">
+                                                            <div style="font-size:11px;opacity:0.7" x-text="'Group: ' + (qd.desiredGroup || 'Ungrouped')"></div>
+                                                          </template>
+                                                        </td>
                                                       </tr>
                                                     </template>
                                                   </tbody>
@@ -985,8 +1001,197 @@
                                               </div>
                                             </template>
 
+                                            <!-- ===== Quality Order ===== -->
+                                            <template x-if="compareFilter === 'quality-order'">
+                                              <div class="card cmp-section cmp-section-settings" style="margin-bottom:10px;overflow:hidden">
+                                                <div class="cmp-section-header">
+                                                  <span class="cmp-section-title">Quality Order</span>
+                                                </div>
+                                                <table class="cmp-settings-table">
+                                                  <thead>
+                                                    <tr>
+                                                      <th class="col-value">Current Order</th>
+                                                      <th class="col-value">Guide Order</th>
+                                                    </tr>
+                                                  </thead>
+                                                  <tbody>
+                                                    <template x-if="cr.qualityStructure && cr.qualityStructure.rows">
+                                                      <template x-for="(row, i) in cr.qualityStructure.rows" :key="'qsrow-'+i">
+                                                        <tr>
+                                                          <td class="current-cell" :class="row.match ? 'current-match' : 'current-diff'" style="position: relative;">
+                                                            <div style="display: flex;">
+                                                              <div style="width: 25px; flex-shrink: 0; padding-top: 1px;">
+                                                                <span style="opacity: 0.5; font-size: 11px;" x-text="(i+1)+'.'"></span>
+                                                              </div>
+                                                              <div style="flex-grow: 1;">
+                                                                <div style="display: flex; align-items: center;">
+                                                                  <span x-text="row.current || '-'"></span>
+                                                                  <template x-if="row.current && cr.qualityStructure && row.current === cr.qualityStructure.currentCutoff">
+                                                                    <template x-if="row.current === cr.qualityStructure.guideCutoff">
+                                                                      <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-green); color: var(--accent-green);">Cutoff</span>
+                                                                    </template>
+                                                                  </template>
+                                                                  <template x-if="row.current && cr.qualityStructure && row.current === cr.qualityStructure.currentCutoff">
+                                                                    <template x-if="row.current !== cr.qualityStructure.guideCutoff">
+                                                                      <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-red); color: var(--accent-red);">Cutoff</span>
+                                                                    </template>
+                                                                  </template>
+                                                                </div>
+                                                                <template x-if="row.currentMembers && row.currentMembers.length > 0">
+                                                                  <div style="font-size: 0.9em; padding-top: 4px; display: flex; flex-direction: column; gap: 2px;">
+                                                                    <template x-for="(mem, j) in row.currentMembers" :key="mem.name">
+                                                                      <div style="display: flex; align-items: center;">
+                                                                        <span style="color: var(--text-muted); margin-right: 6px; font-family: monospace;" x-text="j === row.currentMembers.length - 1 ? '└─' : '├─'"></span>
+                                                                        <span :style="mem.match ? 'color: var(--accent-green);' : 'color: var(--accent-red);'" x-text="mem.name"></span>
+                                                                        <template x-if="cr.qualityStructure && mem.name === cr.qualityStructure.currentCutoff">
+                                                                          <template x-if="mem.name === cr.qualityStructure.guideCutoff">
+                                                                            <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-green); color: var(--accent-green);">Cutoff</span>
+                                                                          </template>
+                                                                        </template>
+                                                                        <template x-if="cr.qualityStructure && mem.name === cr.qualityStructure.currentCutoff">
+                                                                          <template x-if="mem.name !== cr.qualityStructure.guideCutoff">
+                                                                            <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-red); color: var(--accent-red);">Cutoff</span>
+                                                                          </template>
+                                                                        </template>
+                                                                      </div>
+                                                                    </template>
+                                                                  </div>
+                                                                </template>
+                                                              </div>
+                                                            </div>
+                                                          </td>
+                                                          <td class="guide" :class="row.match ? 'current-match' : ''">
+                                                            <div style="display: flex;">
+                                                              <div style="width: 25px; flex-shrink: 0;"></div>
+                                                              <div style="flex-grow: 1;">
+                                                                <div style="display: flex; align-items: center;">
+                                                                  <span x-text="row.guide || '-'"></span>
+                                                                  <template x-if="row.guide && cr.qualityStructure && row.guide === cr.qualityStructure.guideCutoff">
+                                                                    <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--text-muted); color: var(--text-muted);">Cutoff</span>
+                                                                  </template>
+                                                                </div>
+                                                                <template x-if="row.guideMembers && row.guideMembers.length > 0">
+                                                                  <div style="font-size: 0.9em; padding-top: 4px; display: flex; flex-direction: column; gap: 2px;">
+                                                                    <template x-for="(mem, j) in row.guideMembers" :key="mem.name">
+                                                                      <div style="display: flex; align-items: center;">
+                                                                        <span style="color: var(--text-muted); margin-right: 6px; font-family: monospace;" x-text="j === row.guideMembers.length - 1 ? '└─' : '├─'"></span>
+                                                                        <span style="color: var(--text-muted);" x-text="mem.name"></span>
+                                                                        <template x-if="cr.qualityStructure && mem.name === cr.qualityStructure.guideCutoff">
+                                                                          <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--text-muted); color: var(--text-muted);">Cutoff</span>
+                                                                        </template>
+                                                                      </div>
+                                                                    </template>
+                                                                  </div>
+                                                                </template>
+                                                              </div>
+                                                            </div>
+                                                          </td>
+                                                        </tr>
+                                                      </template>
+                                                    </template>
+                                                  </tbody>
+                                                </table>
+                                              </div>
+                                            </template>
+
+                                            
+                                            
+                                            <!-- ===== Disabled Qualities ===== -->
+                                            <template x-if="compareFilter === 'quality-order' && cr.qualityStructure && ((cr.qualityStructure.disabledRows || []).length > 0)">
+                                              <div class="card cmp-section cmp-section-settings" style="margin-bottom:10px;overflow:hidden">
+                                                <div class="cmp-section-header">
+                                                  <span class="cmp-section-title">Disabled Qualities</span>
+                                                </div>
+                                                <table class="cmp-settings-table">
+                                                  <thead>
+                                                    <tr>
+                                                      <th class="col-value">Current</th>
+                                                      <th class="col-value">Guide</th>
+                                                    </tr>
+                                                  </thead>
+                                                  <tbody>
+                                                    <template x-if="cr.qualityStructure && cr.qualityStructure.disabledRows">
+                                                      <template x-for="(row, i) in cr.qualityStructure.disabledRows" :key="'qsdis-'+i">
+                                                        <tr>
+                                                          <td class="current-cell" :style="row.match ? 'color: var(--text-secondary);' : 'color: var(--accent-red); font-weight: normal;'" style="position: relative;">
+                                                            <div style="display: flex;">
+                                                              <div style="width: 25px; flex-shrink: 0; padding-top: 1px;">
+                                                                
+                                                              </div>
+                                                              <div style="flex-grow: 1;">
+                                                                <div style="display: flex; align-items: center;">
+                                                                  <span x-text="row.current || '-'"></span>
+                                                                  <template x-if="row.current && cr.qualityStructure && row.current === cr.qualityStructure.currentCutoff">
+                                                                    <template x-if="row.current === cr.qualityStructure.guideCutoff">
+                                                                      <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-green); color: var(--accent-green);">Cutoff</span>
+                                                                    </template>
+                                                                  </template>
+                                                                  <template x-if="row.current && cr.qualityStructure && row.current === cr.qualityStructure.currentCutoff">
+                                                                    <template x-if="row.current !== cr.qualityStructure.guideCutoff">
+                                                                      <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-red); color: var(--accent-red);">Cutoff</span>
+                                                                    </template>
+                                                                  </template>
+                                                                </div>
+                                                                <template x-if="row.currentMembers && row.currentMembers.length > 0">
+                                                                  <div style="font-size: 1em; padding-top: 4px; display: flex; flex-direction: column; gap: 2px;">
+                                                                    <template x-for="(mem, j) in row.currentMembers" :key="mem.name">
+                                                                      <div style="display: flex; align-items: center;">
+                                                                        <span style="color: var(--text-secondary); margin-right: 6px; font-family: monospace;" x-text="j === row.currentMembers.length - 1 ? '└─' : '├─'"></span>
+                                                                        <span :style="mem.match ? 'color: var(--text-secondary);' : 'color: var(--accent-red);'" x-text="mem.name"></span>
+                                                                        <template x-if="cr.qualityStructure && mem.name === cr.qualityStructure.currentCutoff">
+                                                                          <template x-if="mem.name === cr.qualityStructure.guideCutoff">
+                                                                            <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-green); color: var(--accent-green);">Cutoff</span>
+                                                                          </template>
+                                                                        </template>
+                                                                        <template x-if="cr.qualityStructure && mem.name === cr.qualityStructure.currentCutoff">
+                                                                          <template x-if="mem.name !== cr.qualityStructure.guideCutoff">
+                                                                            <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--accent-red); color: var(--accent-red);">Cutoff</span>
+                                                                          </template>
+                                                                        </template>
+                                                                      </div>
+                                                                    </template>
+                                                                  </div>
+                                                                </template>
+                                                              </div>
+                                                            </div>
+                                                          </td>
+                                                          <td class="guide">
+                                                            <div style="display: flex;">
+                                                              <div style="width: 25px; flex-shrink: 0;"></div>
+                                                              <div style="flex-grow: 1;">
+                                                                <div style="display: flex; align-items: center;">
+                                                                  <span x-text="row.guide || '-'"></span>
+                                                                  <template x-if="row.guide && cr.qualityStructure && row.guide === cr.qualityStructure.guideCutoff">
+                                                                    <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--text-muted); color: var(--text-secondary);">Cutoff</span>
+                                                                  </template>
+                                                                </div>
+                                                                <template x-if="row.guideMembers && row.guideMembers.length > 0">
+                                                                  <div style="font-size: 1em; padding-top: 4px; display: flex; flex-direction: column; gap: 2px;">
+                                                                    <template x-for="(mem, j) in row.guideMembers" :key="mem.name">
+                                                                      <div style="display: flex; align-items: center;">
+                                                                        <span style="color: var(--text-secondary); margin-right: 6px; font-family: monospace;" x-text="j === row.guideMembers.length - 1 ? '└─' : '├─'"></span>
+                                                                        <span style="color: var(--text-secondary);" x-text="mem.name"></span>
+                                                                        <template x-if="cr.qualityStructure && mem.name === cr.qualityStructure.guideCutoff">
+                                                                          <span style="margin-left: 8px; font-size: 9px; padding: 1px 4px; border-radius: 3px; font-weight: bold; text-transform: uppercase; border: 1px solid var(--text-muted); color: var(--text-secondary);">Cutoff</span>
+                                                                        </template>
+                                                                      </div>
+                                                                    </template>
+                                                                  </div>
+                                                                </template>
+                                                              </div>
+                                                            </div>
+                                                          </td>
+                                                        </tr>
+                                                      </template>
+                                                    </template>
+                                                  </tbody>
+                                                </table>
+                                              </div>
+                                            </template>
+
+                                            
                                             <!-- ===== Required CFs (Format Items) ===== -->
-                                            <template x-if="!['general','quality','extra','optional'].includes(compareFilter) && cmpRequiredVisibleIn(cr, compareFilter)">
+                                            <template x-if="!['general','quality','quality-order','extra','optional'].includes(compareFilter) && cmpRequiredVisibleIn(cr, compareFilter)">
                                               <div class="card cmp-section cmp-section-required" style="margin-bottom:10px;overflow:hidden">
                                                 <div class="cmp-section-header">
                                                   <span class="cmp-section-title">Required CFs (Format Items)</span>
@@ -1031,7 +1236,7 @@
                                                  optional groups, preserving the All Diffs visual
                                                  ordering (Format Items -> Default on -> Optional). -->
                                             <template x-for="g in [...((cr.groups || []).filter(g => g.defaultEnabled)), ...((cr.groups || []).filter(g => !g.defaultEnabled))]" :key="'grp-'+g.name">
-                                              <template x-if="!['general','quality','extra'].includes(compareFilter) && cmpGroupVisibleIn(g, compareFilter)">
+                                              <template x-if="!['general','quality','quality-order','extra'].includes(compareFilter) && cmpGroupVisibleIn(g, compareFilter)">
                                                 <div class="card cmp-section" :class="g.defaultEnabled ? 'cmp-section-default-on' : 'cmp-section-optional'" style="margin-bottom:10px;overflow:hidden">
                                                   <div class="cmp-section-header">
                                                     <span class="cmp-section-title" x-text="g.name"></span>
@@ -1098,7 +1303,7 @@
                                             </template>
 
                                             <!-- ===== Additional CFs ===== -->
-                                            <template x-if="(compareFilter === 'extra' || compareFilter === 'all-diffs' || compareFilter === 'all-active') && (cr.extraCFs || []).length > 0">
+                                            <template x-if="!['quality-order'].includes(compareFilter) && (compareFilter === 'extra' || compareFilter === 'all-diffs' || compareFilter === 'all-active') && (cr.extraCFs || []).length > 0">
                                               <div class="card cmp-section cmp-section-additional" style="margin-bottom:10px;overflow:hidden">
                                                 <div class="cmp-section-header">
                                                   <span class="cmp-section-title">Additional CFs</span>
@@ -1126,7 +1331,7 @@
                                             </template>
 
                                             <!-- Empty-state: nothing visible in current pane. -->
-                                            <template x-if="!['general','quality'].includes(compareFilter) &&
+                                            <template x-if="!['general','quality','quality-order'].includes(compareFilter) &&
                                                             !cmpRequiredVisibleIn(cr, compareFilter) &&
                                                             !(cr.groups || []).some(g => cmpGroupVisibleIn(g, compareFilter)) &&
                                                             !((compareFilter === 'extra' || compareFilter === 'all-diffs' || compareFilter === 'all-active') && (cr.extraCFs || []).length > 0)">


### PR DESCRIPTION
Add quality order and quality groups detection

- Adds deterministic quality ordering and a validation check for group assignments when syncing profiles and custom formats between Radarr/Sonarr and Clonarr, preventing mis-ordered qualities and invalid group links during syncs.

What this change does
- Implements quality-order handling so quality entries are applied and preserved in the intended order, avoiding regressions caused by unordered/misordered quality lists.
- Adds a group-existence/validation check

Why this is needed
- Previously quality lists could be applied in a non-deterministic order causing unexpected profile behavior in Radarr/Sonarr.

- These fixes increase reliability of automated profile/format management and make debugging sync issues much easier.

Checklist
- [x] Adds deterministic quality ordering
- [x] Adds group existence/validation check

Detailed changes:

- Updated driftDetailToPendingChange to handle group and quality_order changes.
- Added flattenGroups function to extract group information for drift detection.
- Enhanced diffArrProfile to detect changes in quality groups and order.
- Modified formatDriftDetail to include group change notifications.
- Updated BuildSyncPlan to track group changes and reflect them in the sync plan.
- Improved ExecuteSyncPlan to handle group changes and update quality details accordingly.
- Added UI components to display quality order comparisons and disabled qualities in profiles.
- Updated CSS for improved styling of sync comparison tables.

Screenshots:

<img width="480" height="174" alt="image" src="https://github.com/user-attachments/assets/1479d039-b74a-4031-8382-5e8779682217" />

<img width="544" height="451" alt="image" src="https://github.com/user-attachments/assets/978aa2ff-7c4f-4821-8f01-5511af483785" />

<img width="998" height="497" alt="image" src="https://github.com/user-attachments/assets/535c14e1-0444-4782-8881-2c62d3c1872f" />

<img width="1087" height="841" alt="image" src="https://github.com/user-attachments/assets/2587a11a-dcff-401a-a3ba-fa0bb3c09186" />