### PR TITLE
fix(custom-cfs): preserve metadata in profile editor & add JSON viewer modal

### DIFF
--- a/internal/core/trash.go
+++ b/internal/core/trash.go
@@ -1711,13 +1711,14 @@ func cleanDescription(raw string) string {
 
 // CategorizedCF is a CF with all score contexts for the CF picker.
 type CategorizedCF struct {
-	TrashID     string         `json:"trashId"`
-	Name        string         `json:"name"`
-	TrashScores map[string]int `json:"trashScores"`
-	Description string         `json:"description,omitempty"`
-	IsCustom    bool           `json:"isCustom,omitempty"`
-	Required    bool           `json:"required,omitempty"`  // from CF group: required=true means must-include
-	CFDefault   *bool          `json:"cfDefault,omitempty"` // from CF group: per-CF default override
+	TrashID         string         `json:"trashId"`
+	Name            string         `json:"name"`
+	TrashScores     map[string]int `json:"trashScores"`
+	Description     string         `json:"description,omitempty"`
+	IsCustom        bool           `json:"isCustom,omitempty"`
+	Required        bool           `json:"required,omitempty"`  // from CF group: required=true means must-include
+	CFDefault       *bool          `json:"cfDefault,omitempty"` // from CF group: per-CF default override
+	IncludeInRename bool           `json:"includeInRename,omitempty"`
 }
 
 // CFPickerGroup is a CF group within a picker category, carrying group metadata + all score contexts.
@@ -1872,9 +1873,12 @@ func AllCFsCategorized(ad *AppData, customCFs []CustomCF) *CFPickerData {
 			cat = "Custom"
 		}
 		customByCat[cat] = append(customByCat[cat], CategorizedCF{
-			TrashID:  ccf.ID,
-			Name:     ccf.Name,
-			IsCustom: true,
+			TrashID:         ccf.ID,
+			Name:            ccf.Name,
+			TrashScores:     ccf.TrashScores,
+			Description:     ccf.Description,
+			IncludeInRename: ccf.IncludeInRename,
+			IsCustom:        true,
 		})
 	}
 	// Stable per-group ordering: "Custom" group first (the implicit

--- a/internal/core/trash_test.go
+++ b/internal/core/trash_test.go
@@ -347,6 +347,41 @@ func TestAllCFsCategorized_CustomsAlwaysUnderCustomParent(t *testing.T) {
 	}
 }
 
+func TestAllCFsCategorized_CustomCFMetadataPreserved(t *testing.T) {
+	ad := &AppData{
+		CustomFormats: map[string]*TrashCF{},
+		CFGroups:      []*TrashCFGroup{},
+	}
+	customs := []CustomCF{
+		{
+			ID:              "custom:100",
+			Name:            "Multi-Subs",
+			Category:        "Anime",
+			AppType:         "sonarr",
+			Description:     "Prefer releases that contain multiple subtitles.",
+			TrashScores:     map[string]int{"default": 100},
+			IncludeInRename: true,
+		},
+	}
+	got := AllCFsCategorized(ad, customs)
+	if len(got.Categories) != 1 || len(got.Categories[0].Groups) != 1 {
+		t.Fatalf("expected 1 category with 1 group, got %+v", got)
+	}
+	cf := got.Categories[0].Groups[0].CFs[0]
+	if cf.Name != "Multi-Subs" {
+		t.Errorf("expected Name 'Multi-Subs', got %q", cf.Name)
+	}
+	if cf.Description != "Prefer releases that contain multiple subtitles." {
+		t.Errorf("expected Description 'Prefer releases that contain multiple subtitles.', got %q", cf.Description)
+	}
+	if cf.TrashScores["default"] != 100 {
+		t.Errorf("expected TrashScores['default'] = 100, got %v", cf.TrashScores)
+	}
+	if !cf.IncludeInRename {
+		t.Errorf("expected IncludeInRename=true, got false")
+	}
+}
+
 func TestAllCFsCategorized_NoCustomsProducesNoCustomCategory(t *testing.T) {
 	ad := &AppData{
 		CustomFormats: map[string]*TrashCF{},

--- a/ui/static/css/features/cf-detail.css
+++ b/ui/static/css/features/cf-detail.css
@@ -378,14 +378,22 @@
     color: var(--text-muted);
     letter-spacing: 0.2px;
   }
-  .cf-grid .cf-cell-pills .cf-cell-desc .cf-desc-links a {
+  .cf-grid .cf-cell-pills .cf-cell-desc .cf-desc-links a,
+  .cf-grid .cf-cell-pills .cf-cell-desc .cf-desc-links .cf-desc-json-btn {
+    background: none;
+    border: none;
+    padding: 0;
     color: var(--text-muted);
     text-decoration: none;
     text-transform: uppercase;
     font-weight: 600;
     letter-spacing: 0.3px;
+    cursor: pointer;
+    font-size: 10px;
+    font-family: inherit;
   }
-  .cf-grid .cf-cell-pills .cf-cell-desc .cf-desc-links a:hover {
+  .cf-grid .cf-cell-pills .cf-cell-desc .cf-desc-links a:hover,
+  .cf-grid .cf-cell-pills .cf-cell-desc .cf-desc-links .cf-desc-json-btn:hover {
     color: var(--app-color);
     text-decoration: underline;
   }

--- a/ui/static/css/features/profile-sync-preview.css
+++ b/ui/static/css/features/profile-sync-preview.css
@@ -825,15 +825,26 @@ button.sp-summary-active:focus-visible {
   color: var(--text-muted);
   letter-spacing: 0.2px;
 }
-.sp-cf-desc .cf-desc-links a {
+.sp-cf-desc .cf-desc-links a,
+.sp-cf-desc .cf-desc-links .cf-desc-json-btn,
+.sp-ov-cf-desc .cf-desc-links a,
+.sp-ov-cf-desc .cf-desc-links .cf-desc-json-btn {
+  background: none;
+  border: none;
+  padding: 0;
   color: var(--text-muted);
   text-decoration: none;
   text-transform: uppercase;
   font-weight: 600;
   letter-spacing: 0.3px;
-  margin-right: 12px;
+  cursor: pointer;
+  font-size: 10px;
+  font-family: inherit;
 }
-.sp-cf-desc .cf-desc-links a:hover { color: var(--app-color); text-decoration: underline; }
+.sp-cf-desc .cf-desc-links a:hover,
+.sp-cf-desc .cf-desc-links .cf-desc-json-btn:hover,
+.sp-ov-cf-desc .cf-desc-links a:hover,
+.sp-ov-cf-desc .cf-desc-links .cf-desc-json-btn:hover { color: var(--app-color); text-decoration: underline; }
 /* Rename indicator - sits in the same footer row as the TRaSH/JSON links.
    Blue, uppercase to match the link styling, but no underline/hover since
    it's a behaviour flag (includeCustomFormatWhenRenaming), not a link. */

--- a/ui/static/js/features/custom-formats.js
+++ b/ui/static/js/features/custom-formats.js
@@ -957,6 +957,11 @@ export default {
         const jsonUrl = this.trashCFJsonUrl ? this.trashCFJsonUrl(cf, appType) : '';
         if (guideUrl) metaBits.push(`<a href="${esc(guideUrl)}" target="_blank" rel="noopener noreferrer">TRaSH guide</a>`);
         if (jsonUrl) metaBits.push(`<a href="${esc(jsonUrl)}" target="_blank" rel="noopener noreferrer">JSON</a>`);
+      } else {
+        const tid = cf?.trashId || cf?.id || '';
+        if (tid) {
+          metaBits.push(`<button type="button" class="cf-desc-json-btn" data-cf-id="${esc(tid)}">JSON</button>`);
+        }
       }
       if (!opts.hideRename && cf?.includeInRename) {
         metaBits.push(`<span class="cf-desc-rename" title="Custom Format name is appended to renamed files when this CF matches.">rename</span>`);
@@ -971,15 +976,20 @@ export default {
       const desc = (cf?.description || '').replace(/\^\^([^^\n]+?)\^\^/g, '<u>$1</u>');
       const safeDesc = sanitizeHTML(desc);
       let html = safeDesc;
+      const esc = (u) => String(u).replace(/[<>"'&]/g, c => ({ '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;', '&':'&amp;' }[c]));
+      const links = [];
       if (!cf?.isCustom) {
         const guideUrl = this.trashCFGuideUrl ? this.trashCFGuideUrl(cf, appType) : '';
         const jsonUrl = this.trashCFJsonUrl ? this.trashCFJsonUrl(cf, appType) : '';
-        const esc = (u) => String(u).replace(/[<>"'&]/g, c => ({ '<':'&lt;', '>':'&gt;', '"':'&quot;', "'":'&#39;', '&':'&amp;' }[c]));
-        const links = [];
         if (guideUrl) links.push(`<a href="${esc(guideUrl)}" target="_blank" rel="noopener">TRaSH guide</a>`);
         if (jsonUrl) links.push(`<a href="${esc(jsonUrl)}" target="_blank" rel="noopener">JSON</a>`);
-        if (links.length) html += (safeDesc ? '<br><br>' : '') + links.join(' &nbsp;·&nbsp; ');
+      } else {
+        const tid = cf?.trashId || cf?.id || '';
+        if (tid) {
+          links.push(`<button type="button" class="cf-desc-json-btn" data-cf-id="${esc(tid)}">JSON</button>`);
+        }
       }
+      if (links.length) html += (safeDesc ? '<br><br>' : '') + links.join(' &nbsp;·&nbsp; ');
       return html;
     },
 
@@ -2225,6 +2235,75 @@ export default {
         })),
       };
 
+      if (f.description) {
+        trashJSON.description = f.description;
+      }
+
+      this.cfExportTitle = f.name ? `${f.name} — TRaSH JSON` : 'Export TRaSH JSON';
+      this.cfExportContent = JSON.stringify(trashJSON, null, 2);
+      this.cfExportCopied = false;
+    },
+
+    async viewCustomCFJSON(trashId) {
+      if (!trashId) return;
+      const appType = this.activeAppType || 'radarr';
+      let customCF = (this.cfBrowseData?.[appType]?.customCFs || []).find(c => (c.id === trashId || c.trashId === trashId || c.trash_id === trashId));
+      if (!customCF) {
+        for (const cf of (this.extraCFAllCFs || [])) {
+          if ((cf.trashId === trashId || cf.id === trashId) && cf.specifications) {
+            customCF = cf;
+            break;
+          }
+        }
+      }
+      if (!customCF) {
+        try {
+          const res = await fetch(`/api/custom-cfs?appType=${appType}`);
+          if (res.ok) {
+            const list = await res.json();
+            this.cfBrowseData = {
+              ...this.cfBrowseData,
+              [appType]: { ...(this.cfBrowseData?.[appType] || {}), customCFs: list }
+            };
+            customCF = list.find(c => c.id === trashId || c.trashId === trashId);
+          }
+        } catch (e) {
+          console.error('Failed to load custom CF JSON:', e);
+        }
+      }
+      if (!customCF) return;
+
+      const specs = (customCF.specifications || []).map(s => {
+        let fields = {};
+        if (Array.isArray(s.fields)) {
+          fields = Object.fromEntries(s.fields.map(fld => [fld.name, fld.value]));
+        } else if (s.fields && typeof s.fields === 'object') {
+          fields = s.fields;
+        }
+        return {
+          name: s.name || '',
+          implementation: s.implementation || '',
+          negate: !!s.negate,
+          required: !!s.required,
+          fields: fields,
+        };
+      });
+
+      const trashScores = customCF.trashScores || (customCF.score !== undefined ? { default: customCF.score } : {});
+
+      const trashJSON = {
+        trash_id: customCF.trashId || customCF.id || '',
+        trash_scores: trashScores,
+        name: customCF.name || '',
+        includeCustomFormatWhenRenaming: !!customCF.includeInRename,
+        specifications: specs,
+      };
+
+      if (customCF.description) {
+        trashJSON.description = customCF.description;
+      }
+
+      this.cfExportTitle = customCF.name ? `${customCF.name} — Custom Format JSON` : 'Custom Format JSON';
       this.cfExportContent = JSON.stringify(trashJSON, null, 2);
       this.cfExportCopied = false;
     },

--- a/ui/static/js/features/profiles.js
+++ b/ui/static/js/features/profiles.js
@@ -4907,7 +4907,8 @@ export default {
         // that don't appear in any TRaSH/profile group).
         for (const cf of (this.extraCFAllCFs || [])) {
           if (cf.trashId === tid) {
-            return { name: cf.name, category: 'Custom', groupName: '', defaultScore: cf.score ?? 0, description: cf.description || '', isDangling: false };
+            const def = cf.trashScores?.[scoreSet] ?? cf.trashScores?.default ?? cf.score ?? 0;
+            return { name: cf.name, category: 'Custom', groupName: '', defaultScore: def, description: cf.description || '', isDangling: false };
           }
         }
         // Dangling - rule references a CF that no longer exists. Two cases:

--- a/ui/static/js/main.js
+++ b/ui/static/js/main.js
@@ -331,6 +331,27 @@ function registerSkipLinkHandler() {
   });
 }
 
+let cfJsonHandlerRegistered = false;
+function registerCFJSONHandler() {
+  if (cfJsonHandlerRegistered) return;
+  cfJsonHandlerRegistered = true;
+  document.addEventListener('click', (event) => {
+    const jsonBtn = event.target.closest('.cf-desc-json-btn');
+    if (!jsonBtn) return;
+    event.preventDefault();
+    const id = jsonBtn.getAttribute('data-cf-id');
+    if (id && window.Alpine) {
+      const root = document.querySelector('[x-data]');
+      if (root && root._x_dataStack) {
+        const comp = root._x_dataStack[0];
+        if (comp && typeof comp.viewCustomCFJSON === 'function') {
+          comp.viewCustomCFJSON(id);
+        }
+      }
+    }
+  });
+}
+
 export function clonarr() {
   return applyFeatureModules({
     ...baseState(),
@@ -1401,6 +1422,7 @@ function registerClonarr() {
   registerModalTrapDirective(window.Alpine);
   registerTooltipEscapeListener();
   registerSkipLinkHandler();
+  registerCFJSONHandler();
   registerSidebarToggleShortcut();
   registerSearchShortcut();
   // x-tt="'tooltip text'" - viewport-aware custom tooltip directive.

--- a/ui/static/js/state.js
+++ b/ui/static/js/state.js
@@ -398,6 +398,7 @@ export default function baseState() {
     cfEditorSaving: false,
     cfEditorResult: null,        // {error?, message}
     cfExportContent: '',         // TRaSH JSON export text for modal
+    cfExportTitle: '',           // Title for JSON export modal
     cfExportCopied: false,       // clipboard copy feedback
     cfEditorSchema: {},          // cached per app type: [{implementation, fields:[{name,label,type,selectOptions}]}]
     cfEditorSchemaLoading: false,

--- a/ui/static/partials/modals/cf-export.html
+++ b/ui/static/partials/modals/cf-export.html
@@ -2,7 +2,7 @@
   <!-- Export TRaSH JSON Modal -->
   <div class="modal-overlay" x-show="cfExportContent" @click.self="cfExportContent = ''" @keydown.escape.window="cfExportContent = ''" x-cloak>
     <div class="modal" style="max-width:700px" role="dialog" aria-modal="true" aria-labelledby="modal-title-cf-export" x-trap.noscroll.inert="cfExportContent">
-      <h2 id="modal-title-cf-export" class="modal-title">Export TRaSH JSON</h2>
+      <h2 id="modal-title-cf-export" class="modal-title" x-text="cfExportTitle || 'Export TRaSH JSON'">Export TRaSH JSON</h2>
       <div style="font-size:12px;color:var(--text-muted);margin-bottom:16px">
         TRaSH-Guides format — use this to share custom formats or contribute to the guides.
       </div>


### PR DESCRIPTION
## Summary
Resolves an issue where user-created custom formats did not display their default scores or descriptions in the profile editor, and adds an interactive JSON viewer button for custom formats akin to official TRaSH formats.

---

## What Changed

### 1. Custom Format Metadata Preservation
- **Problem**: When `/api/trash/{app}/all-cfs` assembled catalog items (`CategorizedCF`) for custom formats, it omitted `TrashScores`, `Description`, and `IncludeInRename`. Consequently, custom formats inside the profile customization drawer displayed `"No description"` and defaulted to a score of `0`.
- **Backend Fix (`internal/core/trash.go`)**:
  - Added `IncludeInRename` to the `CategorizedCF` struct.
  - Updated `AllCFsCategorized` to populate `TrashScores`, `Description`, and `IncludeInRename` from the underlying `CustomCF`.
- **Frontend Fix (`ui/static/js/features/profiles.js`)**:
  - Updated fallback default score resolution in `pdAllCustomizations` to inspect `cf.trashScores`.
- **Tests (`internal/core/trash_test.go`)**:
  - Added `TestAllCFsCategorized_CustomCFMetadataPreserved` unit test.

### 2. Interactive JSON Viewer Modal for Custom Formats
- **Feature**: Added a **`JSON`** action button to custom format description rows and tooltips across the application (matching the styling of official TRaSH format links).
- **Functionality**:
  - Clicking **`JSON`** on any custom format opens an interactive modal displaying its complete TRaSH-compatible JSON definition (specifications, conditions, fields, scores, rename flag, and description).
  - Includes a one-click **Copy** button to copy the JSON definition to the clipboard.
- **Frontend Implementation**:
  - Added `viewCustomCFJSON(trashId)` in `custom-formats.js` to resolve custom CF definitions and format TRaSH-compatible specification JSON.
  - Added dynamic title binding (`cfExportTitle`) in `state.js` and `cf-export.html`.
  - Registered a global delegated click listener in `main.js` (`registerCFJSONHandler`).
  - Added matching CSS for `.cf-desc-json-btn` in `profile-sync-preview.css` and `cf-detail.css`.

---

## Verification & Testing
- Ran backend unit tests: `go test ./internal/core` (Passed).
- Verified custom formats (e.g. `Multi-Subs`) in both **Radarr** and **Sonarr** profile customization drawers:
  - Default score (`+100`) and description load correctly.
  - Clicking the **JSON** action button opens the JSON viewer modal with accurate specification fields and a working copy button.

## Screenshots:

### Custom Format:

<img width="1088" height="801" alt="image" src="https://github.com/user-attachments/assets/bd3a9980-5d3b-4ba5-9d28-66b0486c742d" />

### Before:

<img width="948" height="417" alt="image" src="https://github.com/user-attachments/assets/42b03b31-82e7-4dc2-91ec-f61d27bfc6d4" />

### After:

<img width="945" height="413" alt="image" src="https://github.com/user-attachments/assets/bdac123c-56fe-4637-a5c3-11ef7d4e55ba" />

<img width="945" height="710" alt="image" src="https://github.com/user-attachments/assets/d7a3b359-75a8-4905-a78a-58bdc275a490" />