### PR TITLE
fix(instances): fix comparison tool reversing quality order coming from Radarr, false flagging order drifts

### DIFF
--- a/internal/api/instances.go
+++ b/internal/api/instances.go
@@ -2372,16 +2372,14 @@ func buildProfileComparison(inst core.Instance, ad *core.AppData, trashProfileID
 			}
 		}
 	}
-	// Sonarr's API always returns quality items worst-to-best. We reverse them
-	// here so the Compare tool presents them best-to-worst, visually aligning
+	// Both Sonarr and Radarr APIs return quality items worst-to-best (lowest priority first). 
+	// We reverse them here so the Compare tool presents them best-to-worst, visually aligning 
 	// them with the TRaSH guide's best-to-worst format.
-	if inst.Type == "sonarr" {
-		for i, j := 0, len(currentKeys)-1; i < j; i, j = i+1, j-1 {
-			currentKeys[i], currentKeys[j] = currentKeys[j], currentKeys[i]
-		}
-		for i, j := 0, len(disabledKeys)-1; i < j; i, j = i+1, j-1 {
-			disabledKeys[i], disabledKeys[j] = disabledKeys[j], disabledKeys[i]
-		}
+	for i, j := 0, len(currentKeys)-1; i < j; i, j = i+1, j-1 {
+		currentKeys[i], currentKeys[j] = currentKeys[j], currentKeys[i]
+	}
+	for i, j := 0, len(disabledKeys)-1; i < j; i, j = i+1, j-1 {
+		disabledKeys[i], disabledKeys[j] = disabledKeys[j], disabledKeys[i]
 	}
 	
 	gItemMap := make(map[string]core.QualityItem)


### PR DESCRIPTION
Before:

<img width="829" height="244" alt="image" src="https://github.com/user-attachments/assets/c3350912-2ee3-443c-a2ce-680ba373855b" />

After:

<img width="859" height="248" alt="image" src="https://github.com/user-attachments/assets/9228c531-5872-4949-a33b-e1a3707c6f3e" />


